### PR TITLE
Windowing Samples updates for 1.1 GA

### DIFF
--- a/Samples/Windowing/cpp-winui/SampleApp (Package)/SampleApp (Package).wapproj
+++ b/Samples/Windowing/cpp-winui/SampleApp (Package)/SampleApp (Package).wapproj
@@ -66,7 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.20348.19" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0-preview2" />
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
 </Project>

--- a/Samples/Windowing/cpp-winui/SampleApp/SampleApp.vcxproj
+++ b/Samples/Windowing/cpp-winui/SampleApp/SampleApp.vcxproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" />
+  <Import Project="..\packages\Microsoft.WindowsAppSDK.1.1.0-preview2\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.1.0-preview2\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.194\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.194\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210722.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210722.2\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\..\..\Build.Common.Cpp.props" Condition="Exists('..\..\..\Build.Common.Cpp.props')"/>
+  <Import Project="..\..\..\Build.Common.Cpp.props" Condition="Exists('..\..\..\Build.Common.Cpp.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -192,7 +192,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210722.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210722.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.194\build\Microsoft.Windows.SDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.194\build\Microsoft.Windows.SDK.BuildTools.targets')" />
-    <Import Project="..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.targets')" />
+    <Import Project="..\packages\Microsoft.WindowsAppSDK.1.1.0-preview2\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.1.0-preview2\build\native\Microsoft.WindowsAppSDK.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -202,7 +202,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210722.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210722.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.194\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.194\build\Microsoft.Windows.SDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.194\build\Microsoft.Windows.SDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22000.194\build\Microsoft.Windows.SDK.BuildTools.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WindowsAppSDK.1.0.0\build\native\Microsoft.WindowsAppSDK.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.WindowsAppSDK.1.1.0-preview2\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WindowsAppSDK.1.1.0-preview2\build\native\Microsoft.WindowsAppSDK.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.WindowsAppSDK.1.1.0-preview2\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WindowsAppSDK.1.1.0-preview2\build\native\Microsoft.WindowsAppSDK.targets'))" />
   </Target>
 </Project>

--- a/Samples/Windowing/cpp-winui/SampleApp/packages.config
+++ b/Samples/Windowing/cpp-winui/SampleApp/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210722.2" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.22000.194" targetFramework="native" />
-  <package id="Microsoft.WindowsAppSDK" version="1.0.0" targetFramework="native" />
+  <package id="Microsoft.WindowsAppSDK" version="1.1.0-preview2" targetFramework="native" />
 </packages>

--- a/Samples/Windowing/cs-winforms-unpackaged/winforms_unpackaged_app.csproj
+++ b/Samples/Windowing/cs-winforms-unpackaged/winforms_unpackaged_app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x86;x64</Platforms>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0-preview2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />
   </ItemGroup>
 

--- a/Samples/Windowing/cs-winforms-unpackaged/winforms_unpackaged_app.sln
+++ b/Samples/Windowing/cs-winforms-unpackaged/winforms_unpackaged_app.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31229.75
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32328.378
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "winforms_unpackaged_app", "winforms_unpackaged_app.csproj", "{D42797AB-4CBE-44A3-A9F6-5EAF2D657C3D}"
 EndProject
@@ -13,12 +13,10 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D42797AB-4CBE-44A3-A9F6-5EAF2D657C3D}.Debug|arm64.ActiveCfg = Debug|x86
 		{D42797AB-4CBE-44A3-A9F6-5EAF2D657C3D}.Debug|x64.ActiveCfg = Debug|x64
 		{D42797AB-4CBE-44A3-A9F6-5EAF2D657C3D}.Debug|x64.Build.0 = Debug|x64
 		{D42797AB-4CBE-44A3-A9F6-5EAF2D657C3D}.Debug|x86.ActiveCfg = Debug|x86
 		{D42797AB-4CBE-44A3-A9F6-5EAF2D657C3D}.Debug|x86.Build.0 = Debug|x86
-		{D42797AB-4CBE-44A3-A9F6-5EAF2D657C3D}.Release|arm64.ActiveCfg = Release|x86
 		{D42797AB-4CBE-44A3-A9F6-5EAF2D657C3D}.Release|x64.ActiveCfg = Release|x64
 		{D42797AB-4CBE-44A3-A9F6-5EAF2D657C3D}.Release|x64.Build.0 = Release|x64
 		{D42797AB-4CBE-44A3-A9F6-5EAF2D657C3D}.Release|x86.ActiveCfg = Release|x86

--- a/Samples/Windowing/cs-winui/WindowBasics.xaml
+++ b/Samples/Windowing/cs-winui/WindowBasics.xaml
@@ -20,15 +20,21 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" ></RowDefinition>
                         <RowDefinition Height="Auto" ></RowDefinition>
+                        <RowDefinition Height="Auto" ></RowDefinition>
+                        <RowDefinition Height="Auto" ></RowDefinition>
                     </Grid.RowDefinitions>
                     <StackPanel Grid.Row="0" Spacing="10" Margin="0,0,0,10"  Orientation="Horizontal" VerticalAlignment="Center">
                         <TextBox Width="200" x:Name="TitleTextBox" Text="WinUI ❤️ AppWindow"/>
                         <Button Content="Set Window Title" Click="TitleBtn_Click"/>
                     </StackPanel>
-                    <StackPanel Grid.Row="1" Spacing ="10" Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Grid.Row="1" Margin="0,0,10,0" ><Bold>AppWindow Resize:</Bold></TextBlock>
+                    <TextBlock Grid.Row="2" Style="{StaticResource ScenarioDescriptionTextStyle }" Margin="0,0,0,10" TextWrapping="Wrap">Developers can both specify their window's size using <Bold>AppWindow.Resize(size)</Bold>, and set a desired client area size using <Bold>AppWindow.ResizeClient(size)</Bold>.
+                    </TextBlock>
+                    <StackPanel Grid.Row="3" Spacing ="10" Orientation="Horizontal" VerticalAlignment="Center">
                         <TextBox Width="50" x:Name="WidthTextBox" InputScope="Number"></TextBox>
                         <TextBox Width="50" x:Name="HeightTextBox" InputScope="Number"></TextBox>
                         <Button x:Name="SizeBtn" Click="SizeBtn_Click">Resize window</Button>
+                        <Button x:Name="ClientSizeBtn" Click="SizeBtn_Click">Resize client area</Button>
                     </StackPanel>
                 </Grid>
             </StackPanel>

--- a/Samples/Windowing/cs-winui/WindowBasics.xaml.cs
+++ b/Samples/Windowing/cs-winui/WindowBasics.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using WinRT;
 
 namespace Windowing
 {
@@ -47,11 +48,23 @@ namespace Windowing
             {
                 // Silently ignore invalid input...
             }
-
-            if (windowHeight > 0 && windowWidth > 0)
+            if (_mainAppWindow != null)
             {
-                _mainAppWindow.Resize(new Windows.Graphics.SizeInt32(windowWidth, windowHeight));
+                switch (sender.As<Button>().Name)
+                {
+                    case "SizeBtn":
+                        _mainAppWindow.Resize(new Windows.Graphics.SizeInt32(windowWidth, windowHeight));
+                        break;
+
+                    case "ClientSizeBtn":
+                        _mainAppWindow.ResizeClient(new Windows.Graphics.SizeInt32(windowWidth, windowHeight));
+                        break;
+                }
             }
+            //if (windowHeight > 0 && windowWidth > 0)
+            //{
+            //    _mainAppWindow.Resize(new Windows.Graphics.SizeInt32(windowWidth, windowHeight));
+            //}
         }
     }
 }

--- a/Samples/Windowing/cs-winui/Windowing.csproj
+++ b/Samples/Windowing/cs-winui/Windowing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Windowing</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Samples/Windowing/cs-winui/Windowing.csproj
+++ b/Samples/Windowing/cs-winui/Windowing.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0-preview2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.1.588-beta" PrivateAssets="all" />
   </ItemGroup>
@@ -35,6 +35,6 @@
        Tools extension to be activated for this project even if the Windows App SDK Nuget
        package has not yet been restored -->
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnablePreviewMsixTooling)'=='true'">
-    <ProjectCapability Include="Msix"/>
+    <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>

--- a/Samples/Windowing/cs-wpf/wpf_packaged_app (Package)/wpf_packaged_app (Package).wapproj
+++ b/Samples/Windowing/cs-wpf/wpf_packaged_app (Package)/wpf_packaged_app (Package).wapproj
@@ -29,7 +29,7 @@
     <ProjectGuid>6cb98632-6091-412f-ab5d-d6f7000073a6</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <AssetTargetFallback>net6.0.202-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
+    <AssetTargetFallback>net6.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>

--- a/Samples/Windowing/cs-wpf/wpf_packaged_app (Package)/wpf_packaged_app (Package).wapproj
+++ b/Samples/Windowing/cs-wpf/wpf_packaged_app (Package)/wpf_packaged_app (Package).wapproj
@@ -29,7 +29,7 @@
     <ProjectGuid>6cb98632-6091-412f-ab5d-d6f7000073a6</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
+    <AssetTargetFallback>net6.0.202-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>
@@ -53,7 +53,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0-preview2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />
   </ItemGroup>
   <PropertyGroup>

--- a/Samples/Windowing/cs-wpf/wpf_packaged_app.sln
+++ b/Samples/Windowing/cs-wpf/wpf_packaged_app.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31205.134
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32328.378
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "wpf_packaged_app (Package)", "wpf_packaged_app (Package)\wpf_packaged_app (Package).wapproj", "{6CB98632-6091-412F-AB5D-D6F7000073A6}"
 EndProject

--- a/Samples/Windowing/cs-wpf/wpf_packaged_app/wpf_packaged_app.csproj
+++ b/Samples/Windowing/cs-wpf/wpf_packaged_app/wpf_packaged_app.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0-preview2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description
Updating sample to reflect AppWindow API changes for Windows App SDK 1.1 GA. All samples (cs-winui, cpp-winui, cs-winforms, cs-wpf) should be given added functionality to reflect the following AppWindow updates: 
- InsertAfter to show how to set z-order among windows (Emily) 
- ResizeClient to show how to size an AppWindow to fit its content using client coordinates (Sam)
- Tall caption buttons for custom titlebar (Eve) 
- IsCustomTitlebarSupported API (Eve)


## Target Release

1.1 GA

## Checklist

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
