### PR TITLE
Add link to sample templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,6 @@ The samples will be updated with GA releases of the Windows App SDK. The `main` 
 
 These samples are provided by feature teams and we welcome your input on issues and suggestions for new samples. We encourage you to [file a new issue](https://github.com/microsoft/WindowsAppSDK-Samples/issues/new) for any feedback or questions!
 
+Sample authors should follow the [sample guidelines](docs/sample-guidelines.md) to begin developing their samples. For WinUI-based Windows App SDK samples, use the [sample templates](Templates/README.md) which are available for download in the [releases](https://github.com/microsoft/WindowsAppSDK-Samples/releases)
+
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the Code of Conduct FAQ or contact opencode@microsoft.com with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ The samples will be updated with GA releases of the Windows App SDK. The `main` 
 
 These samples are provided by feature teams and we welcome your input on issues and suggestions for new samples. We encourage you to [file a new issue](https://github.com/microsoft/WindowsAppSDK-Samples/issues/new) for any feedback or questions!
 
-Sample authors should follow the [sample guidelines](docs/sample-guidelines.md) to begin developing their samples. For WinUI-based Windows App SDK samples, use the [sample templates](Templates/README.md) which are available for download in the [releases](https://github.com/microsoft/WindowsAppSDK-Samples/releases)
+Sample authors should follow the [samples guidelines](docs/samples-guidelines.md) to begin developing their samples. For WinUI-based Windows App SDK samples, use the [sample templates](Templates/README.md) which are available for download in the [releases](https://github.com/microsoft/WindowsAppSDK-Samples/releases).
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the Code of Conduct FAQ or contact opencode@microsoft.com with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ The samples will be updated with GA releases of the Windows App SDK. The `main` 
 
 These samples are provided by feature teams and we welcome your input on issues and suggestions for new samples. We encourage you to [file a new issue](https://github.com/microsoft/WindowsAppSDK-Samples/issues/new) for any feedback or questions!
 
-Sample authors should follow the [samples guidelines](docs/samples-guidelines.md) to begin developing their samples. For WinUI-based Windows App SDK samples, use the [sample templates](Templates/README.md) which are available for download in the [releases](https://github.com/microsoft/WindowsAppSDK-Samples/releases).
+Sample authors should follow the [samples guidelines](docs/samples-guidelines.md) to begin developing their samples. For WinUI-based Windows App SDK samples, use the [sample templates](Templates/README.md). The VSIX file is available for download in the Github releases page [here](https://github.com/microsoft/WindowsAppSDK-Samples/releases).
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the Code of Conduct FAQ or contact opencode@microsoft.com with any additional questions or comments.

--- a/docs/samples-guidelines.md
+++ b/docs/samples-guidelines.md
@@ -451,7 +451,7 @@ description: "Shows how to create and register background tasks that will run in
 
 ## Sample Templates
 
-Any new C#/C++ WinUI-based samples should use the [WinUI 3 sample templates](../Templates). You can download the template VSIX file under the [releases](https://github.com/microsoft/WindowsAppSDK-Samples/releases) in this repo, under the "Assets" section. The templates provide a scenario-based structure and ensure consistent UI and coding standards across WinUI samples.
+Any new C#/C++ WinUI-based samples should use the [WinUI 3 sample templates](../Templates). You can download the template VSIX file under the Github releases [here](https://github.com/microsoft/WindowsAppSDK-Samples/releases) in this repo, under the "Assets" section. The templates provide a scenario-based structure and ensure consistent UI and coding standards across WinUI samples.
 
 ## Repo Branching
 

--- a/docs/samples-guidelines.md
+++ b/docs/samples-guidelines.md
@@ -7,6 +7,7 @@ This document outlines the guidelines and best practices for Windows App SDK sam
 - [Coding Guidelines](#code-guidelines)
 - [Sample Coverage](#sample-coverage)
 - [Standardization and Naming](#standardization-and-naming)
+- [Sample Templates](#sample-templates)
 - [Repo Branching](#repo-branching)
 - [Checklist](#checklist)
 
@@ -448,9 +449,9 @@ description: "Shows how to create and register background tasks that will run in
 ---
 ```
 
-### Sample Templates
+## Sample Templates
 
-Any new C#/C++ WinUI-based samples should use the [WinUI 3 sample templates](../Templates). The templates provide a scenario-based structure and ensure consistent UI and coding standards across WinUI samples.
+Any new C#/C++ WinUI-based samples should use the [WinUI 3 sample templates](../Templates). You can download the template VSIX file under the [releases](https://github.com/microsoft/WindowsAppSDK-Samples/releases) in this repo, under the "Assets" section. The templates provide a scenario-based structure and ensure consistent UI and coding standards across WinUI samples.
 
 ## Repo Branching
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Adding links from the README/guidelines to the sample templates.

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
