### PR TITLE
Update cs-winui Resource Management sample to 1.0 and fix two bugs.

### DIFF
--- a/Samples/ResourceManagement/cs-winui/ClassLibrary/ClassLibrary.csproj
+++ b/Samples/ResourceManagement/cs-winui/ClassLibrary/ClassLibrary.csproj
@@ -10,8 +10,8 @@
     <None Remove="ClassLibraryResources.resw" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.20348.19" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-preview1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/ResourceManagement/cs-winui/winui_desktop_packaged_app (Package)/winui_desktop_packaged_app (Package).wapproj
+++ b/Samples/ResourceManagement/cs-winui/winui_desktop_packaged_app (Package)/winui_desktop_packaged_app (Package).wapproj
@@ -63,8 +63,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.20348.19" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-preview1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
   </ItemGroup>
   <PropertyGroup>
     <EntryPointProjectUniqueName>..\winui_desktop_packaged_app\winui_desktop_packaged_app.csproj</EntryPointProjectUniqueName>

--- a/Samples/ResourceManagement/cs-winui/winui_desktop_packaged_app/App.xaml
+++ b/Samples/ResourceManagement/cs-winui/winui_desktop_packaged_app/App.xaml
@@ -1,5 +1,5 @@
 <!-- Copyright (c) Microsoft Corporation.
-     Licensed under the MIT License. -->﻿
+     Licensed under the MIT License. -->
 <Application
     x:Class="winui_desktop_packaged_app.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/Samples/ResourceManagement/cs-winui/winui_desktop_packaged_app/winui_desktop_packaged_app.csproj
+++ b/Samples/ResourceManagement/cs-winui/winui_desktop_packaged_app/winui_desktop_packaged_app.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.20348.19" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-preview1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/nuget.config
+++ b/Samples/nuget.config
@@ -11,7 +11,6 @@
     <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
         <add key="Internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
-        <add key="Local" value="C:\_Data\Cobalt\Reunion" />
     </packageSources>
     <disabledPackageSources />
 </configuration>  


### PR DESCRIPTION
## Description

Update cs-winui Resource Management sample to 1.0 and fix two bugs.

Bugs:
- Remove invisible BOM char in XAML copyright header. Made the XML invalid.
- Remove a bad entry from nuget.config (must be from a recent check-in).

## Checklist

- [X] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [X] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [X] Samples set the minimum supported OS version to Windows 10 version 1809.
- [X] Samples build clean with no warnings or errors.