### PR TITLE
Re-calculate drag region for custom TitleBar when window size has changed

### DIFF
--- a/Samples/Windowing/cpp-winui/SampleApp/TitlebarPage.xaml.cpp
+++ b/Samples/Windowing/cpp-winui/SampleApp/TitlebarPage.xaml.cpp
@@ -25,8 +25,17 @@ namespace winrt::SampleApp::implementation
         m_mainWindow = e.Parameter().as<MainWindow>();
         AppWindow appWindow = m_mainWindow.AppWindow();
         m_appWindow = appWindow;
-
+        m_changedToken = m_appWindow.Changed({ this, &TitlebarPage::AppWindowChangedHandler });
     }
+
+    void TitlebarPage::AppWindowChangedHandler(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Windowing::AppWindowChangedEventArgs const& e)
+    {
+        if (e.DidSizeChange() && sender.as<AppWindow>().TitleBar().ExtendsContentIntoTitleBar())
+        {
+            SetCustomTitleBarDragRegion();
+        }
+    }
+
     void TitlebarPage::TitlebarBrandingBtn_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
     {
         m_appWindow.TitleBar().ResetToDefault();
@@ -57,6 +66,7 @@ namespace winrt::SampleApp::implementation
             m_appWindow.Title(defaultTitle);
         }
     }
+
     void TitlebarPage::TitlebarCustomBtn_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
     {
         if (!m_customTitleBar) {
@@ -76,29 +86,8 @@ namespace winrt::SampleApp::implementation
             m_appWindow.TitleBar().ButtonPressedBackgroundColor(Colors::Green());
             m_appWindow.TitleBar().ButtonPressedForegroundColor(Colors::White());
 
-            //Infer titlebar height and set the titlebar height
-            int titleBarHeight = m_appWindow.TitleBar().Height();
-            m_mainWindow.MyTitleBar().Height(titleBarHeight);
-
-            // Get caption button occlusion information
-            // Use LeftInset if you've explicitly set your window layout to RTL or if app language is a RTL language
-            double CaptionButtonOcclusionWidth = m_appWindow.TitleBar().RightInset();
-
-            //// Define your drag Regions
-            int windowIconWidthAndPadding = (int)m_mainWindow.MyWindowIcon().ActualWidth() + (int)m_mainWindow.MyWindowIcon().Margin().Right;
-            int dragRegionWidth = m_appWindow.Size().Width - (CaptionButtonOcclusionWidth + windowIconWidthAndPadding);
-
-            std::vector<Windows::Graphics::RectInt32> dragRects;
-            Windows::Graphics::RectInt32 dragRect;
-
-            dragRect.X = windowIconWidthAndPadding;
-            dragRect.Y = 0;
-            dragRect.Height = titleBarHeight;
-            dragRect.Width = dragRegionWidth;
-
-            dragRects.push_back(dragRect);
-            m_appWindow.TitleBar().SetDragRectangles(dragRects);
-
+            //Set the drag region for the custom titlebar
+            SetCustomTitleBarDragRegion();
         }
         else
         {
@@ -108,10 +97,37 @@ namespace winrt::SampleApp::implementation
             m_appWindow.TitleBar().ResetToDefault();
         }
     }
+
     void TitlebarPage::ResetTitlebarBtn_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
     {
         m_mainWindow.MyTitleBar().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
         m_appWindow.TitleBar().ResetToDefault();
         m_appWindow.Title(defaultTitle);
+    }
+
+    void TitlebarPage::SetCustomTitleBarDragRegion()
+    {
+        // Get the titlebar heigt and set our XAML titlebar element to match
+        int titleBarHeight = m_appWindow.TitleBar().Height();
+        m_mainWindow.MyTitleBar().Height(titleBarHeight);
+
+        // Get caption button occlusion information
+        // Use LeftInset if you've explicitly set your window layout to RTL or if app language is a RTL language
+        double CaptionButtonOcclusionWidth = m_appWindow.TitleBar().RightInset();
+
+        //// Define your drag Regions
+        int windowIconWidthAndPadding = (int)m_mainWindow.MyWindowIcon().ActualWidth() + (int)m_mainWindow.MyWindowIcon().Margin().Right;
+        int dragRegionWidth = m_appWindow.Size().Width - (CaptionButtonOcclusionWidth + windowIconWidthAndPadding);
+
+        std::vector<Windows::Graphics::RectInt32> dragRects;
+        Windows::Graphics::RectInt32 dragRect;
+
+        dragRect.X = windowIconWidthAndPadding;
+        dragRect.Y = 0;
+        dragRect.Height = titleBarHeight;
+        dragRect.Width = dragRegionWidth;
+
+        dragRects.push_back(dragRect);
+        m_appWindow.TitleBar().SetDragRectangles(dragRects);
     }
 }

--- a/Samples/Windowing/cpp-winui/SampleApp/TitlebarPage.xaml.cpp
+++ b/Samples/Windowing/cpp-winui/SampleApp/TitlebarPage.xaml.cpp
@@ -115,7 +115,7 @@ namespace winrt::SampleApp::implementation
         // Use LeftInset if you've explicitly set your window layout to RTL or if app language is a RTL language
         double CaptionButtonOcclusionWidth = m_appWindow.TitleBar().RightInset();
 
-        //// Define your drag Regions
+        // Define your drag Regions
         int windowIconWidthAndPadding = (int)m_mainWindow.MyWindowIcon().ActualWidth() + (int)m_mainWindow.MyWindowIcon().Margin().Right;
         int dragRegionWidth = m_appWindow.Size().Width - (CaptionButtonOcclusionWidth + windowIconWidthAndPadding);
 

--- a/Samples/Windowing/cpp-winui/SampleApp/TitlebarPage.xaml.h
+++ b/Samples/Windowing/cpp-winui/SampleApp/TitlebarPage.xaml.h
@@ -7,14 +7,7 @@ namespace winrt::SampleApp::implementation
 
 	struct TitlebarPage : TitlebarPageT<TitlebarPage>
 	{
-		
-
-	private:
-		AppWindow m_appWindow{ nullptr };
-		SampleApp::MainWindow m_mainWindow{ nullptr };
-
-
-	public:
+    public:
 		TitlebarPage();
 		void OnNavigatedTo(NavigationEventArgs const& e);
 
@@ -24,8 +17,14 @@ namespace winrt::SampleApp::implementation
 		void TitlebarBrandingBtn_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
 		void TitlebarCustomBtn_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
 		void ResetTitlebarBtn_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
-	};
+		void SetCustomTitleBarDragRegion();
+		void AppWindowChangedHandler(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Windowing::AppWindowChangedEventArgs const& e);
 
+	private:
+		AppWindow m_appWindow{ nullptr };
+		SampleApp::MainWindow m_mainWindow{ nullptr };
+		winrt::event_token m_changedToken;
+	};
 }
 
 

--- a/Samples/Windowing/cs-winui/SampleApp/TitlebarPage.xaml.cs
+++ b/Samples/Windowing/cs-winui/SampleApp/TitlebarPage.xaml.cs
@@ -26,19 +26,30 @@ namespace SampleApp
         private bool m_isBrandedTitleBar;
         private MainWindow m_mainWindow;
 
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            // Gets the AppWindow using the windowing interop methods (see WindowingInterop.cs for details)
-            m_mainAppWindow = e.Parameter.As<Window>().GetAppWindow();
-            m_mainWindow = e.Parameter as MainWindow;
-            base.OnNavigatedTo(e);
-        }
-
         public TitlebarPage()
         {
             this.InitializeComponent();
         }
-        
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            // Gets the AppWindow using the windowing interop methods (see WindowingInterop.cs for details)
+            m_mainAppWindow = e.Parameter.As<Window>().GetAppWindow();
+
+            m_mainWindow = e.Parameter as MainWindow;
+            m_mainAppWindow.Changed += MainAppWindow_Changed;
+            base.OnNavigatedTo(e);
+        }
+
+        private void MainAppWindow_Changed(AppWindow sender, AppWindowChangedEventArgs args)
+        {
+            if(args.DidSizeChange && sender.TitleBar.ExtendsContentIntoTitleBar)
+            {
+                // Need to update our drag region if the size of the window changes
+                SetDragRegionForCustomTitleBar();
+            }
+        }
+
         private void TitlebarBrandingBtn_Click(object sender, RoutedEventArgs e)
         {
             m_mainAppWindow.TitleBar.ResetToDefault();
@@ -95,29 +106,8 @@ namespace SampleApp
                 m_mainAppWindow.TitleBar.ButtonPressedBackgroundColor = Colors.Green;
                 m_mainAppWindow.TitleBar.ButtonPressedForegroundColor = Colors.White;
 
-                //Infer titlebar height
-                int titleBarHeight = m_mainAppWindow.TitleBar.Height;
-                m_mainWindow.MyTitleBar.Height = titleBarHeight;
-
-                // Get caption button occlusion information
-                // Use LeftInset if you've explicitly set your window layout to RTL or if app language is a RTL language
-                int CaptionButtonOcclusionWidth = m_mainAppWindow.TitleBar.RightInset;
-
-                // Define your drag Regions
-                int windowIconWidthAndPadding = (int)m_mainWindow.MyWindowIcon.ActualWidth + (int)m_mainWindow.MyWindowIcon.Margin.Right;
-                int dragRegionWidth = m_mainAppWindow.Size.Width - (CaptionButtonOcclusionWidth + windowIconWidthAndPadding );
-
-                Windows.Graphics.RectInt32[] dragRects = new Windows.Graphics.RectInt32[] { };
-                Windows.Graphics.RectInt32 dragRect;
-
-                dragRect.X = windowIconWidthAndPadding;
-                dragRect.Y = 0;
-                dragRect.Height = titleBarHeight;
-                dragRect.Width = dragRegionWidth;
-
-                var dragRectsArray = dragRects.Append(dragRect).ToArray();
-                m_mainAppWindow.TitleBar.SetDragRectangles(dragRectsArray);
-
+                // Set the drag region for the custom TitleBar
+                SetDragRegionForCustomTitleBar();
             }
             else
             {
@@ -125,6 +115,31 @@ namespace SampleApp
                 m_mainWindow.MyTitleBar.Visibility = Visibility.Collapsed;
                 m_mainAppWindow.TitleBar.ResetToDefault();
             }
+        }
+
+        private void SetDragRegionForCustomTitleBar()
+        {
+            //Infer titlebar height
+            int titleBarHeight = m_mainAppWindow.TitleBar.Height;
+            m_mainWindow.MyTitleBar.Height = titleBarHeight;
+
+            // Get caption button occlusion information
+            // Use LeftInset if you've explicitly set your window layout to RTL or if app language is a RTL language
+            int CaptionButtonOcclusionWidth = m_mainAppWindow.TitleBar.RightInset;
+
+            // Define your drag Regions
+            int windowIconWidthAndPadding = (int)m_mainWindow.MyWindowIcon.ActualWidth + (int)m_mainWindow.MyWindowIcon.Margin.Right;
+            int dragRegionWidth = m_mainAppWindow.Size.Width - (CaptionButtonOcclusionWidth + windowIconWidthAndPadding);
+
+            Windows.Graphics.RectInt32[] dragRects = new Windows.Graphics.RectInt32[] { };
+            Windows.Graphics.RectInt32 dragRect;
+
+            dragRect.X = windowIconWidthAndPadding;
+            dragRect.Y = 0;
+            dragRect.Height = titleBarHeight;
+            dragRect.Width = dragRegionWidth;
+
+            m_mainAppWindow.TitleBar.SetDragRectangles(dragRects.Append(dragRect).ToArray());
         }
     }
 }

--- a/Samples/Windowing/cs-winui/SampleApp/TitlebarPage.xaml.cs
+++ b/Samples/Windowing/cs-winui/SampleApp/TitlebarPage.xaml.cs
@@ -43,7 +43,7 @@ namespace SampleApp
 
         private void MainAppWindow_Changed(AppWindow sender, AppWindowChangedEventArgs args)
         {
-            if(args.DidSizeChange && sender.TitleBar.ExtendsContentIntoTitleBar)
+            if (args.DidSizeChange && sender.TitleBar.ExtendsContentIntoTitleBar)
             {
                 // Need to update our drag region if the size of the window changes
                 SetDragRegionForCustomTitleBar(sender);

--- a/Samples/Windowing/cs-winui/SampleApp/TitlebarPage.xaml.cs
+++ b/Samples/Windowing/cs-winui/SampleApp/TitlebarPage.xaml.cs
@@ -46,7 +46,7 @@ namespace SampleApp
             if(args.DidSizeChange && sender.TitleBar.ExtendsContentIntoTitleBar)
             {
                 // Need to update our drag region if the size of the window changes
-                SetDragRegionForCustomTitleBar();
+                SetDragRegionForCustomTitleBar(sender);
             }
         }
 
@@ -107,7 +107,7 @@ namespace SampleApp
                 m_mainAppWindow.TitleBar.ButtonPressedForegroundColor = Colors.White;
 
                 // Set the drag region for the custom TitleBar
-                SetDragRegionForCustomTitleBar();
+                SetDragRegionForCustomTitleBar(m_mainAppWindow);
             }
             else
             {
@@ -117,19 +117,19 @@ namespace SampleApp
             }
         }
 
-        private void SetDragRegionForCustomTitleBar()
+        private void SetDragRegionForCustomTitleBar(AppWindow appWindow)
         {
             //Infer titlebar height
-            int titleBarHeight = m_mainAppWindow.TitleBar.Height;
+            int titleBarHeight = appWindow.TitleBar.Height;
             m_mainWindow.MyTitleBar.Height = titleBarHeight;
 
             // Get caption button occlusion information
             // Use LeftInset if you've explicitly set your window layout to RTL or if app language is a RTL language
-            int CaptionButtonOcclusionWidth = m_mainAppWindow.TitleBar.RightInset;
+            int CaptionButtonOcclusionWidth = appWindow.TitleBar.RightInset;
 
             // Define your drag Regions
             int windowIconWidthAndPadding = (int)m_mainWindow.MyWindowIcon.ActualWidth + (int)m_mainWindow.MyWindowIcon.Margin.Right;
-            int dragRegionWidth = m_mainAppWindow.Size.Width - (CaptionButtonOcclusionWidth + windowIconWidthAndPadding);
+            int dragRegionWidth = appWindow.Size.Width - (CaptionButtonOcclusionWidth + windowIconWidthAndPadding);
 
             Windows.Graphics.RectInt32[] dragRects = new Windows.Graphics.RectInt32[] { };
             Windows.Graphics.RectInt32 dragRect;
@@ -139,7 +139,7 @@ namespace SampleApp
             dragRect.Height = titleBarHeight;
             dragRect.Width = dragRegionWidth;
 
-            m_mainAppWindow.TitleBar.SetDragRectangles(dragRects.Append(dragRect).ToArray());
+            appWindow.TitleBar.SetDragRectangles(dragRects.Append(dragRect).ToArray());
         }
     }
 }


### PR DESCRIPTION
The first iteration of the sample lacked recalculating the drag region when the window size changed, this lead to a bug where if you resized the window to a larger size than when you selected to have a custom TitleBar you could not grab the window and move it in the space between the system caption controls and where the drag region was initially calculated to be.

This update breaks out the calculation and setting of the drag region into a separate method and adds an event handler for AppWindow.Changed that calls it when the DidSizeChange property is set, for both the C++ and C# samples.

There are also some minor formatting cleanups in the modified files while I was at it...