### PR TITLE
AppLifecycle samples: added license header to XAML files

### DIFF
--- a/Samples/AppLifecycle/Activation/cpp-winui-packaged/CppWinUiDesktopActivation/CppWinUiDesktopActivation/App.xaml
+++ b/Samples/AppLifecycle/Activation/cpp-winui-packaged/CppWinUiDesktopActivation/CppWinUiDesktopActivation/App.xaml
@@ -1,8 +1,9 @@
-﻿<Application
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application
     x:Class="CppWinUiDesktopActivation.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:CppWinUiDesktopActivation">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/Samples/AppLifecycle/Activation/cpp-winui-packaged/CppWinUiDesktopActivation/CppWinUiDesktopActivation/MainWindow.xaml
+++ b/Samples/AppLifecycle/Activation/cpp-winui-packaged/CppWinUiDesktopActivation/CppWinUiDesktopActivation/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window
     x:Class="CppWinUiDesktopActivation.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Samples/AppLifecycle/Activation/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/App.xaml
+++ b/Samples/AppLifecycle/Activation/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application
     x:Class="CsWinUiDesktopActivation.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/AppLifecycle/Activation/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/MainWindow.xaml
+++ b/Samples/AppLifecycle/Activation/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window
     x:Class="CsWinUiDesktopActivation.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Samples/AppLifecycle/Activation/cs-wpf-packaged/CsWpfActivation/App.xaml
+++ b/Samples/AppLifecycle/Activation/cs-wpf-packaged/CsWpfActivation/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application x:Class="CsWpfActivation.App"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application x:Class="CsWpfActivation.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:CsWpfActivation"

--- a/Samples/AppLifecycle/Activation/cs-wpf-packaged/CsWpfActivation/MainWindow.xaml
+++ b/Samples/AppLifecycle/Activation/cs-wpf-packaged/CsWpfActivation/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window x:Class="CsWpfActivation.MainWindow"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window x:Class="CsWpfActivation.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/AppLifecycle/Activation/cs-wpf-unpackaged/CsWpfActivation/App.xaml
+++ b/Samples/AppLifecycle/Activation/cs-wpf-unpackaged/CsWpfActivation/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application x:Class="CsWpfActivation.App"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application x:Class="CsWpfActivation.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:CsWpfActivation"

--- a/Samples/AppLifecycle/Activation/cs-wpf-unpackaged/CsWpfActivation/MainWindow.xaml
+++ b/Samples/AppLifecycle/Activation/cs-wpf-unpackaged/CsWpfActivation/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window x:Class="CsWpfActivation.MainWindow"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window x:Class="CsWpfActivation.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/AppLifecycle/Instancing/cpp-winui-packaged/CppWinUiDesktopInstancing/CppWinUiDesktopInstancing/App.xaml
+++ b/Samples/AppLifecycle/Instancing/cpp-winui-packaged/CppWinUiDesktopInstancing/CppWinUiDesktopInstancing/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application
     x:Class="CppWinUiDesktopInstancing.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/AppLifecycle/Instancing/cpp-winui-packaged/CppWinUiDesktopInstancing/CppWinUiDesktopInstancing/App.xaml.cpp
+++ b/Samples/AppLifecycle/Instancing/cpp-winui-packaged/CppWinUiDesktopInstancing/CppWinUiDesktopInstancing/App.xaml.cpp
@@ -38,6 +38,11 @@ App::App()
 }
 
 // Enum-to-string helpers. This app only supports Launch and File activation.
+// Note that ExtendedActivationKind is a superset of ActivationKind, so 
+// we could reduce these 2 methods to one, and cast appropriately from
+// ActivationKind to ExtendedActivationKind. However, this sample keeps
+// them separate to illustrate the difference between Xaml::LaunchActivatedEventArgs
+// and AppLifecycle::AppActivationArguments
 winrt::hstring KindString(
     winrt::Windows::ApplicationModel::Activation::ActivationKind kind)
 {

--- a/Samples/AppLifecycle/Instancing/cpp-winui-packaged/CppWinUiDesktopInstancing/CppWinUiDesktopInstancing/MainWindow.xaml
+++ b/Samples/AppLifecycle/Instancing/cpp-winui-packaged/CppWinUiDesktopInstancing/CppWinUiDesktopInstancing/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window
     x:Class="CppWinUiDesktopInstancing.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Samples/AppLifecycle/Instancing/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/App.xaml
+++ b/Samples/AppLifecycle/Instancing/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application
     x:Class="CsWinUiDesktopInstancing.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/AppLifecycle/Instancing/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/MainWindow.xaml
+++ b/Samples/AppLifecycle/Instancing/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window
     x:Class="CsWinUiDesktopInstancing.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Samples/AppLifecycle/Instancing/cs-wpf-packaged/CsWpfInstancing/App.xaml
+++ b/Samples/AppLifecycle/Instancing/cs-wpf-packaged/CsWpfInstancing/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application x:Class="CsWpfInstancing.App"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application x:Class="CsWpfInstancing.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:CsWpfInstancing"

--- a/Samples/AppLifecycle/Instancing/cs-wpf-packaged/CsWpfInstancing/MainWindow.xaml
+++ b/Samples/AppLifecycle/Instancing/cs-wpf-packaged/CsWpfInstancing/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window x:Class="CsWpfInstancing.MainWindow"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window x:Class="CsWpfInstancing.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/AppLifecycle/Instancing/cs-wpf-unpackaged/CsWpfInstancing/App.xaml
+++ b/Samples/AppLifecycle/Instancing/cs-wpf-unpackaged/CsWpfInstancing/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application x:Class="CsWpfInstancing.App"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application x:Class="CsWpfInstancing.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:CsWpfInstancing"

--- a/Samples/AppLifecycle/Instancing/cs-wpf-unpackaged/CsWpfInstancing/MainWindow.xaml
+++ b/Samples/AppLifecycle/Instancing/cs-wpf-unpackaged/CsWpfInstancing/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window x:Class="CsWpfInstancing.MainWindow"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window x:Class="CsWpfInstancing.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/AppLifecycle/StateNotifications/cpp-winui-packaged/CppWinUiDesktopState/CppWinUiDesktopState/App.xaml
+++ b/Samples/AppLifecycle/StateNotifications/cpp-winui-packaged/CppWinUiDesktopState/CppWinUiDesktopState/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application
     x:Class="CppWinUiDesktopState.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/AppLifecycle/StateNotifications/cpp-winui-packaged/CppWinUiDesktopState/CppWinUiDesktopState/MainWindow.xaml
+++ b/Samples/AppLifecycle/StateNotifications/cpp-winui-packaged/CppWinUiDesktopState/CppWinUiDesktopState/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window
     x:Class="CppWinUiDesktopState.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Samples/AppLifecycle/StateNotifications/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/App.xaml
+++ b/Samples/AppLifecycle/StateNotifications/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application
     x:Class="CsWinUiDesktopState.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/AppLifecycle/StateNotifications/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/MainWindow.xaml
+++ b/Samples/AppLifecycle/StateNotifications/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window
     x:Class="CsWinUiDesktopState.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Samples/AppLifecycle/StateNotifications/cs-wpf-packaged/CsWpfState/App.xaml
+++ b/Samples/AppLifecycle/StateNotifications/cs-wpf-packaged/CsWpfState/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application x:Class="CsWpfState.App"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application x:Class="CsWpfState.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:CsWpfState"

--- a/Samples/AppLifecycle/StateNotifications/cs-wpf-packaged/CsWpfState/MainWindow.xaml
+++ b/Samples/AppLifecycle/StateNotifications/cs-wpf-packaged/CsWpfState/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window x:Class="CsWpfState.MainWindow"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window x:Class="CsWpfState.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Samples/AppLifecycle/StateNotifications/cs-wpf-unpackaged/CsWpfState/App.xaml
+++ b/Samples/AppLifecycle/StateNotifications/cs-wpf-unpackaged/CsWpfState/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application x:Class="CsWpfState.App"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Application x:Class="CsWpfState.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:CsWpfState"

--- a/Samples/AppLifecycle/StateNotifications/cs-wpf-unpackaged/CsWpfState/MainWindow.xaml
+++ b/Samples/AppLifecycle/StateNotifications/cs-wpf-unpackaged/CsWpfState/MainWindow.xaml
@@ -1,4 +1,6 @@
-﻿<Window x:Class="CsWpfState.MainWindow"
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Window x:Class="CsWpfState.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

##### Description

##### Checklist

- [ ] Please ensure your samples can be correctly built using the Visual Studio versions
      in https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio
- [ ] If you're adding a new sample, and it is related to one of the existing scenarios 
      (ResourceManagement, Windowing, etc) make sure to add them in the corresponding folder.
- [ ] Samples should build on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [ ] Samples should set the minimum version to Windows 10 version 1809.
- [ ] Make sure samples build clean with no warnings or errors.