### PR TITLE
Add local packages folder so NugetCommand is happy

### DIFF
--- a/Samples/localpackages/readme.md
+++ b/Samples/localpackages/readme.md
@@ -1,0 +1,1 @@
+Local source for packages. Places nupkg files in this directory to test them out before uploading.

--- a/Samples/localpackages/readme.md
+++ b/Samples/localpackages/readme.md
@@ -1,1 +1,2 @@
-Local source for packages. Places nupkg files in this directory to test them out before uploading.
+Local source for packages.
+This is used by the the nightly pipelines for build compat testing.


### PR DESCRIPTION
Recently added a local packages in the Samples/nuget.config. But builds are failing because the directory does not exist. Add local packages folder so NugetCommand task is happy.