### PR TITLE
add project file indentation formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -117,7 +117,7 @@ trim_trailing_whitespace = true
 end_of_line = crlf
 
 # Visual Studio XML project files
-[*.{csproj,vcxproj,vcxproj.filters}]
+[**.{csproj,vcxproj,vcxproj.filters}]
 indent_size = 2
 
 [**.{xaml,xml}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -116,6 +116,9 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 end_of_line = crlf
 
+# Visual Studio XML project files
+[*.{csproj,vcxproj,vcxproj.filters}]
+indent_size = 2
 
 [**.{xaml,xml}]
 indent_style = space


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Adding indentation setting for csproj, vcxproj, vcxproj.filters files to the editorconfig

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
