### PR TITLE
Remove internal feed from main sample nuget.config

### DIFF
--- a/Samples/nuget.config
+++ b/Samples/nuget.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was added for building in the CI pipeline. It is not used when building locally. -->
 <configuration>
     <packageRestore>
@@ -10,7 +10,6 @@
     <packageSources>
     <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-        <add key="Internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
     </packageSources>
     <disabledPackageSources />
 </configuration>  


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

The internal feed was accidentally added in #130. This is also causing issues with multi-feed authentication. Removing the internal feed.

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
