### PR TITLE
Added information to clarify the Windows 11 requirement for TitleBar customization

### DIFF
--- a/Samples/Windowing/README.md
+++ b/Samples/Windowing/README.md
@@ -17,6 +17,11 @@ extendedZipContent:
 
 These samples demonstrate how to use the AppWindow class to manage your application's window.
 
+## Limitations
+
+Please note that customization of a window's TitleBar using the AppWindowTitleBar APIs is only supported on Windows 11 or later. This is illustrated in the sample by using the (IsCustomizationSupported)[https://docs.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.iscustomizationsupported] method. Please see the [Title bar
+  customization](https://docs.microsoft.com/en-us/windows/apps/develop/title-bar) article for more details.
+
 ## Prerequisites
 
 * See [System requirements for Windows app development](https://docs.microsoft.com/windows/apps/windows-app-sdk/system-requirements).

--- a/Samples/Windowing/README.md
+++ b/Samples/Windowing/README.md
@@ -19,8 +19,8 @@ These samples demonstrate how to use the AppWindow class to manage your applicat
 
 ## Limitations
 
-Please note that customization of a window's TitleBar using the AppWindowTitleBar APIs is only supported on Windows 11 or later. This is illustrated in the sample by using the (IsCustomizationSupported)[https://docs.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.iscustomizationsupported] method. Please see the [Title bar
-  customization](https://docs.microsoft.com/en-us/windows/apps/develop/title-bar) article for more details.
+Please note that customization of a window's TitleBar using the AppWindowTitleBar APIs is only supported on Windows 11 or later. This is illustrated in the sample by using the (IsCustomizationSupported)[https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.iscustomizationsupported] method. Please see the [Title bar
+  customization](https://docs.microsoft.com/windows/apps/develop/title-bar) article for more details.
 
 ## Prerequisites
 

--- a/Samples/Windowing/cpp-winui/SampleApp/TitlebarPage.xaml.cpp
+++ b/Samples/Windowing/cpp-winui/SampleApp/TitlebarPage.xaml.cpp
@@ -44,6 +44,7 @@ namespace winrt::SampleApp::implementation
         m_mainWindow.MyTitleBar().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
 
         m_brandTitleBar = !m_brandTitleBar;
+        // Check to see if customization is supported. Currently only supported on Windows 11.
         if (AppWindowTitleBar::IsCustomizationSupported() && m_brandTitleBar)
         {
             m_appWindow.Title(L"Default titlebar with custom color customization");
@@ -71,6 +72,7 @@ namespace winrt::SampleApp::implementation
 
     void TitlebarPage::TitlebarCustomBtn_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
     {
+        // Check to see if customization is supported. Currently only supported on Windows 11.
         if (AppWindowTitleBar::IsCustomizationSupported() && !m_customTitleBar) {
             m_customTitleBar = true;
             m_appWindow.TitleBar().ExtendsContentIntoTitleBar(true);

--- a/Samples/Windowing/cs-winforms-unpackaged/AppForm.cs
+++ b/Samples/Windowing/cs-winforms-unpackaged/AppForm.cs
@@ -364,6 +364,7 @@ namespace winforms_unpackaged_app
             _mainAppWindow.TitleBar.ResetToDefault();
 
             _isBrandedTitleBar = !_isBrandedTitleBar;
+            // Check to see if customization is supported. Currently only supported on Windows 11.
             if (AppWindowTitleBar.IsCustomizationSupported() && _isBrandedTitleBar)
             {
                 _mainAppWindow.Title = "Default titlebar with custom color customization";
@@ -393,6 +394,7 @@ namespace winforms_unpackaged_app
         {
             _mainAppWindow.TitleBar.ExtendsContentIntoTitleBar = !_mainAppWindow.TitleBar.ExtendsContentIntoTitleBar;
 
+            // Check to see if customization is supported. Currently only supported on Windows 11.
             if (AppWindowTitleBar.IsCustomizationSupported() && _mainAppWindow.TitleBar.ExtendsContentIntoTitleBar)
             {
                 // Show the custom titlebar

--- a/Samples/Windowing/cs-winui/TitleBar.xaml.cs
+++ b/Samples/Windowing/cs-winui/TitleBar.xaml.cs
@@ -35,6 +35,7 @@ namespace Windowing
             _mainAppWindow.TitleBar.ResetToDefault();
 
             _isBrandedTitleBar = !_isBrandedTitleBar;
+            // Check to see if customization is supported. Currently only supported on Windows 11.
             if (AppWindowTitleBar.IsCustomizationSupported() && _isBrandedTitleBar)
             {
                 _mainAppWindow.Title = "Default titlebar with custom color customization";
@@ -71,6 +72,7 @@ namespace Windowing
         {
             _mainAppWindow.TitleBar.ExtendsContentIntoTitleBar = !_mainAppWindow.TitleBar.ExtendsContentIntoTitleBar;
 
+            // Check to see if customization is supported. Currently only supported on Windows 11.
             if (AppWindowTitleBar.IsCustomizationSupported() && _mainAppWindow.TitleBar.ExtendsContentIntoTitleBar)
             {
                 // Show the custom titlebar

--- a/Samples/Windowing/cs-wpf/wpf_packaged_app/TitleBarPage.xaml.cs
+++ b/Samples/Windowing/cs-wpf/wpf_packaged_app/TitleBarPage.xaml.cs
@@ -29,6 +29,7 @@ namespace wpf_packaged_app
             _mainAppWindow.TitleBar.ResetToDefault();
 
             _isBrandedTitleBar = !_isBrandedTitleBar;
+            // Check to see if customization is supported. Currently only supported on Windows 11.
             if (AppWindowTitleBar.IsCustomizationSupported() && _isBrandedTitleBar)
             {
                 _mainAppWindow.Title = "Default titlebar with custom color customization";
@@ -65,6 +66,7 @@ namespace wpf_packaged_app
         {
             _mainAppWindow.TitleBar.ExtendsContentIntoTitleBar = !_mainAppWindow.TitleBar.ExtendsContentIntoTitleBar;
 
+            // Check to see if customization is supported. Currently only supported on Windows 11.
             if (AppWindowTitleBar.IsCustomizationSupported() && _mainAppWindow.TitleBar.ExtendsContentIntoTitleBar)
             {
                 // Show the custom titlebar


### PR DESCRIPTION
## Description
Updates to the windowing samples to make it clearer that the IsCustomizationSupported call is there due to the functionality only being available on Windows 11 and later.
Added a note to the readme to call out this limitation as well and a link to the conceptual article for TitleBar customization for more details.

## Checklist
N/A - This is a minor update that is not changing any actual code, so the samples have not been built. This is a docs and comments update only.