### PR TITLE
add github action to build samples

### DIFF
--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       # - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
       - name: Restore nuget packages for all solutions
-        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
+        run: msbuild 'Samples\ResourceManagement\cpp-console-unpackaged\*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
 
       - name: Restore nuget packages for all solutions
         run: msbuild 'Samples\**\*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# GitHub Action configuration script for WindowsAppSDK-Samples continuous integration tasks.
+
+name: GHA CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: '**'
+
+jobs:
+  samples-buils-VS-2019:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+
+      # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+      - name: Setup MSBuild.exe
+        uses: microsoft/setup-msbuild@v1.0.3
+      
+      - name: Use NuGet 5.2.0
+        uses: nuget/setup-nuget@v1
+        
+      - name: Run Msbuild
+        run: msbuild $env:Solution_Name /p:platform=$env:buildPlatform /p:Configuration=$env:buildConfiguration
+
+      - run: nuget restore .\${{ env.SamplesRepoName }}\Samples\**\*.sln
+
+      - name: Restore nuget packages for all solutions
+        run: msbuild '.\${{ env.SamplesRepoName }}\Samples\**\*.sln' /p:configuration='Release' /p:platform='x86' /t:restore
+      
+      - name: Build all Sample solutions
+        run: msbuild '.\${{ env.SamplesRepoName }}\Samples\**\*.sln' /p:configuration='Release' /p:platform='x86'
+             

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Use NuGet 5.2.0
         uses: nuget/setup-nuget@v1
 
-      - run: nuget restore .\${{ env.SamplesRepoName }}\Samples\**\*.sln
+      - run: nuget restore Samples\**\*.sln
 
       - name: Restore nuget packages for all solutions
-        run: msbuild '.\${{ env.SamplesRepoName }}\Samples\**\*.sln' /p:configuration='Release' /p:platform='x86' /t:restore
+        run: msbuild 'Samples\**\*.sln' /p:configuration='Release' /p:platform='x86' /t:restore
       
       - name: Build all Sample solutions
-        run: msbuild '.\${{ env.SamplesRepoName }}\Samples\**\*.sln' /p:configuration='Release' /p:platform='x86'
+        run: msbuild 'Samples\**\*.sln' /p:configuration='Release' /p:platform='x86'
              

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -15,6 +15,12 @@ on:
 jobs:
   samples-build-VS-2019:
     runs-on: windows-2019
+
+    strategy:
+      matrix:
+        configuration: [Release, Debug]
+        platform: [x86, x64]
+
     steps:
       - uses: actions/checkout@v2
 
@@ -28,8 +34,8 @@ jobs:
       - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
 
       - name: Restore nuget packages for all solutions
-        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration='Release' /p:platform='x86' /t:restore
+        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
       
       - name: Build all Sample solutions
-        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration='Release' /p:platform='x86'
+        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
              

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       # - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
       - name: Restore nuget packages for all solutions
-        run: msbuild 'Samples\ResourceManagement\cpp-console-unpackaged\*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
+        run: msbuild 'Samples\ResourceManagement\cpp-console-unpackaged\console_unpackaged_app.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
 
       - name: Restore nuget packages for all solutions
         run: msbuild 'Samples\**\*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       # - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
       - name: Restore nuget packages for all solutions
-        run: msbuild ' Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
+        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
 
       - name: Restore nuget packages for all solutions
         run: msbuild 'Samples/*/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -13,7 +13,7 @@ on:
     branches: '**'
 
 jobs:
-  samples-buils-VS-2019:
+  samples-build-VS-2019:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -24,9 +24,6 @@ jobs:
       
       - name: Use NuGet 5.2.0
         uses: nuget/setup-nuget@v1
-        
-      - name: Run Msbuild
-        run: msbuild $env:Solution_Name /p:platform=$env:buildPlatform /p:Configuration=$env:buildConfiguration
 
       - run: nuget restore .\${{ env.SamplesRepoName }}\Samples\**\*.sln
 

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Use NuGet 5.2.0
         uses: nuget/setup-nuget@v1
 
-      - run: nuget restore Samples\**\*.sln
+      - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
 
       - name: Restore nuget packages for all solutions
-        run: msbuild 'Samples\**\*.sln' /p:configuration='Release' /p:platform='x86' /t:restore
+        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration='Release' /p:platform='x86' /t:restore
       
       - name: Build all Sample solutions
-        run: msbuild 'Samples\**\*.sln' /p:configuration='Release' /p:platform='x86'
+        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration='Release' /p:platform='x86'
              

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -34,8 +34,8 @@ jobs:
       # - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
 
       - name: Restore nuget packages for all solutions
-        run: msbuild 'Samples/**/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
+        run: msbuild 'Samples/*/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
       
       - name: Build all Sample solutions
-        run: msbuild 'Samples/**/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
+        run: msbuild 'Samples/*/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
              

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Use NuGet 5.2.0
         uses: nuget/setup-nuget@v1
 
-      - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
+      # - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
 
       - name: Restore nuget packages for all solutions
-        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
+        run: msbuild 'Samples/**/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
       
       - name: Build all Sample solutions
-        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
+        run: msbuild 'Samples/**/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
              

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -31,8 +31,10 @@ jobs:
       - name: Use NuGet 5.2.0
         uses: nuget/setup-nuget@v1
 
-      # - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
-      - name: Restore nuget packages for all solutions
+      - name: Restore nuget packages for console upackaged
+        run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
+      
+      - name: Restore nuget packages for console upackaged
         run: msbuild 'Samples\ResourceManagement\cpp-console-unpackaged\console_unpackaged_app.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
 
       - name: Restore nuget packages for all solutions

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -36,8 +36,8 @@ jobs:
         run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
 
       - name: Restore nuget packages for all solutions
-        run: msbuild 'Samples/*/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
+        run: msbuild 'Samples\**\*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
       
       - name: Build all Sample solutions
-        run: msbuild 'Samples/*/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
+        run: msbuild 'Samples\**\*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
              

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       # - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
       - name: Restore nuget packages for all solutions
-        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
+        run: msbuild 'Samples/ResourceManagement/cpp-console-unpackaged/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }}
 
       - name: Restore nuget packages for all solutions
         run: msbuild 'Samples/*/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore

--- a/.github/workflows/samples_ci.yml
+++ b/.github/workflows/samples_ci.yml
@@ -32,6 +32,8 @@ jobs:
         uses: nuget/setup-nuget@v1
 
       # - run: nuget restore Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln
+      - name: Restore nuget packages for all solutions
+        run: msbuild ' Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore
 
       - name: Restore nuget packages for all solutions
         run: msbuild 'Samples/*/*.sln' /p:configuration=${{ matrix.configuration }} /p:platform=${{ matrix.platform }} /t:restore


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

##### Description
This PR is still incomplete. What I'm trying to achieve here is to be able to build all the samples (including potentially new samples) with different versions of Visua Studio in a CI build, since we have had samples not being able to build with some versions, so we might want to catch that before we merge Pull Requests.
##### Checklist

- [ ] Please ensure your samples can be correctly built using the Visual Studio versions
      in https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio
- [ ] If you're adding a new sample, and it is related to one of the existing scenarios 
      (ResourceManagement, Windowing, etc) make sure to add them in the corresponding folder.
- [ ] Samples should build on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [ ] Samples should set the minimum version to Windows 10 version 1809.
- [ ] Make sure samples build clean with no warnings or errors.