### PR TITLE
Push Notification Samples: Add section on differences between packaged and unpackaged Apps settings.

### DIFF
--- a/Samples/Notifications/Push/README.md
+++ b/Samples/Notifications/Push/README.md
@@ -13,15 +13,18 @@ This sample demonstrates:
 1. How an app can use the Windows App SDK to request a WNS Channel URI
     * The WNS Channel URI uniquely identifies the app for a current user on a specific device, allowing the app server to send notifications to the app.
 2.	How to use the Windows App SDK to register an app for foreground and background activation and handle the activations.
+
 ## Requirements
 * A web API tool (like Postman or fiddler) to send notifications.
    * The Windows App SDK push notifications APIs provides an API to register for and receive notifications from an external app service. The web API tool is used to emulate the external app service.
 * An Azure AppId for your app.
    * To obtain an Azure AppId, follow "Configure your app's identity in Azure Active Directory" [here](https://docs.microsoft.com/windows/apps/windows-app-sdk/notifications/push/push-quickstart#configure-your-apps-identity-in-azure-active-directory).
 * Windows 10
+
 ## Building and running the sample 
 Before building the sample, make sure to set up your environment correctly by following the steps [here](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment).
 For the unpackaged sample apps, in addition to the steps for setting up the environment for the Windows App SDK, make sure to follow the instructions [here](https://docs.microsoft.com/windows/apps/windows-app-sdk/deploy-unpackaged-apps).
+
 ### To build the sample
 1. Open the solution file (.sln) in the subfolder of the sample in Visual Studio.
 2. Replace the guid in the following line (near the top of the sample) with your own Azure AppId:
@@ -32,12 +35,53 @@ winrt::guid remoteId{ "00000000-0000-0000-0000-000000000000"};
 4. Debug the project. Press **F5**, or select **Debug** \> **Start Debugging**. 
 
 The sample will display a WNS Channel URI which uniquely identify this app, for this user on this device and thus can be used by other apps (usually a server app) to send notifications to this specific app.
+
 ## Receiving Notifications
 Follow these [instructions]() to send a notification to the sample. 
    * Leave the sample running to receive notifications in the foreground.
    * Close the sample to receive notifications in the background.
+
+## Packaged and Unpackaged Apps Considerations
+
+### Unpackaged App
+```xml
+<PackagedType>none</PackagedType>
+```
+
+ddlm dll
+
+### Packaged App
+appxmanifest Extension
+
+COM Server
+
+```xml
+<Extensions>
+  <uap:Extension Category="windows.protocol" EntryPoint="Windows.FullTrustApplication">
+    <uap:Protocol Name="windowsappsdktestprotocol-packaged">
+      <uap:DisplayName>Windows App SDK TestProtocol</uap:DisplayName>
+    </uap:Protocol>
+  </uap:Extension>
+  <com:Extension Category="windows.comServer">
+    <com:ComServer>
+      <com:ExeServer Executable="PushNotificationsTestApp\PushNotificationsTestApp.exe" DisplayName="SampleBackgroundApp" Arguments="----WindowsAppSDKPushServer">
+        <com:Class Id="[Your app's Azure AppId]" DisplayName="Windows App SDK Push" />
+      </com:ExeServer>
+    </com:ComServer>
+  </com:Extension>
+</Extensions>    
+```
+
+Take notice that the Packaged sample has a special extension to the COM server and protocol used to deliver the notification to the app.
+
+---
+**How is an upackaged sample get the notification?**
+
+*If the packaged sample requires the extensions for the COM server and protocol in order to receive notifications, how does the unpackage sample manages to receive notification has it does not have an appxmanifest?*
+
 ## Related Links
 - [Windows App SDK](https://docs.microsoft.com/windows/apps/windows-app-sdk/)
 - [Push Notifications Doc](https://docs.microsoft.com/windows/apps/windows-app-sdk/notifications/push/)
+
 ## Common Issues
 * If there was an error obtaining the WNS Channel URI, make sure you've replaced the zero'ed out remote id (near the top of the sample) with your own remote id.


### PR DESCRIPTION
## Description

Add section on differences between packaged and unpackaged apps settings for Push Notifications

## Target Release

WindowsAppSDK v1.1

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
