### PR TITLE
Update Insights cpp-win32 app for different Build Tools versions

### DIFF
--- a/Samples/Insights/cpp-win32/InsightsSample.vcxproj
+++ b/Samples/Insights/cpp-win32/InsightsSample.vcxproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="packages\Microsoft.WindowsAppSDK.1.0.0-preview1\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('packages\Microsoft.WindowsAppSDK.1.0.0-preview1\build\native\Microsoft.WindowsAppSDK.props')" />
+  <Import Project="..\..\Build.Common.Cpp.props" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
@@ -39,39 +40,33 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -11,7 +11,7 @@ how to best contribute to the Windows App SDK Samples repository!
 ##### Checklist
 
 - [ ] Please ensure your samples can be correctly built using the Visual Studio versions
-      in the Visual Studio versions in https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio
+      in https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio
 - [ ] If you're adding a new sample, and it is related to one of the existing scenarios 
       (ResourceManagement, Windowing, etc) make sure to add them in the corresponding folder.
 - [ ] Samples should build on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

##### Description
When updating the samples to automatically detect which build tool version to use in my 
 previous PR (https://github.com/microsoft/WindowsAppSDK-Samples/pull/92) 
I failed to check if there had been any new samples added to the repo while my PR was still open. 
I noticed there's a new Sample that is not yet supporting this automatic detection, so I'm updating it :) 
This sample was added before I updated the PR Template to remind developers about this, so it was an unfortunate coincidence :) 
With this change though, the app now builds in both VS2019 and VS2022 using Build tools v142 and v143 respectively. 

##### Checklist

- [X] Please ensure your samples can be correctly built using the Visual Studio versions
      in the Visual Studio versions in https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio
- [] If you're adding a new sample, and it is related to one of the existing scenarios 
      (ResourceManagement, Windowing, etc) make sure to add them in the corresponding folder.
- [X] Samples should build on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [X] Samples should set the minimum version to Windows 10 version 1809.
- [X] Make sure samples build clean with no warnings or errors.