### PR TITLE
Ensure GetStatus doesn't crash and ensure MSIX package of the sample …

### DIFF
--- a/Samples/DeploymentManager/cpp-winui/Scenario2_Initialize.xaml.cpp
+++ b/Samples/DeploymentManager/cpp-winui/Scenario2_Initialize.xaml.cpp
@@ -34,7 +34,6 @@ namespace winrt::DeploymentManagerSample::implementation
     void Scenario2_Initialize::UpdateDeploymentResultMessages(DeploymentResult deploymentResult)
     {
         resultStatus().Text(L"Result Status: "); // TODO DeploymentStatus to string
-        resultExtendedError().Text(L"Result ExtendedError: " + to_hstring(deploymentResult.ExtendedError()));
 
         // Check the result.
         if (deploymentResult.Status() == DeploymentStatus::Ok)
@@ -44,6 +43,8 @@ namespace winrt::DeploymentManagerSample::implementation
         }
         else
         {
+            resultExtendedError().Text(L"Result ExtendedError: " + to_hstring(deploymentResult.ExtendedError()));
+
             // The WindowsAppRuntime is in a bad state which Initialize() did not fix.
             // Do error reporting or gather information for submitting a bug.
             // Gracefully exit the program or carry on without using the WindowsAppRuntime.

--- a/Samples/DeploymentManager/cs-winui/Package.appxmanifest
+++ b/Samples/DeploymentManager/cs-winui/Package.appxmanifest
@@ -8,7 +8,7 @@
 
   <Identity
     Name="b15c58b4-2998-4ce3-9bea-6ca5d3f8fdb3"
-    Publisher="CN=Microsoft Corporation"
+    Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
     Version="1.1.0.0" />
 
   <Properties>

--- a/Samples/DeploymentManager/cs-winui/Scenario1_GetStatus.xaml.cs
+++ b/Samples/DeploymentManager/cs-winui/Scenario1_GetStatus.xaml.cs
@@ -29,7 +29,6 @@ namespace DeploymentManagerSample
             // error code. The Status is usually the property of interest, as the ExtendedError is
             // typically used for diagnostic purposes or troubleshooting. 
             resultStatus.Text = "Result Status: " + result.Status.ToString();
-            resultExtendedError.Text = "Result ExtendedError: " + result.ExtendedError.ToString();
 
             // Check the resulting Status.
             if (result.Status == DeploymentStatus.Ok)
@@ -38,6 +37,7 @@ namespace DeploymentManagerSample
             }
             else
             {
+                resultExtendedError.Text = "Result ExtendedError: " + result.ExtendedError.ToString();
                 // A not-Ok status means it is not ready for us. The Status will indicate the
                 // reason it is not Ok, such as some packages need to be installed.
                 resultImplication.Text = "The Windows App Runtime is not ready for use.";


### PR DESCRIPTION
…is created with correct publisher details.

<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

The sample app crashes on successful GetStatus and Initialize operations because the code tries to reference the ExtendedError field which is null for successes. The fix is to avoid the referencing in case of successes and try it only in case of failures.

## Target Release

Please specify which release this PR should align with. e.g., 1.0, 1.1, 1.1 Preview 1.

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
