### PR TITLE
Update nuget.config

### DIFF
--- a/HelloWorld/reunioncppdesktopsampleapp/nuget.config
+++ b/HelloWorld/reunioncppdesktopsampleapp/nuget.config
@@ -8,7 +8,6 @@
     </packageRestore>
     <packageSources>
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-        <add key="Project.Reunion.Internal.ReleaseSigned" value="https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.Internal.ReleaseSigned/nuget/v3/index.json" />
     </packageSources>
     <disabledPackageSources />
     <activePackageSource>


### PR DESCRIPTION
This change updates nuget.config to only point at nuget.org (forgot to do this in my previous change). I verified that even after deleting project reunion things from my nuget cache and the solution packages directory then reloading the VS project the project reunion packages were repopulated in the solution directory.