### PR TITLE
Display a message box with error code included if dynamic dependencies init fails.

### DIFF
--- a/Samples/ResourceManagement/cs-winforms-unpackaged/Program.cs
+++ b/Samples/ResourceManagement/cs-winforms-unpackaged/Program.cs
@@ -20,9 +20,15 @@ namespace winforms_unpackaged_app
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            // Initialize dynamic dependencies so we can consume the Project Reunion APIs in the Project Reunion framework package from this unpackaged app.
+            // Initialize dynamic dependencies so we can consume the Project Reunion APIs in the Project
+            // Reunion framework package from this unpackaged app.
             // Take a dependency on Project Reunion v0.8 preview.
-            MddBootstrap.Initialize(8, "preview");
+            int hr = MddBootstrap.Initialize(8, "preview");
+            if (hr < 0)
+            {
+                MessageBox.Show("Fail to initialize Dynamic Dependencies with error " + hr, "Error!");
+                return;
+            }
             
             var resourceManager = new ResourceManager("winforms_unpackaged_app.pri");
             // Fall back to other resource loaders if the resource is not found in MRT, in this case .net.

--- a/Samples/ResourceManagement/cs-winforms-unpackaged/Program.cs
+++ b/Samples/ResourceManagement/cs-winforms-unpackaged/Program.cs
@@ -26,7 +26,7 @@ namespace winforms_unpackaged_app
             int hr = MddBootstrap.Initialize(8, "preview");
             if (hr < 0)
             {
-                MessageBox.Show("Fail to initialize Dynamic Dependencies with error " + hr, "Error!");
+                MessageBox.Show("Fail to initialize Dynamic Dependencies with error 0x" + hr.ToString("X"), "Error!");
                 return;
             }
             


### PR DESCRIPTION
Execution terminates after box is dismissed.

Closes #48 

**How verified**
Changed
    `int hr = MddBootstrap.Initialize(8, "preview");`
to
    `int hr = MddBootstrap.Initialize(9, "preview");`
That version doesn't exist.

Dialog I saw:
![message_box_2](https://user-images.githubusercontent.com/35987549/130161506-1bba466e-ceff-45aa-b9d1-978e58dd074f.png)

-2147023727 corresponds to 1169 (0x491) which is "There was no match for the specified key in the index." (see https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--1000-1299-)