### PR TITLE
Samples VSIX Build And Release Pipeline

### DIFF
--- a/Templates/VSIX/Directory.Build.targets
+++ b/Templates/VSIX/Directory.Build.targets
@@ -166,6 +166,7 @@ xmlns:ns="http://schemas.microsoft.com/developer/vstemplate/2005">
       OutputPaths="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension).generated')"
       XslContent="$(_UnconditionalVsTemplateXslt)" />
     <!-- Replace the original .vstemplate -->
+    <Delete Files="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension)')" />
     <Move SourceFiles="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension).generated')"
       DestinationFiles="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension)')" OverwriteReadOnlyFiles="true" />
 

--- a/Templates/VSIX/Directory.Build.targets
+++ b/Templates/VSIX/Directory.Build.targets
@@ -166,7 +166,7 @@ xmlns:ns="http://schemas.microsoft.com/developer/vstemplate/2005">
       OutputPaths="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension).generated')"
       XslContent="$(_UnconditionalVsTemplateXslt)" />
     <!-- Replace the original .vstemplate -->
-    <Copy SourceFiles="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension).generated')"
+    <Move SourceFiles="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension).generated')"
       DestinationFiles="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension)')" OverwriteReadOnlyFiles="true" />
 
     <!-- Repack the archive -->

--- a/Templates/VSIX/Directory.Build.targets
+++ b/Templates/VSIX/Directory.Build.targets
@@ -166,8 +166,8 @@ xmlns:ns="http://schemas.microsoft.com/developer/vstemplate/2005">
       OutputPaths="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension).generated')"
       XslContent="$(_UnconditionalVsTemplateXslt)" />
     <!-- Replace the original .vstemplate -->
-    <Move SourceFiles="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension).generated')"
-      DestinationFiles="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension).generated')"
+      DestinationFiles="@(_allVsTemplates->'$(_tempDir)%(RecursiveDir)%(Filename)%(Extension)')" OverwriteReadOnlyFiles="true" />
 
     <!-- Repack the archive -->
     <ZipDirectory SourceDirectory="$(_tempDir)"

--- a/Templates/VSIX/nuget.config
+++ b/Templates/VSIX/nuget.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <clear />
+    <add key="globalPackagesFolder" value="$\..\packages" />
+    <add key="repositoryPath" value="$\..\packages" />
+  </config>
+  <packageSources>
+    <clear />
+    <add key="ProjectReunion internal" value="https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
+
+    <!-- a local directory to allow testing nupkg files without pushing to a remote feed -->
+    <add key="localpackages" value="localpackages" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/Templates/VSIX/nuget.config
+++ b/Templates/VSIX/nuget.config
@@ -9,8 +9,6 @@
     <clear />
     <add key="ProjectReunion internal" value="https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
 
-    <!-- a local directory to allow testing nupkg files without pushing to a remote feed -->
-    <add key="localpackages" value="localpackages" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -25,7 +25,7 @@ stages:
           Write-Host $WinAppSDKVersion
           [xml]$props = Get-Content -Encoding utf8 -Path $file
           $props.Project.PropertyGroup.WindowsAppSdkVersion.innerText = $WindowsAppSDKNugetPackageVersion
-          Write-Host $publicNuspec.OuterXml
+          Write-Host $publicNuspec
           Set-Content -Encoding utf8 -Value $publicNuspec.OuterXml $file
       
     - task: VSBuild@1

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -17,7 +17,11 @@ parameters:
   - name: "ReleaseNotes"
     displayName: "Release Notes" 
     type: string
+    default: ''
   - name: "IsDraft"
+    type: boolean
+    default: False
+  - name: "IsPreRelease"
     type: boolean
     default: False
   - name: "WinAppSDKVersion"

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -8,22 +8,22 @@ parameters:
   - name: "Action"
     displayName: "GitHub Release Action" 
     type: string
-    default: 'create'
+    default: 'none'
     values:
     - 'none'
     - 'create'
     - 'edit'
     - 'delete'
   - name: "ReleaseNotes"
-    displayName: "Release Notes" 
+    displayName: "Release Notes (Not used in none and delete option)" 
     type: string
     default: ''
   - name: "IsDraft"
-    displayName: "IsDraft: Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published."
+    displayName: "IsDraft: \n Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published."
     type: boolean
     default: False
   - name: "IsPreRelease"
-    displayName: "IsPrelease: Indicate whether the release should be marked as a pre-release." 
+    displayName: "IsPrelease: \n Indicate whether the release should be marked as a pre-release." 
     type: boolean
     default: False
   - name: "WinAppSDKVersion"

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -43,15 +43,18 @@ stages:
       inputs:
         solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
         platform: 'Any CPU'
-        configuration: 'Debug'
+        configuration: 'Release'
         msBuildArgs: '/t:restore '
+
+    - script: |
+      dir /s $(Build.SourcesDirectory)
 
     - task: VSBuild@1
       displayName: 'Build WindowsAppSDKSampleVSIX.sln'
       inputs:
         solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
         platform: 'Any CPU'
-        configuration: 'Debug'
+        configuration: 'Release'
 
     - script: |
         dir /s $(Build.SourcesDirectory)

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -1,6 +1,11 @@
 # see https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases for info on yaml ADO jobs
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 parameters:
+  # Version of the WindowsAppSDK used to build the Samples VSIX
+  - name: "WinAppSDKVersion"
+    displayName: "Windows App SDK version" 
+    type: string
+    default: '1.0.0-preview3'
   # This is used as a unique identifier for the GitHub Release.
   - name: "ReleaseTag"
     displayName: "Release Unique Identifier" 
@@ -25,18 +30,13 @@ parameters:
     type: string
     default: 'Replace Me'
   - name: "IsDraft"
-    displayName: "IsDraft: \n Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published."
+    displayName: "IsDraft: \n Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published. (Not used in none and delete option)"
     type: boolean
     default: False
   - name: "IsPreRelease"
-    displayName: "IsPrelease: \n Indicate whether the release should be marked as a pre-release." 
+    displayName: "IsPrelease: \n Indicate whether the release should be marked as a pre-release. (Not used in none and delete option)" 
     type: boolean
     default: False
-  # Version of the WindowsAppSDK used to build the Samples VSIX
-  - name: "WinAppSDKVersion"
-    displayName: "Windows App SDK version" 
-    type: string
-    default: '1.0.0-preview3'
 
 stages:
 - stage: BuildAndReleaseVSIX

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -42,8 +42,8 @@ stages:
       inputs:
         command: 'restore'
         feedsToUse: 'config'
-        nugetConfigPath: $(Build.SourcesDirectory)\Templates\VSIX\nuget.config'
-        restoreSolution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln'
+        nugetConfigPath: Templates\VSIX\nuget.config'
+        restoreSolution: Templates\VSIX\WindowsAppSDKSampleVSIX.sln'
 
     - script: |
         dir /s $(Build.SourcesDirectory)

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -17,7 +17,7 @@ parameters:
   - name: "ReleaseNotes"
     displayName: "Release Notes (Not used in none and delete option)" 
     type: string
-    default: ''
+    default: 'Replace Me'
   - name: "IsDraft"
     displayName: "IsDraft: \n Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published."
     type: boolean

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -2,11 +2,11 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 parameters:
   - name: "ReleaseTag"
-    displayName: "Release Tag" 
+    displayName: "Release Tag and Post Title" 
     type: string
     default: ''
   - name: "Action"
-    displayName: "GitHub Release Option" 
+    displayName: "GitHub Release Action" 
     type: string
     default: 'create'
     values:
@@ -17,11 +17,13 @@ parameters:
   - name: "ReleaseNotes"
     displayName: "Release Notes" 
     type: string
-    default: ' '
+    default: ''
   - name: "IsDraft"
+    displayName: "IsDraft: Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published."
     type: boolean
     default: False
   - name: "IsPreRelease"
+    displayName: "IsPrelease: Indicate whether the release should be marked as a pre-release." 
     type: boolean
     default: False
   - name: "WinAppSDKVersion"
@@ -30,9 +32,9 @@ parameters:
     default: '1.0.0-preview3'
 
 stages:
-- stage: BuildVSIX
+- stage: BuildAndReleaseVSIX
   jobs:
-  - job: BuildVSIX
+  - job: BuildAndReleaseVSIX
     pool:
       vmImage: 'windows-2022'
     steps:

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -1,17 +1,6 @@
 # see https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases for info on yaml ADO jobs
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 parameters:
-  # Version of the WindowsAppSDK used to build the Samples VSIX
-  - name: "WinAppSDKVersion"
-    displayName: "Windows App SDK version" 
-    type: string
-    default: ''
-  # This is used as a unique identifier for the GitHub Release.
-  - name: "ReleaseTag"
-    displayName: "Release Unique Identifier" 
-    type: string
-    default: ''
-  # GitHubRelease@1 Action
   - name: "Action"
     displayName: "GitHub Release Action" 
     type: string
@@ -21,20 +10,31 @@ parameters:
     - 'create' # Builds and publishes the VSIX and also creates a github release
     - 'edit' # Builds and publishes the VSIX and edits an existing github release
     - 'delete' # Does not build the VSIX and deletes an existing github release
+  # Version of the WindowsAppSDK used to build the Samples VSIX
+  - name: "WinAppSDKVersion"
+    displayName: "Windows App SDK version (Required except for 'delete' action)" 
+    type: string
+    default: 'Placeholder'
+  # This is used as a unique identifier for the GitHub Release.
+  - name: "ReleaseTag"
+    displayName: "Release Unique Identifier (Required for 'create','edit','delete' actions)" 
+    type: string
+    default: 'Placeholder'
+  # GitHubRelease@1 Action
   - name: "ReleaseTitle"
-    displayName: "Release Title (Unused in none and delete Action)" 
+    displayName: "Release Title (Required for 'create','edit' actions)" 
     type: string
-    default: 'Replace Me'
+    default: 'Placeholder'
   - name: "ReleaseNotes"
-    displayName: "Release Notes (Unused in none and delete Action)" 
+    displayName: "Release Notes (Required for 'create','edit' actions)" 
     type: string
-    default: 'Replace Me'
+    default: 'Placeholder'
   - name: "IsDraft"
-    displayName: "IsDraft: \n Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published. (Unused in none and delete Action)"
+    displayName: "IsDraft: \n Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published. (Required for 'create','edit' actions)"
     type: boolean
     default: False
   - name: "IsPreRelease"
-    displayName: "IsPrelease: \n Indicate whether the release should be marked as a pre-release. (Unused in none and delete Action)" 
+    displayName: "IsPrelease: \n Indicate whether the release should be marked as a pre-release. (Required for 'create','edit' actions)" 
     type: boolean
     default: False
 

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -25,8 +25,8 @@ stages:
           Write-Host $WinAppSDKVersion
           [xml]$props = Get-Content -Encoding utf8 -Path $file
           $props.Project.PropertyGroup.WindowsAppSdkVersion.innerText = $WindowsAppSDKNugetPackageVersion
-          Write-Host $publicNuspec
-          Set-Content -Encoding utf8 -Value $publicNuspec.OuterXml $file
+          Write-Host $props
+          Set-Content -Encoding utf8 -Value $props.OuterXml $file
       
     - task: VSBuild@1
       displayName: 'Restore WindowsAppSDKSampleVSIX.sln'

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -43,7 +43,7 @@ stages:
       inputs:
         solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
         platform: 'Any CPU'
-        configuration: 'Release'
+        configuration: 'Debug'
         msBuildArgs: '/t:restore '
 
     - task: VSBuild@1
@@ -51,7 +51,7 @@ stages:
       inputs:
         solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
         platform: 'Any CPU'
-        configuration: 'Release'
+        configuration: 'Debug'
 
     - script: |
         dir /s $(Build.SourcesDirectory)

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -6,9 +6,11 @@ parameters:
     type: string
     default: ''
   - name: "Action"
+    displayName: "GitHub Release Option" 
     type: string
     default: 'create'
     values:
+    - 'None'
     - 'create'
     - 'edit'
     - 'delete'
@@ -76,12 +78,13 @@ stages:
           PathtoPublish: '$(Build.ArtifactStagingDirectory)\VSIX'
           ArtifactName: 'VSIX'
 
-    - task: GitHubRelease@1
-      inputs:
-        gitHubConnection: 'GitHub - benkuhn - 2-18'
-        repositoryName: 'microsoft/WindowsAppSDK-Samples'
-        action: ${{ parameters.Action }}
-        tag: ${{ parameters.ReleaseTag }}
-        assets: '$(Build.ArtifactStagingDirectory)/VSIX/WindowsAppSDKSampleVSIX.vsix'
-        tagSource: manual
-        isDraft: ${{ parameters.IsDraft }}
+    - ${{ if ne(parameters.Action, 'none') }}:
+      - task: GitHubRelease@1
+        inputs:
+          gitHubConnection: 'GitHub - benkuhn - 2-18'
+          repositoryName: 'microsoft/WindowsAppSDK-Samples'
+          action: ${{ parameters.Action }}
+          tag: ${{ parameters.ReleaseTag }}
+          assets: '$(Build.ArtifactStagingDirectory)/VSIX/WindowsAppSDKSampleVSIX.vsix'
+          tagSource: 'userSpecifiedTag'
+          isDraft: ${{ parameters.IsDraft }}

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -2,7 +2,7 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 parameters:
   - name: "ReleaseTag"
-    displayName: "Release Tag and Post Title" 
+    displayName: "Release Unique Identifier" 
     type: string
     default: ''
   - name: "Action"

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -22,9 +22,8 @@ stages:
         script: |
           $file = '$(Build.SourcesDirectory)\Templates\VSIX\Directory.Build.props'
           $WinAppSDKVersion = '${{ parameters.WinAppSDKVersion }}'
-          Write-Host $WinAppSDKVersion
           [xml]$props = Get-Content -Encoding utf8 -Path $file
-          $props.Project.PropertyGroup.WindowsAppSdkVersion.innerText = $WindowsAppSDKNugetPackageVersion
+          $props.Project.PropertyGroup.WindowsAppSdkVersion.innerText = $WinAppSDKVersion
           Write-Host $props.OuterXml
           Set-Content -Encoding utf8 -Value $props.OuterXml $file
       

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -30,11 +30,11 @@ parameters:
     type: string
     default: 'Placeholder'
   - name: "IsDraft"
-    displayName: "IsDraft: \n Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published. (Required for 'create','edit' actions)"
+    displayName: "IsDraft: \n Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published. (Effective only in 'create','edit' actions)"
     type: boolean
     default: False
   - name: "IsPreRelease"
-    displayName: "IsPrelease: \n Indicate whether the release should be marked as a pre-release. (Required for 'create','edit' actions)" 
+    displayName: "IsPrelease: \n Indicate whether the release should be marked as a pre-release. (Effective only in 'create','edit' actions)" 
     type: boolean
     default: False
 

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -10,10 +10,13 @@ parameters:
     type: string
     default: 'create'
     values:
-    - 'None'
+    - 'none'
     - 'create'
     - 'edit'
     - 'delete'
+  - name: "ReleaseNotes"
+    displayName: "Release Notes" 
+    type: string
   - name: "IsDraft"
     type: boolean
     default: False
@@ -88,3 +91,6 @@ stages:
           assets: '$(Build.ArtifactStagingDirectory)/VSIX/WindowsAppSDKSampleVSIX.vsix'
           tagSource: 'userSpecifiedTag'
           isDraft: ${{ parameters.IsDraft }}
+          releaseNotesSource: 'inline'
+          releaseNotesInline: ${{ parameters.ReleaseNotes }}
+          addChangeLog: false

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -31,7 +31,7 @@ stages:
       inputs:
         nuGetServiceConnections: 'Internal-ReleaseSigned'
 
-    - ${{ if ne(parameters.BuildType, 'delete') }}:
+    - ${{ if ne(parameters.Action, 'delete') }}:
       # Update path for MSIX reference in build\NuSpecs\build\Microsoft.WindowsAppSDK.AppXReference.props
       # Before, this was a hardcoded value
       - task: PowerShell@2

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -5,7 +5,7 @@ parameters:
     displayName: "Windows App SDK version" 
   # You can find this value in the URL of the build https://dev.azure.com/microsoft/WindowsAppSDK/_build/results?buildId=35021212&view=results
     type: string
-    default: ''
+    default: '1.0.0-preview3'
 
 stages:
 - stage: BuildVSIX

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -14,6 +14,9 @@ stages:
     pool:
       vmImage: 'windows-2022'
     steps:
+    - task: NuGetAuthenticate@0
+    inputs:
+      nuGetServiceConnections: 'Internal-ReleaseSigned'
     # Update path for MSIX reference in build\NuSpecs\build\Microsoft.WindowsAppSDK.AppXReference.props
     # Before, this was a hardcoded value
     - task: PowerShell@2

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -22,19 +22,19 @@ parameters:
     - 'edit' # Builds and publishes the VSIX and edits an existing github release
     - 'delete' # Does not build the VSIX and deletes an existing github release
   - name: "ReleaseTitle"
-    displayName: "Release Title (Not used in none and delete option)" 
+    displayName: "Release Title (Unused in none and delete Action)" 
     type: string
     default: 'Replace Me'
   - name: "ReleaseNotes"
-    displayName: "Release Notes (Not used in none and delete option)" 
+    displayName: "Release Notes (Unused in none and delete Action)" 
     type: string
     default: 'Replace Me'
   - name: "IsDraft"
-    displayName: "IsDraft: \n Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published. (Not used in none and delete option)"
+    displayName: "IsDraft: \n Indicate whether the release should be saved as a draft (unpublished). If unchecked, the release will be published. (Unused in none and delete Action)"
     type: boolean
     default: False
   - name: "IsPreRelease"
-    displayName: "IsPrelease: \n Indicate whether the release should be marked as a pre-release. (Not used in none and delete option)" 
+    displayName: "IsPrelease: \n Indicate whether the release should be marked as a pre-release. (Unused in none and delete Action)" 
     type: boolean
     default: False
 

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -1,0 +1,45 @@
+# see https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases for info on yaml ADO jobs
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+parameters:
+  - name: "WinAppSDKVersion"
+    displayName: "Windows App SDK version" 
+  # You can find this value in the URL of the build https://dev.azure.com/microsoft/WindowsAppSDK/_build/results?buildId=35021212&view=results
+    type: string
+    default: ''
+
+stages:
+- stage: BuildVSIX
+  jobs:
+  - job: BuildVSIX
+    pool: 'ProjectReunionESPool'
+    steps:
+    # Update path for MSIX reference in build\NuSpecs\build\Microsoft.WindowsAppSDK.AppXReference.props
+    # Before, this was a hardcoded value
+    - task: PowerShell@2
+      displayName: 'Update version in Directory.Build.props'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $file = '$(Build.SourcesDirectory)\Templates\VSIX\Directory.Build.props'
+          $WinAppSDKVersion = '${{ parameters.WinAppSDKVersion }}'
+          [xml]$props = Get-Content -Encoding utf8 -Path $file
+          $props.Project.PropertyGroup.WindowsAppSdkVersion = $WindowsAppSDKNugetPackageVersion
+          Set-Content -Encoding utf8 -Value $publicNuspec.OuterXml $file
+      
+    - task: VSBuild@1
+      displayName: 'Restore WindowsAppSDKSampleVSIX.sln'
+      inputs:
+        solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
+        platform: 'Any CPU'
+        configuration: 'Release'
+        msBuildArgs: '/t:restore '
+
+    - task: VSBuild@1
+      displayName: 'Build WindowsAppSDKSampleVSIX.sln'
+      inputs:
+        solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
+        platform: 'Any CPU'
+        configuration: 'Release'
+
+    - script: |
+        dir /s $(Build.SourcesDirectory)

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -40,9 +40,6 @@ stages:
         configuration: 'Release'
         msBuildArgs: '/t:restore'
 
-    - script: |
-        dir /s $(Build.SourcesDirectory)
-
     - task: VSBuild@1
       displayName: 'Build WindowsAppSDKSampleVSIX.sln'
       inputs:
@@ -50,5 +47,30 @@ stages:
         platform: 'Any CPU'
         configuration: 'Release'
 
-    - script: |
-        dir /s $(Build.SourcesDirectory)
+    - task: CopyFiles@2
+      displayName: 'Extract files for Nuget Package from Full: DWriteCorePackageName'
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)\Templates\VSIX\bin\Release'
+        Contents: |
+          WindowsAppSDKSampleVSIX.vsix
+        TargetFolder: '$(Build.ArtifactStagingDirectory)\VSIX'
+        flattenFolders: false
+
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish VSIX artifacts'
+      inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)\VSIX'
+        ArtifactName: 'VSIX'
+
+    - task: GitHubRelease@1
+      inputs:
+        gitHubConnection: 'GitHub - benkuhn - 2-18'
+        repositoryName: 'microsoft/WindowsAppSDK-Samples'
+        action: 'create'
+        target: '$(myCommitSHA)'
+        assets: '$(Build.ArtifactStagingDirectory)/VSIX'
+        tagSource: 'gitTag'
+        title: 'VSIX-Samples'
+        isDraft: true
+        changeLogCompareToRelease: 'lastFullRelease'
+        changeLogType: 'commitBased'

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -38,13 +38,12 @@ stages:
         echo ##vso[task.setvariable variable=VCToolsInstallDir]%VCToolsInstallDir%
       displayName: 'Retrieve VC tools directory'
 
-    - task: VSBuild@1
-      displayName: 'Restore WindowsAppSDKSampleVSIX.sln'
+    - task: NuGetCommand@2
       inputs:
-        solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
-        platform: 'Any CPU'
-        configuration: 'Release'
-        msBuildArgs: '/t:restore '
+        command: 'restore'
+        feedsToUse: 'config'
+        nugetConfigPath: $(Build.SourcesDirectory)\Templates\VSIX\nuget.config'
+        restoreSolution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln'
 
     - script: |
         dir /s $(Build.SourcesDirectory)

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -17,7 +17,7 @@ parameters:
   - name: "ReleaseNotes"
     displayName: "Release Notes" 
     type: string
-    default: ''
+    default: ' '
   - name: "IsDraft"
     type: boolean
     default: False

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -15,8 +15,9 @@ stages:
       vmImage: 'windows-2022'
     steps:
     - task: NuGetAuthenticate@0
-    inputs:
-      nuGetServiceConnections: 'Internal-ReleaseSigned'
+      inputs:
+        nuGetServiceConnections: 'Internal-ReleaseSigned'
+
     # Update path for MSIX reference in build\NuSpecs\build\Microsoft.WindowsAppSDK.AppXReference.props
     # Before, this was a hardcoded value
     - task: PowerShell@2

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -25,7 +25,7 @@ stages:
           Write-Host $WinAppSDKVersion
           [xml]$props = Get-Content -Encoding utf8 -Path $file
           $props.Project.PropertyGroup.WindowsAppSdkVersion.innerText = $WindowsAppSDKNugetPackageVersion
-          Write-Host $props
+          Write-Host $props.OuterXml
           Set-Content -Encoding utf8 -Value $props.OuterXml $file
       
     - task: VSBuild@1

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -22,6 +22,7 @@ stages:
         script: |
           $file = '$(Build.SourcesDirectory)\Templates\VSIX\Directory.Build.props'
           $WinAppSDKVersion = '${{ parameters.WinAppSDKVersion }}'
+          Write-Host $WinAppSDKVersion
           [xml]$props = Get-Content -Encoding utf8 -Path $file
           $props.Project.PropertyGroup.WindowsAppSdkVersion = $WindowsAppSDKNugetPackageVersion
           Set-Content -Encoding utf8 -Value $publicNuspec.OuterXml $file

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -1,9 +1,22 @@
 # see https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases for info on yaml ADO jobs
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 parameters:
+  - name: "ReleaseTag"
+    displayName: "Release Tag" 
+    type: string
+    default: ''
+  - name: "Action"
+    type: string
+    default: 'create'
+    values:
+    - 'create'
+    - 'edit'
+    - 'delete'
+  - name: "IsDraft"
+    type: boolean
+    default: False
   - name: "WinAppSDKVersion"
     displayName: "Windows App SDK version" 
-  # You can find this value in the URL of the build https://dev.azure.com/microsoft/WindowsAppSDK/_build/results?buildId=35021212&view=results
     type: string
     default: '1.0.0-preview3'
 
@@ -18,59 +31,57 @@ stages:
       inputs:
         nuGetServiceConnections: 'Internal-ReleaseSigned'
 
-    # Update path for MSIX reference in build\NuSpecs\build\Microsoft.WindowsAppSDK.AppXReference.props
-    # Before, this was a hardcoded value
-    - task: PowerShell@2
-      displayName: 'Update version in Directory.Build.props'
-      inputs:
-        targetType: 'inline'
-        script: |
-          $file = '$(Build.SourcesDirectory)\Templates\VSIX\Directory.Build.props'
-          $WinAppSDKVersion = '${{ parameters.WinAppSDKVersion }}'
-          [xml]$props = Get-Content -Encoding utf8 -Path $file
-          $props.Project.PropertyGroup.WindowsAppSdkVersion.innerText = $WinAppSDKVersion
-          Write-Host $props.OuterXml
-          Set-Content -Encoding utf8 -Value $props.OuterXml $file
+    - ${{ if ne(parameters.BuildType, 'delete') }}:
+      # Update path for MSIX reference in build\NuSpecs\build\Microsoft.WindowsAppSDK.AppXReference.props
+      # Before, this was a hardcoded value
+      - task: PowerShell@2
+        displayName: 'Update version in Directory.Build.props'
+        inputs:
+          targetType: 'inline'
+          script: |
+            $file = '$(Build.SourcesDirectory)\Templates\VSIX\Directory.Build.props'
+            $WinAppSDKVersion = '${{ parameters.WinAppSDKVersion }}'
+            [xml]$props = Get-Content -Encoding utf8 -Path $file
+            $props.Project.PropertyGroup.WindowsAppSdkVersion.innerText = $WinAppSDKVersion
+            Write-Host $props.OuterXml
+            Set-Content -Encoding utf8 -Value $props.OuterXml $file
 
-    - task: VSBuild@1
-      displayName: 'Restore WindowsAppSDKSampleVSIX.sln'
-      inputs:
-        solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
-        platform: 'Any CPU'
-        configuration: 'Release'
-        msBuildArgs: '/t:restore'
+      - task: VSBuild@1
+        displayName: 'Restore WindowsAppSDKSampleVSIX.sln'
+        inputs:
+          solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
+          platform: 'Any CPU'
+          configuration: 'Release'
+          msBuildArgs: '/t:restore'
 
-    - task: VSBuild@1
-      displayName: 'Build WindowsAppSDKSampleVSIX.sln'
-      inputs:
-        solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
-        platform: 'Any CPU'
-        configuration: 'Release'
+      - task: VSBuild@1
+        displayName: 'Build WindowsAppSDKSampleVSIX.sln'
+        inputs:
+          solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
+          platform: 'Any CPU'
+          configuration: 'Release'
 
-    - task: CopyFiles@2
-      displayName: 'Extract files for Nuget Package from Full: DWriteCorePackageName'
-      inputs:
-        SourceFolder: '$(Build.SourcesDirectory)\Templates\VSIX\bin\Release'
-        Contents: |
-          WindowsAppSDKSampleVSIX.vsix
-        TargetFolder: '$(Build.ArtifactStagingDirectory)\VSIX'
-        flattenFolders: false
+      - task: CopyFiles@2
+        displayName: 'Extract files for Nuget Package from Full: DWriteCorePackageName'
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)\Templates\VSIX\bin\Release'
+          Contents: |
+            WindowsAppSDKSampleVSIX.vsix
+          TargetFolder: '$(Build.ArtifactStagingDirectory)\VSIX'
+          flattenFolders: false
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish VSIX artifacts'
-      inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)\VSIX'
-        ArtifactName: 'VSIX'
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish VSIX artifacts'
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)\VSIX'
+          ArtifactName: 'VSIX'
 
     - task: GitHubRelease@1
       inputs:
         gitHubConnection: 'GitHub - benkuhn - 2-18'
         repositoryName: 'microsoft/WindowsAppSDK-Samples'
-        action: 'create'
-        target: '$(myCommitSHA)'
-        assets: '$(Build.ArtifactStagingDirectory)/VSIX'
-        tagSource: 'gitTag'
-        title: 'VSIX-Samples'
-        isDraft: true
-        changeLogCompareToRelease: 'lastFullRelease'
-        changeLogType: 'commitBased'
+        action: ${{ parameters.Action }}
+        tag: ${{ parameters.ReleaseTag }}
+        assets: '$(Build.ArtifactStagingDirectory)/VSIX/WindowsAppSDKSampleVSIX.vsix'
+        tagSource: manual
+        isDraft: ${{ parameters.IsDraft }}

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -24,7 +24,8 @@ stages:
           $WinAppSDKVersion = '${{ parameters.WinAppSDKVersion }}'
           Write-Host $WinAppSDKVersion
           [xml]$props = Get-Content -Encoding utf8 -Path $file
-          $props.Project.PropertyGroup.WindowsAppSdkVersion = $WindowsAppSDKNugetPackageVersion
+          $props.Project.PropertyGroup.WindowsAppSdkVersion.innerText = $WindowsAppSDKNugetPackageVersion
+          Write-Host $publicNuspec.OuterXml
           Set-Content -Encoding utf8 -Value $publicNuspec.OuterXml $file
       
     - task: VSBuild@1

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -14,6 +14,10 @@ parameters:
     - 'create'
     - 'edit'
     - 'delete'
+  - name: "ReleaseTitle"
+    displayName: "Release Title (Not used in none and delete option)" 
+    type: string
+    default: 'Replace Me'
   - name: "ReleaseNotes"
     displayName: "Release Notes (Not used in none and delete option)" 
     type: string
@@ -94,6 +98,7 @@ stages:
           repositoryName: 'microsoft/WindowsAppSDK-Samples'
           action: ${{ parameters.Action }}
           tag: ${{ parameters.ReleaseTag }}
+          title: ${{ parameters.ReleaseTitle }}
           assets: '$(Build.ArtifactStagingDirectory)/VSIX/WindowsAppSDKSampleVSIX.vsix'
           tagSource: 'userSpecifiedTag'
           isDraft: ${{ parameters.IsDraft }}

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -28,22 +28,13 @@ stages:
           Write-Host $props.OuterXml
           Set-Content -Encoding utf8 -Value $props.OuterXml $file
 
-    # The environment variable VCToolsInstallDir isn't defined on lab machines, so we need to retrieve it ourselves.
-    - script: |
-        "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -Latest -prerelease -requires Microsoft.Component.MSBuild -property InstallationPath > %TEMP%\vsinstalldir.txt
-        set /p _VSINSTALLDIR15=<%TEMP%\vsinstalldir.txt
-        del %TEMP%\vsinstalldir.txt
-        call "%_VSINSTALLDIR15%\Common7\Tools\VsDevCmd.bat"
-        echo VCToolsInstallDir = %VCToolsInstallDir%
-        echo ##vso[task.setvariable variable=VCToolsInstallDir]%VCToolsInstallDir%
-      displayName: 'Retrieve VC tools directory'
-
-    - task: NuGetCommand@2
+    - task: VSBuild@1
+      displayName: 'Restore WindowsAppSDKSampleVSIX.sln'
       inputs:
-        command: 'restore'
-        feedsToUse: 'config'
-        nugetConfigPath: Templates\VSIX\nuget.config'
-        restoreSolution: Templates\VSIX\WindowsAppSDKSampleVSIX.sln'
+        solution: $(Build.SourcesDirectory)\Templates\VSIX\WindowsAppSDKSampleVSIX.sln
+        platform: 'Any CPU'
+        configuration: 'Release'
+        msBuildArgs: '/t:restore'
 
     - script: |
         dir /s $(Build.SourcesDirectory)

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -5,7 +5,7 @@ parameters:
   - name: "WinAppSDKVersion"
     displayName: "Windows App SDK version" 
     type: string
-    default: '1.0.0-preview3'
+    default: ''
   # This is used as a unique identifier for the GitHub Release.
   - name: "ReleaseTag"
     displayName: "Release Unique Identifier" 

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -1,19 +1,21 @@
 # see https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases for info on yaml ADO jobs
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 parameters:
+  # This is used as a unique identifier for the GitHub Release.
   - name: "ReleaseTag"
     displayName: "Release Unique Identifier" 
     type: string
     default: ''
+  # GitHubRelease@1 Action
   - name: "Action"
     displayName: "GitHub Release Action" 
     type: string
     default: 'none'
     values:
-    - 'none'
-    - 'create'
-    - 'edit'
-    - 'delete'
+    - 'none' # Only builds the VSIX and publish it to Build Artifacts.
+    - 'create' # Builds and publishes the VSIX and also creates a github release
+    - 'edit' # Builds and publishes the VSIX and edits an existing github release
+    - 'delete' # Does not build the VSIX and deletes an existing github release
   - name: "ReleaseTitle"
     displayName: "Release Title (Not used in none and delete option)" 
     type: string
@@ -30,6 +32,7 @@ parameters:
     displayName: "IsPrelease: \n Indicate whether the release should be marked as a pre-release." 
     type: boolean
     default: False
+  # Version of the WindowsAppSDK used to build the Samples VSIX
   - name: "WinAppSDKVersion"
     displayName: "Windows App SDK version" 
     type: string

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -11,7 +11,8 @@ stages:
 - stage: BuildVSIX
   jobs:
   - job: BuildVSIX
-    pool: 'ProjectReunionESPool'
+    pool:
+      vmImage: 'windows-2022'
     steps:
     # Update path for MSIX reference in build\NuSpecs\build\Microsoft.WindowsAppSDK.AppXReference.props
     # Before, this was a hardcoded value

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -27,7 +27,17 @@ stages:
           $props.Project.PropertyGroup.WindowsAppSdkVersion.innerText = $WinAppSDKVersion
           Write-Host $props.OuterXml
           Set-Content -Encoding utf8 -Value $props.OuterXml $file
-      
+
+    # The environment variable VCToolsInstallDir isn't defined on lab machines, so we need to retrieve it ourselves.
+    - script: |
+        "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -Latest -prerelease -requires Microsoft.Component.MSBuild -property InstallationPath > %TEMP%\vsinstalldir.txt
+        set /p _VSINSTALLDIR15=<%TEMP%\vsinstalldir.txt
+        del %TEMP%\vsinstalldir.txt
+        call "%_VSINSTALLDIR15%\Common7\Tools\VsDevCmd.bat"
+        echo VCToolsInstallDir = %VCToolsInstallDir%
+        echo ##vso[task.setvariable variable=VCToolsInstallDir]%VCToolsInstallDir%
+      displayName: 'Retrieve VC tools directory'
+
     - task: VSBuild@1
       displayName: 'Restore WindowsAppSDKSampleVSIX.sln'
       inputs:

--- a/WindowsAppSDK-BuildVSIX.yml
+++ b/WindowsAppSDK-BuildVSIX.yml
@@ -47,7 +47,7 @@ stages:
         msBuildArgs: '/t:restore '
 
     - script: |
-      dir /s $(Build.SourcesDirectory)
+        dir /s $(Build.SourcesDirectory)
 
     - task: VSBuild@1
       displayName: 'Build WindowsAppSDKSampleVSIX.sln'


### PR DESCRIPTION
VSIX Build and Release pipeline.
This PR defines the yml file that builds the Samples VSIX from a version of WindowsAppSDK and also creates the GitHub Release for it.
The github release task documented below is used to create the release and the parameters on the pipeline flows into the parameters of this task. 
https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azure-devops

**Parameters:**
_Release Unique Identifier_
This is used as a unique identifier for the GitHub Release.
Spaces not permitted

_GitHub Release Action_
- 'none'   
 This option only builds the VSIX, publishes it to Build Artifacts.
- 'create'
This option builds and publishes the VSIX and also creates a github release
- 'edit'
This option builds and publishes the VSIX and edits an existing github release
To edit an old release, provide "Release Unique Identifier" of the release you want to edit in the "Release Unique Identifier" field.
- 'delete'
This option does not build the VSIX and deletes an existing github release
To delete an old release, provide "Release Unique Identifier" of the release you want to delete in the "Release Unique Identifier" field.

_ReleaseTitle_
The title of the Release

_ReleaseNotes_
The notes of the Release

_IsDraft_
Indicates whether the release should be saved as a draft (unpublished). If unchecked, the release will be published

_IsPreRelease_
Indicate whether the release should be marked as a pre-release. 

_WinAppSDKVersion_
Version of the WindowsAppSDK used to build the Samples VSIX
