### PR TITLE
Add and condition the import of Build.Common.cpp.props file in samples

### DIFF
--- a/Samples/AppLifecycle/Activation/cpp-console-unpackaged/CppWinRtConsoleActivation/CppWinRtConsoleActivation.vcxproj
+++ b/Samples/AppLifecycle/Activation/cpp-console-unpackaged/CppWinRtConsoleActivation/CppWinRtConsoleActivation.vcxproj
@@ -3,6 +3,7 @@
   <Import Project="..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\..\..\..\Build.Common.Cpp.props" Condition="Exists('..\..\..\..\Build.Common.Cpp.props')"/>
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>

--- a/Samples/AppLifecycle/Activation/cpp-winui-packaged/CppWinUiDesktopActivation/CppWinUiDesktopActivation/CppWinUiDesktopActivation.vcxproj
+++ b/Samples/AppLifecycle/Activation/cpp-winui-packaged/CppWinUiDesktopActivation/CppWinUiDesktopActivation/CppWinUiDesktopActivation.vcxproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\..\..\..\..\Build.Common.Cpp.props" Condition="Exists('..\..\..\..\..\Build.Common.Cpp.props')"/>
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>

--- a/Samples/AppLifecycle/Instancing/cpp-winui-packaged/CppWinUiDesktopInstancing/CppWinUiDesktopInstancing/CppWinUiDesktopInstancing.vcxproj
+++ b/Samples/AppLifecycle/Instancing/cpp-winui-packaged/CppWinUiDesktopInstancing/CppWinUiDesktopInstancing/CppWinUiDesktopInstancing.vcxproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\..\..\..\..\Build.Common.Cpp.props" Condition="Exists('..\..\..\..\..\Build.Common.Cpp.props')"/>
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>

--- a/Samples/AppLifecycle/StateNotifications/cpp-winui-packaged/CppWinUiDesktopState/CppWinUiDesktopState/CppWinUiDesktopState.vcxproj
+++ b/Samples/AppLifecycle/StateNotifications/cpp-winui-packaged/CppWinUiDesktopState/CppWinUiDesktopState/CppWinUiDesktopState.vcxproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" />
   <Import Project="..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props')" />
+  <Import Project="..\..\..\..\..\Build.Common.Cpp.props" Condition="Exists('..\..\..\..\..\Build.Common.Cpp.props')"/>
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>

--- a/Samples/DynamicDependencies/DirectX/D3D9ExSample.vcxproj
+++ b/Samples/DynamicDependencies/DirectX/D3D9ExSample.vcxproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props')" />
+  <Import Project="..\..\Build.Common.Cpp.props" Condition="Exists('..\..\Build.Common.Cpp.props')"/>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/Samples/Insights/cpp-win32/InsightsSample.vcxproj
+++ b/Samples/Insights/cpp-win32/InsightsSample.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="packages\Microsoft.WindowsAppSDK.1.0.0-preview1\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('packages\Microsoft.WindowsAppSDK.1.0.0-preview1\build\native\Microsoft.WindowsAppSDK.props')" />
-  <Import Project="..\..\Build.Common.Cpp.props" />
+  <Import Project="..\..\Build.Common.Cpp.props" Condition="Exists('..\..\Build.Common.Cpp.props')"/>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>

--- a/Samples/Installer/cpp-console-unpackaged/LaunchInstaller.vcxproj
+++ b/Samples/Installer/cpp-console-unpackaged/LaunchInstaller.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\..\Build.Common.Cpp.props" />
+  <Import Project="..\..\Build.Common.Cpp.props" Condition="Exists('..\..\Build.Common.Cpp.props')"/>
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>

--- a/Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.vcxproj
+++ b/Samples/ResourceManagement/cpp-console-unpackaged/console_unpackaged_app.vcxproj
@@ -3,7 +3,7 @@
   <Import Project="packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="packages\Microsoft.Windows.CppWinRT.2.0.210714.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('packages\Microsoft.Windows.CppWinRT.2.0.210714.1\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\..\Build.Common.Cpp.props" />
+  <Import Project="..\..\Build.Common.Cpp.props" Condition="Exists('..\..\Build.Common.Cpp.props')"/>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>

--- a/Samples/ResourceManagement/cpp-winui/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp.vcxproj
+++ b/Samples/ResourceManagement/cpp-winui/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp.vcxproj
@@ -3,7 +3,7 @@
   <Import Project="..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210714.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210714.1\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\..\..\Build.Common.Cpp.props" />
+  <Import Project="..\..\..\Build.Common.Cpp.props" Condition="Exists('..\..\..\Build.Common.Cpp.props')"/>
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>

--- a/Samples/TextRendering/cpp-win32/DWriteCoreGallery/DWriteCoreGallery.vcxproj
+++ b/Samples/TextRendering/cpp-win32/DWriteCoreGallery/DWriteCoreGallery.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" />
-  <Import Project="..\..\..\Build.Common.Cpp.props" />
+  <Import Project="..\..\..\Build.Common.Cpp.props" Condition="Exists('..\..\..\Build.Common.Cpp.props')"/>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/Samples/Unpackaged/cpp-console-unpackaged/Unpackaged.vcxproj
+++ b/Samples/Unpackaged/cpp-console-unpackaged/Unpackaged.vcxproj
@@ -4,7 +4,7 @@
   <Import Project="packages\Microsoft.WindowsAppSDK.1.0.0-preview3\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('packages\Microsoft.WindowsAppSDK.1.0.0-preview3\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" />
   <Import Project="packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.196\build\Microsoft.Windows.SDK.BuildTools.props')" />
-  <Import Project="..\..\Build.Common.Cpp.props" />
+  <Import Project="..\..\Build.Common.Cpp.props" Condition="Exists('..\..\Build.Common.Cpp.props')"/>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>

--- a/Samples/Windowing/cpp-winui/SampleApp/SampleApp.vcxproj
+++ b/Samples/Windowing/cpp-winui/SampleApp/SampleApp.vcxproj
@@ -3,7 +3,7 @@
   <Import Project="..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.194\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.194\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210722.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210722.2\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\..\..\Build.Common.Cpp.props" />
+  <Import Project="..\..\..\Build.Common.Cpp.props" Condition="Exists('..\..\..\Build.Common.Cpp.props')"/>
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

This PR fixes the import of the common props file used to automatically use the PlatformToolset version for each Visual Studio.
This is needed because we have internal build pipelines that only have one version of VS installed, so we need to use the correct PlatformToolset or else it fails the build. 

Also, we condition the import, since these samples are made available outside the Repo and the common props file doesn't exist there, so it would fail when trying to import it

## Checklist

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). 
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
