### PR TITLE
Fix icon path in C++ sample template

### DIFF
--- a/Templates/VSIX/Project Templates/cpp-winui-template/MainWindow.xaml.cpp
+++ b/Templates/VSIX/Project Templates/cpp-winui-template/MainWindow.xaml.cpp
@@ -24,7 +24,7 @@ namespace winrt::$safeprojectname$::implementation
         Title(winrt::$safeprojectname$::SampleConfig::FeatureName);
 
         HWND hwnd = GetWindowHandle();
-        LoadIcon(hwnd, L"windows-sdk.ico");
+        LoadIcon(hwnd, L"Assets/windows-sdk.ico");
         SetWindowSize(hwnd, 1050, 800);
         PlacementCenterWindowInMonitorWin32(hwnd);
     }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Fixing a bug in the sample templates with wrong icon path in C++ WinUI templates.

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
