### PR TITLE
Add missing copyright for xaml files

### DIFF
--- a/Samples/ResourceManagement/cpp-winui/winui_desktop_packaged_app_cpp/App.xaml
+++ b/Samples/ResourceManagement/cpp-winui/winui_desktop_packaged_app_cpp/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application
+﻿<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<Application
     x:Class="winui_desktop_packaged_app_cpp.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/ResourceManagement/cpp-winui/winui_desktop_packaged_app_cpp/MainWindow.xaml
+++ b/Samples/ResourceManagement/cpp-winui/winui_desktop_packaged_app_cpp/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window
+﻿<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<Window
     x:Class="winui_desktop_packaged_app_cpp.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/ResourceManagement/cs-winui/winui_desktop_packaged_app/App.xaml
+++ b/Samples/ResourceManagement/cs-winui/winui_desktop_packaged_app/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->﻿
+<Application
     x:Class="winui_desktop_packaged_app.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/ResourceManagement/cs-winui/winui_desktop_packaged_app/MainWindow.xaml
+++ b/Samples/ResourceManagement/cs-winui/winui_desktop_packaged_app/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<Window
     x:Class="winui_desktop_packaged_app.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/ResourceManagement/cs-wpf/wpf_packaged_app/App.xaml
+++ b/Samples/ResourceManagement/cs-wpf/wpf_packaged_app/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application x:Class="wpf_packaged_app.App"
+﻿<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<Application x:Class="wpf_packaged_app.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:wpf_packaged_app"

--- a/Samples/ResourceManagement/cs-wpf/wpf_packaged_app/MainWindow.xaml
+++ b/Samples/ResourceManagement/cs-wpf/wpf_packaged_app/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window x:Class="wpf_packaged_app.MainWindow"
+﻿<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<Window x:Class="wpf_packaged_app.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

##### Description
Add missing copyright headers for XAML files in ResourceManagement samples