### PR TITLE
Changes to make the post build script a bit more robust

### DIFF
--- a/DWriteCore/DWriteCoreGallery/DWriteCoreGallery (packaging)/DWriteCoreGallery (packaging).wapproj
+++ b/DWriteCore/DWriteCoreGallery/DWriteCoreGallery (packaging)/DWriteCoreGallery (packaging).wapproj
@@ -36,14 +36,6 @@
       <Configuration>Release</Configuration>
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|AnyCPU">
-      <Configuration>Debug</Configuration>
-      <Platform>AnyCPU</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|AnyCPU">
-      <Configuration>Release</Configuration>
-      <Platform>AnyCPU</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup>
     <WapProjPath Condition="'$(WapProjPath)'==''">$(MSBuildExtensionsPath)\Microsoft\DesktopBridge\</WapProjPath>
@@ -84,7 +76,7 @@
      $(ProjectDir) will not have been evaluated yet.
      -->
     <PostBuildEvent>
-		powershell.exe -ExecutionPolicy Unrestricted -file "$(ProjectDir)AddReunionPackageDependency.ps1" -appxManifestPath "$(ProjectDir)$(OutDir)AppxManifest.xml" -packagesDirectory "$(SolutionDir)packages" -architecture $(PlatformName) -appxRecipePath "$(ProjectDir)$(OutDir)$(TargetFileName).build.appxrecipe"
+		powershell.exe -ExecutionPolicy Unrestricted -file "$(ProjectDir)AddReunionPackageDependency.ps1" -appxManifestPath "$(ProjectDir)$(OutDir)AppxManifest.xml" -solutionDirectory $(SolutionDir) -architecture $(PlatformName) -appxRecipePath "$(ProjectDir)$(OutDir)$(TargetFileName).build.appxrecipe"
 	</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/HelloWorld/reunioncppdesktopsampleapp/ReunionCppDesktopSampleApp/ReunionCppDesktopSampleApp (Package)/ReunionCppDesktopSampleApp (Package).wapproj
+++ b/HelloWorld/reunioncppdesktopsampleapp/ReunionCppDesktopSampleApp/ReunionCppDesktopSampleApp (Package)/ReunionCppDesktopSampleApp (Package).wapproj
@@ -84,7 +84,7 @@
 	 script to remove its from the appxrecipe.
      -->
     <PostBuildEvent>
-		powershell.exe -ExecutionPolicy Unrestricted -file "$(ProjectDir)AddReunionPackageDependency.ps1" -appxManifestPath "$(ProjectDir)$(OutDir)AppxManifest.xml" -packagesDirectory "$(SolutionDir)packages" -architecture $(PlatformName) -appxRecipePath "$(ProjectDir)$(OutDir)$(TargetFileName).build.appxrecipe"
+		powershell.exe -ExecutionPolicy Unrestricted -file "$(ProjectDir)AddReunionPackageDependency.ps1" -appxManifestPath "$(ProjectDir)$(OutDir)AppxManifest.xml" -solutionDirectory $(SolutionDir) -architecture $(PlatformName) -appxRecipePath "$(ProjectDir)$(OutDir)$(TargetFileName).build.appxrecipe"
 		powershell.exe -ExecutionPolicy Unrestricted -file "$(ProjectDir)ExcludeExtraReunionDllFromPackage.ps1" -appxRecipePath "$(ProjectDir)$(OutDir)$(TargetFileName).build.appxrecipe"
 	</PostBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
This change makes the post build script a bit more robust for the case where there is more than 1 project reunion package folder. It does this by first consulting the packages.config file for what version of Microsoft.ProjectReunion it should use. This change also has a minor edit to the DwriteGallery package project to remove "Any CPU" for architecture because we currently don't support it with the framework package.