### PR TITLE
Cleanup sample templates

### DIFF
--- a/Templates/VSIX/Item Templates/WinUI3ScenarioPageCpp/Scenario3_ShortName.xaml.cpp
+++ b/Templates/VSIX/Item Templates/WinUI3ScenarioPageCpp/Scenario3_ShortName.xaml.cpp
@@ -7,8 +7,10 @@
 #include "$safeitemname$.g.cpp"
 #endif
 
-using namespace winrt;
-using namespace Microsoft::UI::Xaml;
+namespace winrt
+{
+    using namespace Microsoft::UI::Xaml;
+}
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/App.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/App.xaml.cpp
@@ -6,32 +6,33 @@
 #include "App.xaml.h"
 #include "MainWindow.xaml.h"
 
-using namespace winrt;
-using namespace Microsoft::UI::Xaml;
-using namespace Microsoft::UI::Xaml::Controls;
-using namespace Microsoft::UI::Xaml::Navigation;
-using namespace Windows::Foundation;
-using namespace $safeprojectname$;
-using namespace $safeprojectname$::implementation;
-
-App::App()
+namespace winrt
 {
-    InitializeComponent();
-
-#if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
-    UnhandledException([](IInspectable const&, UnhandledExceptionEventArgs const& e)
-    {
-        if (IsDebuggerPresent())
-        {
-            auto errorMessage = e.Message();
-            __debugbreak();
-        }
-    });
-#endif
+    using namespace Windows::Foundation;
+    using namespace Microsoft::UI::Xaml;
 }
 
-void App::OnLaunched(LaunchActivatedEventArgs const&)
+namespace winrt::$safeprojectname$::implementation
 {
-    window = make<MainWindow>();
-    window.Activate();
+    App::App()
+    {
+        InitializeComponent();
+
+#if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
+        UnhandledException([](winrt::IInspectable const&, winrt::UnhandledExceptionEventArgs const& e)
+            {
+                if (IsDebuggerPresent())
+                {
+                    auto errorMessage = e.Message();
+                    __debugbreak();
+                }
+            });
+#endif
+    }
+
+    void App::OnLaunched(winrt::LaunchActivatedEventArgs const&)
+    {
+        window = winrt::make<MainWindow>();
+        window.Activate();
+    }
 }

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainPage.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainPage.xaml.cpp
@@ -51,7 +51,7 @@ namespace winrt::$safeprojectname$::implementation
 
     void MainPage::NavView_Loaded(IInspectable const&, RoutedEventArgs const&)
     {
-        for (auto s : Scenarios())
+        for (auto&& s : Scenarios())
         {
             FontIcon fontIcon{};
             fontIcon.FontFamily(winrt::FontFamily(L"Segoe MDL2 Assets"));
@@ -140,7 +140,7 @@ namespace winrt::$safeprojectname$::implementation
         }
         else
         {
-            for (auto item : NavView().MenuItems())
+            for (auto&& item : NavView().MenuItems())
             {
                 auto navViewItem = item.try_as<NavigationViewItem>();
                 if (navViewItem != nullptr && 

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainPage.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainPage.xaml.cpp
@@ -17,7 +17,6 @@ namespace winrt
     using namespace Windows::UI::Xaml::Interop;
 }
 
-
 namespace winrt::$safeprojectname$::implementation
 {
     $safeprojectname$::MainPage MainPage::current{ nullptr };
@@ -87,7 +86,7 @@ namespace winrt::$safeprojectname$::implementation
         }
         else if (args.InvokedItemContainer() != nullptr)
         {
-            hstring navItemTag = winrt::unbox_value<hstring>(args.InvokedItemContainer().Tag());
+            auto navItemTag = winrt::unbox_value<hstring>(args.InvokedItemContainer().Tag());
             if (navItemTag != L"")
             {
                 NavView_Navigate(navItemTag, args.RecommendedNavigationTransitionInfo());
@@ -143,7 +142,7 @@ namespace winrt::$safeprojectname$::implementation
         {
             for (auto item : NavView().MenuItems())
             {
-                NavigationViewItem navViewItem = item.try_as<NavigationViewItem>();
+                auto navViewItem = item.try_as<NavigationViewItem>();
                 if (navViewItem != nullptr && 
                     winrt::unbox_value<hstring>(navViewItem.Tag()) == e.SourcePageType().Name)
                 {

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainWindow.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainWindow.xaml.cpp
@@ -65,24 +65,25 @@ namespace winrt::$safeprojectname$::implementation
 
     void MainWindow::PlacementCenterWindowInMonitorWin32(HWND hwnd)
     {
-        RECT rc;
-        GetWindowRect(hwnd, &rc);
-        ClipOrCenterRectToMonitorWin32(&rc);
-        SetWindowPos(hwnd, nullptr, rc.left, rc.top, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+        RECT windowMontiorRectToAdjust;
+        GetWindowRect(hwnd, &windowMontiorRectToAdjust);
+        ClipOrCenterRectToMonitorWin32(windowMontiorRectToAdjust);
+        SetWindowPos(hwnd, nullptr, windowMontiorRectToAdjust.left,
+            windowMontiorRectToAdjust.top, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
     }
 
     void MainWindow::ClipOrCenterRectToMonitorWin32(_Inout_ RECT* prc)
     {
         MONITORINFO mi{ sizeof(mi) };
-        GetMonitorInfoW(MonitorFromRect(prc, MONITOR_DEFAULTTONEAREST), &mi);
+        GetMonitorInfoW(MonitorFromRect(&prc, MONITOR_DEFAULTTONEAREST), &mi);
 
         const auto& rcWork = mi.rcWork;
-        const int w = prc->right - prc->left;
-        const int h = prc->bottom - prc->top;
+        const int w = (&prc)->right - (&prc)->left;
+        const int h = (&prc)->bottom - (&prc)->top;
 
-        prc->left = rcWork.left + (rcWork.right - rcWork.left - w) / 2;
-        prc->top = rcWork.top + (rcWork.bottom - rcWork.top - h) / 2;
-        prc->right = prc->left + w;
-        prc->bottom = prc->top + h;
+        (&prc)->left = rcWork.left + (rcWork.right - rcWork.left - w) / 2;
+        (&prc)->top = rcWork.top + (rcWork.bottom - rcWork.top - h) / 2;
+        (&prc)->right = (&prc)->left + w;
+        (&prc)->bottom = (&prc)->top + h;
     }
 }

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainWindow.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainWindow.xaml.cpp
@@ -10,6 +10,11 @@
 #include "SampleConfiguration.h"
 #endif
 
+namespace winrt
+{
+    using namespace Microsoft::UI::Xaml;
+}
+
 namespace winrt::$safeprojectname$::implementation
 {
     MainWindow::MainWindow()
@@ -28,7 +33,7 @@ namespace winrt::$safeprojectname$::implementation
     {
         if (_hwnd == nullptr)
         {
-            winrt::Microsoft::UI::Xaml::Window window = *this;
+            Window window = *this;
             window.as<IWindowNative>()->get_WindowHandle(&_hwnd);
         }
         return _hwnd;

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainWindow.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainWindow.xaml.cpp
@@ -72,7 +72,7 @@ namespace winrt::$safeprojectname$::implementation
             windowMontiorRectToAdjust.top, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
     }
 
-    void MainWindow::ClipOrCenterRectToMonitorWin32(_Inout_ RECT* prc)
+    void MainWindow::ClipOrCenterRectToMonitorWin32(RECT& prc)
     {
         MONITORINFO mi{ sizeof(mi) };
         GetMonitorInfoW(MonitorFromRect(&prc, MONITOR_DEFAULTTONEAREST), &mi);

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainWindow.xaml.h
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/MainWindow.xaml.h
@@ -16,7 +16,7 @@ namespace winrt::$safeprojectname$::implementation
         void SetWindowSize(HWND hwnd, const int width, const int height);
         HWND GetWindowHandle();
         void LoadIcon(HWND hwnd, wchar_t const* iconName);
-        void ClipOrCenterRectToMonitorWin32(RECT* prc);
+        void ClipOrCenterRectToMonitorWin32(RECT& prc);
         void PlacementCenterWindowInMonitorWin32(HWND hwnd);
     };
 }

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/Project.idl
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/Project.idl
@@ -4,7 +4,7 @@
 namespace $safeprojectname$
 {
     /* The following code is scenario/feature-specific IDL.
-    Samples authors should modify these runtime classes as approriate. */
+    Samples authors should modify these runtime classes as appropriate. */
 
     [default_interface]
     runtimeclass Scenario1_ShortName : Microsoft.UI.Xaml.Controls.Page

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/Project.idl
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/Project.idl
@@ -21,7 +21,6 @@ namespace $safeprojectname$
      /* The following code is template-specific IDL.
      These runtime classes are the same across all C++/WinRT WinUI samples. */
 
-    [default_interface]
     runtimeclass MainPage : Microsoft.UI.Xaml.Controls.Page
     {
         MainPage();

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/SampleConfiguration.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/SampleConfiguration.cpp
@@ -6,16 +6,20 @@
 #include "SampleConfiguration.h"
 #include "MainPage.xaml.h" 
 
-using namespace winrt;
-using namespace winrt::$safeprojectname$;
-using namespace Microsoft::UI::Xaml;
-using namespace Windows::Foundation::Collections;
+namespace winrt
+{
+    using namespace Microsoft::UI::Xaml;
+    using namespace Windows::Foundation::Collections;
+}
 
-IVector<Scenario> implementation::MainPage::scenariosInner = winrt::single_threaded_observable_vector<Scenario>(
-	{
-		Scenario{ L"Scenario 1", winrt::hstring(winrt::name_of<$safeprojectname$::Scenario1_ShortName>())},
-		Scenario{ L"Scenario 2", winrt::hstring(winrt::name_of<$safeprojectname$::Scenario2_ShortName>())}
-	});
+namespace winrt::$safeprojectname$
+{
+    IVector<Scenario> implementation::MainPage::scenariosInner = winrt::single_threaded_observable_vector<Scenario>(
+        {
+            Scenario{ L"Scenario 1", winrt::hstring(winrt::name_of<$safeprojectname$::Scenario1_ShortName>())},
+            Scenario{ L"Scenario 2", winrt::hstring(winrt::name_of<$safeprojectname$::Scenario2_ShortName>())}
+        });
 
-hstring SampleConfig::FeatureName{ L"$safeprojectname$" };
-ElementTheme SampleConfig::CurrentTheme{ ElementTheme::Default };
+    hstring SampleConfig::FeatureName{ L"$safeprojectname$" };
+    ElementTheme SampleConfig::CurrentTheme{ ElementTheme::Default };
+}

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/Scenario1_ShortName.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/Scenario1_ShortName.xaml.cpp
@@ -7,15 +7,15 @@
 #include "Scenario1_ShortName.g.cpp"
 #endif
 
-using namespace winrt;
-using namespace Microsoft::UI::Xaml;
-using namespace Microsoft::UI::Xaml::Controls;
-using namespace Windows::Foundation;
-
+namespace winrt
+{
+    using namespace Microsoft::UI::Xaml;
+    using namespace Microsoft::UI::Xaml::Controls;
+    using namespace Windows::Foundation;
+}
 
 namespace winrt::$safeprojectname$::implementation
 {
-
     MainPage Scenario1_ShortName::rootPage{ nullptr };
 
     Scenario1_ShortName::Scenario1_ShortName()
@@ -29,18 +29,15 @@ namespace winrt::$safeprojectname$::implementation
         rootPage.NotifyUser(L"Everything was ok!", InfoBarSeverity::Success);
     }
 
-
     void Scenario1_ShortName::ErrorMessage_Click(IInspectable const&, RoutedEventArgs const&)
     {
         rootPage.NotifyUser(L"Something went wrong.", InfoBarSeverity::Error);
     }
 
-
     void Scenario1_ShortName::InformationalMessage_Click(IInspectable const&, RoutedEventArgs const&)
     {
         rootPage.NotifyUser(L"This is the informational bar.", InfoBarSeverity::Informational);
     }
-
 
     void Scenario1_ShortName::ClearMessage_Click(IInspectable const&, RoutedEventArgs const&)
     {

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/Scenario2_ShortName.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/Scenario2_ShortName.xaml.cpp
@@ -7,11 +7,10 @@
 #include "Scenario2_ShortName.g.cpp"
 #endif
 
-using namespace winrt;
-using namespace Microsoft::UI::Xaml;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
+namespace winrt
+{
+    using namespace Microsoft::UI::Xaml;
+}
 
 namespace winrt::$safeprojectname$::implementation
 {

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/SettingsPage.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/SettingsPage.xaml.cpp
@@ -25,12 +25,12 @@ namespace winrt::$safeprojectname$::implementation
 
     void SettingsPage::OnNavigatedTo(NavigationEventArgs const&)
     {
-        for (UIElement c : themePanel().Children())
+        for (UIElement&& c : themePanel().Children())
         {
-            ElementTheme tag = c.as<RadioButton>().Tag().as<ElementTheme>();
+            auto tag = c.as<RadioButton>().Tag().as<ElementTheme>();
             if (tag == SampleConfig::CurrentTheme)
             {
-                RadioButton radioButton = c.as<RadioButton>();
+                auto radioButton = c.as<RadioButton>();
                 radioButton.IsChecked(true);
             }
         }
@@ -38,10 +38,10 @@ namespace winrt::$safeprojectname$::implementation
 
     void SettingsPage::OnThemeRadioButtonChecked(IInspectable const& sender, RoutedEventArgs const&)
     { 
-        RadioButton radiobutton = sender.as<RadioButton>();
+        auto radiobutton = sender.as<RadioButton>();
         auto selectedTheme = unbox_value<ElementTheme>(radiobutton.Tag());
 
-        Grid content = MainPage::Current().Content().as<Grid>();
+        auto content = MainPage::Current().Content().as<Grid>();
         if (content != nullptr)
         {
             content.RequestedTheme(selectedTheme);

--- a/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/SettingsPage.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/WinUI3TemplateCpp/SettingsPage.xaml.cpp
@@ -8,11 +8,13 @@
 #endif
 #include <SampleConfiguration.h>
 
-using namespace winrt;
-using namespace Microsoft::UI::Xaml;
-using namespace Microsoft::UI::Xaml::Controls;
-using namespace Microsoft::UI::Xaml::Navigation;
-using namespace Windows::Foundation;
+namespace winrt
+{
+    using namespace Microsoft::UI::Xaml;
+    using namespace Microsoft::UI::Xaml::Controls;
+    using namespace Microsoft::UI::Xaml::Navigation;
+    using namespace Windows::Foundation;
+}
 
 namespace winrt::$safeprojectname$::implementation
 {
@@ -37,7 +39,7 @@ namespace winrt::$safeprojectname$::implementation
     void SettingsPage::OnThemeRadioButtonChecked(IInspectable const& sender, RoutedEventArgs const&)
     { 
         RadioButton radiobutton = sender.as<RadioButton>();
-        ElementTheme selectedTheme = unbox_value<ElementTheme>(radiobutton.Tag());
+        auto selectedTheme = unbox_value<ElementTheme>(radiobutton.Tag());
 
         Grid content = MainPage::Current().Content().as<Grid>();
         if (content != nullptr)

--- a/Templates/VSIX/Project Templates/cs-winui-template/MainPage.xaml.cs
+++ b/Templates/VSIX/Project Templates/cs-winui-template/MainPage.xaml.cs
@@ -10,7 +10,6 @@ using System.Linq;
 
 namespace $safeprojectname$
 {
-
     public partial class MainPage : Page
     {
         public static MainPage Current;

--- a/Templates/VSIX/Project Templates/cs-winui-template/MainWindow.xaml.cs
+++ b/Templates/VSIX/Project Templates/cs-winui-template/MainWindow.xaml.cs
@@ -35,24 +35,24 @@ namespace $safeprojectname$
 
             fixed (char* nameLocal = iconName)
             {
-                HANDLE imageHandle = LoadImage(default,
+                HANDLE hSmallIcon = LoadImage(default,
                     nameLocal,
                     GDI_IMAGE_TYPE.IMAGE_ICON,
                     GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON),
                     GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYSMICON),
                     IMAGE_FLAGS.LR_LOADFROMFILE | IMAGE_FLAGS.LR_SHARED);
-                SendMessage(hwnd, WM_SETICON, ICON_SMALL, imageHandle.Value);
+                SendMessage(hwnd, WM_SETICON, ICON_SMALL, hSmallIcon.Value);
             }
 
             fixed (char* nameLocal = iconName)
             {
-                HANDLE imageHandle = LoadImage(default,
+                HANDLE hBigIcon = LoadImage(default,
                     nameLocal,
                     GDI_IMAGE_TYPE.IMAGE_ICON,
                     GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON),
                     GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYSMICON),
                     IMAGE_FLAGS.LR_LOADFROMFILE | IMAGE_FLAGS.LR_SHARED);
-                SendMessage(hwnd, WM_SETICON, ICON_BIG, imageHandle.Value);
+                SendMessage(hwnd, WM_SETICON, ICON_BIG, hBigIcon.Value);
             }
         }
 

--- a/Templates/VSIX/Project Templates/cs-winui-template/MainWindow.xaml.cs
+++ b/Templates/VSIX/Project Templates/cs-winui-template/MainWindow.xaml.cs
@@ -80,18 +80,14 @@ namespace $safeprojectname$
 
         private void ClipOrCenterRectToMonitorWin32(ref RECT prc)
         {
-            HMONITOR hMonitor;
-            RECT rc;
+            MONITORINFO mi = new MONITORINFO(); 
+            mi.cbSize = (uint)Marshal.SizeOf<MONITORINFO>();
+            GetMonitorInfo(MonitorFromRect(prc, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST), ref mi);
+
+            RECT rc = mi.rcWork;
             int w = prc.right - prc.left;
             int h = prc.bottom - prc.top;
 
-            hMonitor = MonitorFromRect(prc, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
-            MONITORINFO mi = new MONITORINFO();
-            mi.cbSize = (uint)Marshal.SizeOf<MONITORINFO>();
-
-            GetMonitorInfo(hMonitor, ref mi);
-
-            rc = mi.rcWork;
             prc.left = rc.left + (rc.right - rc.left - w) / 2;
             prc.top = rc.top + (rc.bottom - rc.top - h) / 2;
             prc.right = prc.left + w;

--- a/Templates/VSIX/Project Templates/cs-winui-template/Scenario1_ShortName.xaml.cs
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Scenario1_ShortName.xaml.cs
@@ -8,8 +8,9 @@ namespace $safeprojectname$
 {
     public partial class Scenario1_ShortName : Page
     {
-    private MainPage rootPage = MainPage.Current;
-    public Scenario1_ShortName()
+        private MainPage rootPage = MainPage.Current;
+
+        public Scenario1_ShortName()
         {
             this.InitializeComponent();
         }
@@ -17,7 +18,6 @@ namespace $safeprojectname$
         private void SuccessMessage_Click(object sender, RoutedEventArgs e)
         {
             rootPage.NotifyUser("Everything was ok!", InfoBarSeverity.Success);
-
         }
 
         private void ErrorMessage_Click(object sender, RoutedEventArgs e)

--- a/Templates/VSIX/Project Templates/cs-winui-template/SettingsPage.xaml.cs
+++ b/Templates/VSIX/Project Templates/cs-winui-template/SettingsPage.xaml.cs
@@ -31,7 +31,6 @@ namespace $safeprojectname$
                     content.RequestedTheme = selectedTheme;
                     SampleConfig.CurrentTheme = content.RequestedTheme;
                 }
-            
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

##### Description
This PR cleans up some of the sample template code (mainly in the C++ templates).

This includes:
- refactoring `using namespace winrt`
- auto&& in range-based for loops to avoid extra copies
- using `auto` to avoid repeating `<T>`
- NULL -> nullptr 
- update HMONITOR functions.

##### Checklist

- [ ] Please ensure your samples can be correctly built using the Visual Studio versions
      in https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio
- [ ] If you're adding a new sample, and it is related to one of the existing scenarios 
      (ResourceManagement, Windowing, etc) make sure to add them in the corresponding folder.
- [ ] Samples should build on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [ ] Samples should set the minimum version to Windows 10 version 1809.
- [ ] Make sure samples build clean with no warnings or errors.