### PR TITLE
User/emhuang/windowing samples1.1

### DIFF
--- a/Samples/Windowing/cs-winui/SampleConfiguration.cs
+++ b/Samples/Windowing/cs-winui/SampleConfiguration.cs
@@ -19,7 +19,8 @@ namespace Windowing
         {
             new Scenario() { Title = "Window Basics", ClassName = typeof(WindowBasics).FullName },
             new Scenario() { Title = "Title Bar", ClassName = typeof(TitleBar).FullName },
-            new Scenario() { Title = "Presenters", ClassName = typeof(Presenters).FullName }
+            new Scenario() { Title = "Presenters", ClassName = typeof(Presenters).FullName },
+            new Scenario() { Title = "Z-Order", ClassName = typeof(ZOrder).FullName}
         };
     }
 

--- a/Samples/Windowing/cs-winui/Windowing.csproj
+++ b/Samples/Windowing/cs-winui/Windowing.csproj
@@ -11,10 +11,13 @@
     <EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Remove="ZOrder.xaml" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0-preview2" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.1.588-beta" PrivateAssets="all" />
   </ItemGroup>
 
@@ -36,5 +39,10 @@
        package has not yet been restored -->
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnablePreviewMsixTooling)'=='true'">
     <ProjectCapability Include="Msix" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="ZOrder.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
   </ItemGroup>
 </Project>

--- a/Samples/Windowing/cs-winui/Windowing.sln
+++ b/Samples/Windowing/cs-winui/Windowing.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31717.71
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Windowing", "Windowing.csproj", "{C958D8FD-0433-462C-9990-CD1F104D6656}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Windowing", "Windowing.csproj", "{C958D8FD-0433-462C-9990-CD1F104D6656}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Samples/Windowing/cs-winui/ZOrder.xaml
+++ b/Samples/Windowing/cs-winui/ZOrder.xaml
@@ -1,0 +1,33 @@
+﻿<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<Page
+    x:Class="Windowing.ZOrder"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Windowing"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+        <ScrollViewer Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+            <StackPanel Spacing="10" Margin="10,10,10,10">
+                <TextBlock Text="Description:" Style="{StaticResource ScenarioHeaderTextStyle}"/>
+                <TextBlock Style="{StaticResource ScenarioDescriptionTextStyle}" TextWrapping="Wrap">
+                    Something about Z-Order here.
+                </TextBlock>
+                <Button x:Name="TopZOrderBtn" Click="SwitchZOrder">Top of Z-Order</Button>
+                <Button x:Name="BottomZOrderBtn" Click="SwitchZOrder">Bottom of Z-Order</Button>
+                <Button x:Name="myNewWindowButton" Click="myNewWindowButton_Click">New Window</Button>
+                <StackPanel Orientation="Horizontal">
+                    <Button x:Name="myFromIndexToTopBtn" Click="myFromIndexToTopBtn_Click">Move window to top (right below this window):</Button>
+                    <ListBox x:Name="myListBox"></ListBox>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <Button x:Name="myMoveBelowIndexBtn" Click="myMoveBelowIndexBtn_Click">Move window below:</Button>
+                    <ListBox x:Name="myOtherListBox"></ListBox>
+                </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/Samples/Windowing/cs-winui/ZOrder.xaml
+++ b/Samples/Windowing/cs-winui/ZOrder.xaml
@@ -14,17 +14,20 @@
             <StackPanel Spacing="10" Margin="10,10,10,10">
                 <TextBlock Text="Description:" Style="{StaticResource ScenarioHeaderTextStyle}"/>
                 <TextBlock Style="{StaticResource ScenarioDescriptionTextStyle}" TextWrapping="Wrap">
-                    Something about Z-Order here.
+                    Z-Order allows you to control where your windows lies in the Z-Order stack. Windows higher up the Z-Order stack are in the forefront of your screen, while windows lower in the stack are hidden behind other windows. 
                 </TextBlock>
-                <Button x:Name="TopZOrderBtn" Click="SwitchZOrder">Top of Z-Order</Button>
-                <Button x:Name="BottomZOrderBtn" Click="SwitchZOrder">Bottom of Z-Order</Button>
+                <StackPanel Orientation="Horizontal">
+                    <Button x:Name="TopZOrderBtn" Click="SwitchZOrder">Make this window on top of Z-Order</Button>
+                    <Button x:Name="BottomZOrderBtn" Click="SwitchZOrder">Make this window on the bottom of Z-Order</Button>
+                </StackPanel>
+                
                 <Button x:Name="myNewWindowButton" Click="myNewWindowButton_Click">New Window</Button>
                 <StackPanel Orientation="Horizontal">
-                    <Button x:Name="myFromIndexToTopBtn" Click="myFromIndexToTopBtn_Click">Move window to top (right below this window):</Button>
+                    <Button x:Name="myFromIndexToTopBtn" Click="myFromIndexToTopBtn_Click">Move chosen window right below this window:</Button>
                     <ListBox x:Name="myListBox"></ListBox>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal">
-                    <Button x:Name="myMoveBelowIndexBtn" Click="myMoveBelowIndexBtn_Click">Move window below:</Button>
+                    <Button x:Name="myMoveBelowIndexBtn" Click="myMoveBelowIndexBtn_Click">Move this window right below chosen window:</Button>
                     <ListBox x:Name="myOtherListBox"></ListBox>
                 </StackPanel>
             </StackPanel>

--- a/Samples/Windowing/cs-winui/ZOrder.xaml.cs
+++ b/Samples/Windowing/cs-winui/ZOrder.xaml.cs
@@ -73,31 +73,25 @@ namespace Windowing
 
         private void myFromIndexToTopBtn_Click(object sender, RoutedEventArgs e)
         {
-            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            Microsoft.UI.WindowId windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
-            Microsoft.UI.Windowing.AppWindow appWindow = Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
-            if (appWindow != null)
+            if (_mainAppWindow != null & myListBox.SelectedIndex != -1 & windowList.Any())
             {
                 Window OtherWindow = windowList[myListBox.SelectedIndex];
                 var otherhWnd = WinRT.Interop.WindowNative.GetWindowHandle(OtherWindow);
                 Microsoft.UI.WindowId otherWindowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(otherhWnd);
                 Microsoft.UI.Windowing.AppWindow otherAppWindow = Microsoft.UI.Windowing.AppWindow.GetFromWindowId(otherWindowId);
-                otherAppWindow.MoveInZOrderBelow(windowId);
+                otherAppWindow.MoveInZOrderBelow(_mainAppWindow.Id);
             }
-
         }
 
         private void myMoveBelowIndexBtn_Click(object sender, RoutedEventArgs e)
         {
-            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            Microsoft.UI.WindowId windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
-            Microsoft.UI.Windowing.AppWindow appWindow = Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
-            if (appWindow != null)
+            if (_mainAppWindow != null & myOtherListBox.SelectedIndex != -1 & windowList.Any())
             {
                 Window OtherWindow = windowList[myOtherListBox.SelectedIndex];
                 var otherhWnd = WinRT.Interop.WindowNative.GetWindowHandle(OtherWindow);
                 Microsoft.UI.WindowId otherWindowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(otherhWnd);
-                appWindow.MoveInZOrderBelow(otherWindowId);
+                _mainAppWindow.MoveInZOrderBelow(otherWindowId);
+
             }
         }
     }

--- a/Samples/Windowing/cs-winui/ZOrder.xaml.cs
+++ b/Samples/Windowing/cs-winui/ZOrder.xaml.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using WinRT;
+
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace Windowing
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class ZOrder : Page
+    {
+        private AppWindow _mainAppWindow = MainWindow.AppWindow;
+        List<Window> windowList = new List<Window>();
+
+        public ZOrder()
+        {
+            this.InitializeComponent();
+        }
+
+        private void SwitchZOrder(object sender, RoutedEventArgs e)
+        {
+            // Bail out if we don't have an AppWindow object.
+            if (_mainAppWindow != null)
+            {
+                switch (sender.As<Button>().Name)
+                {
+                    case "BottomZOrderBtn":
+                        _mainAppWindow.MoveInZOrderAtBottom();
+                        break;
+
+                    case "TopZOrderBtn":
+                        _mainAppWindow.MoveInZOrderAtTop();
+                        break;
+
+                    default:
+                        
+                        break;
+                }
+            }
+        }
+
+        private void myNewWindowButton_Click(object sender, RoutedEventArgs e)
+        {
+            Window nextWindow = new Window();
+            nextWindow.Content = new TextBlock() { Text = "A wild window appears!" };
+            nextWindow.Title = "Window #" + windowList.Count.ToString();
+            nextWindow.Activate();
+            windowList.Add(nextWindow);
+            myListBox.Items.Add(nextWindow.Title);
+            myOtherListBox.Items.Add(nextWindow.Title);
+        }
+
+        private void myFromIndexToTopBtn_Click(object sender, RoutedEventArgs e)
+        {
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            Microsoft.UI.WindowId windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
+            Microsoft.UI.Windowing.AppWindow appWindow = Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
+            if (appWindow != null)
+            {
+                Window OtherWindow = windowList[myListBox.SelectedIndex];
+                var otherhWnd = WinRT.Interop.WindowNative.GetWindowHandle(OtherWindow);
+                Microsoft.UI.WindowId otherWindowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(otherhWnd);
+                Microsoft.UI.Windowing.AppWindow otherAppWindow = Microsoft.UI.Windowing.AppWindow.GetFromWindowId(otherWindowId);
+                otherAppWindow.MoveInZOrderBelow(windowId);
+            }
+
+        }
+
+        private void myMoveBelowIndexBtn_Click(object sender, RoutedEventArgs e)
+        {
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            Microsoft.UI.WindowId windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
+            Microsoft.UI.Windowing.AppWindow appWindow = Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
+            if (appWindow != null)
+            {
+                Window OtherWindow = windowList[myOtherListBox.SelectedIndex];
+                var otherhWnd = WinRT.Interop.WindowNative.GetWindowHandle(OtherWindow);
+                Microsoft.UI.WindowId otherWindowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(otherhWnd);
+                appWindow.MoveInZOrderBelow(otherWindowId);
+            }
+        }
+    }
+}

--- a/Samples/Windowing/cs-winui/ZOrder.xaml.cs
+++ b/Samples/Windowing/cs-winui/ZOrder.xaml.cs
@@ -92,6 +92,10 @@ namespace Windowing
                 windowList.RemoveAt(index);
                 myListBox.Items.RemoveAt(index);
                 myOtherListBox.Items.RemoveAt(index);
+                if(index == windowList.Count)
+                {
+                    m_windowCount--;
+                }
             }
         }
 

--- a/Samples/Windowing/cs-winui/ZOrder.xaml.cs
+++ b/Samples/Windowing/cs-winui/ZOrder.xaml.cs
@@ -92,10 +92,18 @@ namespace Windowing
                 windowList.RemoveAt(index);
                 myListBox.Items.RemoveAt(index);
                 myOtherListBox.Items.RemoveAt(index);
-                if(index == windowList.Count)
+
+                for (int i = 0; i < windowList.Count; i++)
                 {
-                    m_windowCount--;
+                    var new_title = i + 1;
+                    WindowId windowId = windowList[i];
+                    AppWindow iteratedAppWindow = AppWindow.GetFromWindowId(windowId);
+                    iteratedAppWindow.Title = "Window #" + new_title.ToString();
+                    myListBox.Items[i] = "Window #" + new_title.ToString();
+                    myOtherListBox.Items[i] = "Window #" + new_title.ToString();
                 }
+
+                m_windowCount = windowList.Count;
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Added z-order feature to CS-WinUI windowing samples.

Cs WPF outstanding.
Cs Winforms outstanding.
Cpp WinUI outstanding.

## Target Release

Aligns with v1.1 Preview 1-3.

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
