### PR TITLE
[SelfContainedDeployment] Added workaround for bug in 1.1.

### DIFF
--- a/Samples/SelfContainedDeployment/cpp-winui-packaged/SelfContainedDeployment.vcxproj
+++ b/Samples/SelfContainedDeployment/cpp-winui-packaged/SelfContainedDeployment.vcxproj
@@ -210,4 +210,9 @@
     <Error Condition="!Exists('packages\Microsoft.WindowsAppSDK.1.1.0-preview3\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.WindowsAppSDK.1.1.0-preview3\build\native\Microsoft.WindowsAppSDK.props'))" />
     <Error Condition="!Exists('packages\Microsoft.WindowsAppSDK.1.1.0-preview3\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.WindowsAppSDK.1.1.0-preview3\build\native\Microsoft.WindowsAppSDK.targets'))" />
   </Target>
+  <Target Name="_RemoveFrameworkReferences" BeforeTargets="_ConvertItems;_CalculateInputsForGenerateCurrentProjectAppxManifest">
+	<ItemGroup>
+	<FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="$([System.String]::Copy('%(FrameworkSdkReference.SDKName)').StartsWith('Microsoft.WindowsAppRuntime.'))" />
+	</ItemGroup>
+  </Target>
 </Project>

--- a/Samples/SelfContainedDeployment/cs-winui-packaged-wap/SelfContainedDeployment (Package)/SelfContainedDeployment (Package).wapproj
+++ b/Samples/SelfContainedDeployment/cs-winui-packaged-wap/SelfContainedDeployment (Package)/SelfContainedDeployment (Package).wapproj
@@ -71,4 +71,9 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
+  <Target Name="_RemoveFrameworkReferences" BeforeTargets="_ConvertItems;_CalculateInputsForGenerateCurrentProjectAppxManifest">
+   <ItemGroup>
+    <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="$([System.String]::Copy('%(FrameworkSdkReference.SDKName)').StartsWith('Microsoft.WindowsAppRuntime.'))" />
+   </ItemGroup>
+  </Target>
 </Project>

--- a/Samples/SelfContainedDeployment/cs-winui-packaged-wap/SelfContainedDeployment/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs-winui-packaged-wap/SelfContainedDeployment/SelfContainedDeployment.csproj
@@ -55,4 +55,10 @@
       <Generator>MSBuild:Compile</Generator>
     </None>
   </ItemGroup>
+	
+  <Target Name="_RemoveFrameworkReferences" BeforeTargets="_ConvertItems;_CalculateInputsForGenerateCurrentProjectAppxManifest">
+	  <ItemGroup>
+		  <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="$([System.String]::Copy('%(FrameworkSdkReference.SDKName)').StartsWith('Microsoft.WindowsAppRuntime.'))" />
+	  </ItemGroup>
+  </Target>
 </Project>

--- a/Samples/SelfContainedDeployment/cs-winui-packaged/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs-winui-packaged/SelfContainedDeployment.csproj
@@ -38,4 +38,10 @@
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnablePreviewMsixTooling)'=='true'">
     <ProjectCapability Include="Msix" />
   </ItemGroup>
+
+  <Target Name="_RemoveFrameworkReferences" BeforeTargets="_ConvertItems;_CalculateInputsForGenerateCurrentProjectAppxManifest">
+	  <ItemGroup>
+		  <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="$([System.String]::Copy('%(FrameworkSdkReference.SDKName)').StartsWith('Microsoft.WindowsAppRuntime.'))" />
+	  </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
The intent of self-contained deployment is to remove any dependencies on the framework package. For MSIX projects, there is a bug in 1.1 that doesn't remove a reference in the MSIX manifest as it should. This workaround ensures that all references to the WinAppSDK framework package are removed. This will be unnecessary in 1.2.

https://task.ms/38856145