### PR TITLE
Fix broken DWriteCore sample when using x86 Release config

### DIFF
--- a/Samples/TextRendering/cpp-win32/DWriteCoreGallery/DWriteCoreGallery.vcxproj
+++ b/Samples/TextRendering/cpp-win32/DWriteCoreGallery/DWriteCoreGallery.vcxproj
@@ -102,6 +102,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
##### Description

The DWriteCore samples use C++20 for `std::span`. However, the x86 Release (Win32 Release) configuration in the VCXProj file omits setting the `<LanguageStandard>` to `stdcpplatest` for Release|Win32

This means the sample doesn't compile for x86 Release. :(
Fortunately the fix is simple. :)

(This was noticed while attempting to build the Samples as part of the WinAppSDK pipeline [here](https://microsoft.visualstudio.com/ProjectReunion/_git/ProjectReunionInternal/pullrequest/6536284?iteration=4&base=3). )

