### PR TITLE
remove fxcop from checklist

### DIFF
--- a/docs/samples-guidelines.md
+++ b/docs/samples-guidelines.md
@@ -479,9 +479,7 @@ Run the Windows App Certification Kit (WACK) on a Release build. If your sample 
 
 ### Perform code analysis
 
-For C++ samples, make sure samples build clean with no warnings or errors.
-
-For C# samples, run FxCop.
+Make sure samples build clean with no warnings or errors.
 
 ### Verify accessibility
 


### PR DESCRIPTION
FxCop is outdated and is included as a Roslyn analyzer in the .NET 5+ SDK.