### PR TITLE
fix configuration mapping for sample

### DIFF
--- a/Samples/Windowing/cs-wpf/wpf_packaged_app.sln
+++ b/Samples/Windowing/cs-wpf/wpf_packaged_app.sln
@@ -15,14 +15,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Debug|x64.ActiveCfg = Debug|x64
-		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Debug|x64.Build.0 = Debug|x64
-		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Debug|x86.ActiveCfg = Debug|x86
-		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Debug|x86.Build.0 = Debug|x86
-		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Release|x64.ActiveCfg = Release|Any CPU
-		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Release|x64.Build.0 = Release|Any CPU
-		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Release|x86.ActiveCfg = Release|Any CPU
-		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Release|x86.Build.0 = Release|Any CPU
 		{6CB98632-6091-412F-AB5D-D6F7000073A6}.Debug|x64.ActiveCfg = Debug|x64
 		{6CB98632-6091-412F-AB5D-D6F7000073A6}.Debug|x64.Build.0 = Debug|x64
 		{6CB98632-6091-412F-AB5D-D6F7000073A6}.Debug|x64.Deploy.0 = Debug|x64
@@ -35,6 +27,14 @@ Global
 		{6CB98632-6091-412F-AB5D-D6F7000073A6}.Release|x86.ActiveCfg = Release|x86
 		{6CB98632-6091-412F-AB5D-D6F7000073A6}.Release|x86.Build.0 = Release|x86
 		{6CB98632-6091-412F-AB5D-D6F7000073A6}.Release|x86.Deploy.0 = Release|x86
+		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Debug|x64.ActiveCfg = Debug|x64
+		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Debug|x64.Build.0 = Debug|x64
+		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Debug|x86.ActiveCfg = Debug|x86
+		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Debug|x86.Build.0 = Debug|x86
+		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Release|x64.ActiveCfg = Release|x64
+		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Release|x64.Build.0 = Release|x64
+		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Release|x86.ActiveCfg = Release|x86
+		{93E98476-0F66-4E46-B3F3-096724E0DE4A}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Samples/Windowing/cs-wpf/wpf_packaged_app/MainWindow.xaml.cs
+++ b/Samples/Windowing/cs-wpf/wpf_packaged_app/MainWindow.xaml.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 using System;
 using System.Windows;
-using System;
-using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using Microsoft.UI;

--- a/Samples/Windowing/cs-wpf/wpf_packaged_app/WindowingInterop.cs
+++ b/Samples/Windowing/cs-wpf/wpf_packaged_app/WindowingInterop.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Windows;
-using System;
-using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using Microsoft.UI;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

##### Description
Fixes configuration mapping. Before, the sample wouldn't build in Release x64 because the mapping was looking like this:
![image](https://user-images.githubusercontent.com/26077674/137203592-4e8591ab-ccc2-46d4-93e5-86b2aec7b09f.png)

After this change, it looks like this:
![image](https://user-images.githubusercontent.com/26077674/137203631-9c27f9df-4468-4a5d-9c61-86424d563f3c.png)

I built the sample in Release and Debug for both x64 and x86 and it now builds :) I also removed a few "using" directives that were repeated and gave warnings in the sample building. 
##### Checklist

- [x] Please ensure your samples can be correctly built using the Visual Studio versions
      in https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio
- [ ] If you're adding a new sample, and it is related to one of the existing scenarios 
      (ResourceManagement, Windowing, etc) make sure to add them in the corresponding folder.
- [x] Samples should build on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [x] Samples should set the minimum version to Windows 10 version 1809.
- [x] Make sure samples build clean with no warnings or errors.