### PR TITLE
Fix broken links in sample README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository hosts samples for the [Windows App SDK](https://github.com/micro
 #### App Lifecycle and System Services
 - [App Lifecycle](Samples/AppLifecycle): These samples demonstrate app instancing using the AppLifecycle APIs. They include the following features:
     - [Activation](Samples/AppLifecycle/Activation): These samples demonstrate support for rich activation kinds.
-    - [Instancing](Samples/Applifecycle/Instancing): These samples demonstrate support for single and selective multi-instancing.
-    - [Power Notifications](Samples/Applifecycle/StateNotifications): These samples demonstrate the power/system state notifications for managing app workload.
+    - [Instancing](Samples/AppLifecycle/Instancing): These samples demonstrate support for single and selective multi-instancing.
+    - [Power Notifications](Samples/AppLifecycle/StateNotifications): These samples demonstrate the power/system state notifications for managing app workload.
 
 #### Data and Files
 - [Resource Management](Samples/ResourceManagement): These samples demonstrates app resource management using the MRT Core APIs.


### PR DESCRIPTION
## Description

GitHub URLs are case-sensitive, and a couple links used the wrong casing for "AppLifecycle". This is a doc-only change so I didn't run any of the tasks below.

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
