### PR TITLE
Net6 update

### DIFF
--- a/Samples/AppLifecycle/Activation/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation (Package)/CsWinUiDesktopActivation (Package).wapproj
+++ b/Samples/AppLifecycle/Activation/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation (Package)/CsWinUiDesktopActivation (Package).wapproj
@@ -38,7 +38,7 @@
     <ProjectGuid>75f5a3a4-5821-42a6-96a8-85fea269b1e9</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
-    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
+    <AssetTargetFallback>net6.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     <EntryPointProjectUniqueName>..\CsWinUiDesktopActivation\CsWinUiDesktopActivation.csproj</EntryPointProjectUniqueName>

--- a/Samples/AppLifecycle/Activation/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/CsWinUiDesktopActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/CsWinUiDesktopActivation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsWinUiDesktopActivation</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Samples/AppLifecycle/Activation/cs-wpf-packaged/CsWpfActivation/CsWpfActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs-wpf-packaged/CsWpfActivation/CsWpfActivation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win-x86;win-x64</RuntimeIdentifiers>

--- a/Samples/AppLifecycle/Instancing/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing (Package)/CsWinUiDesktopInstancing (Package).wapproj
+++ b/Samples/AppLifecycle/Instancing/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing (Package)/CsWinUiDesktopInstancing (Package).wapproj
@@ -38,7 +38,7 @@
     <ProjectGuid>00c39744-8a06-4f19-8387-08d5d2f51efe</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
-    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
+    <AssetTargetFallback>net6.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     <EntryPointProjectUniqueName>..\CsWinUiDesktopInstancing\CsWinUiDesktopInstancing.csproj</EntryPointProjectUniqueName>

--- a/Samples/AppLifecycle/Instancing/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsWinUiDesktopInstancing</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Samples/AppLifecycle/Instancing/cs-wpf-packaged/CsWpfInstancing/CsWpfInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs-wpf-packaged/CsWpfInstancing/CsWpfInstancing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win-x86;win-x64</RuntimeIdentifiers>

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/cs-winui-packaged.csproj
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/cs-winui-packaged.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>cs_winui_packaged</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Samples/AppLifecycle/StateNotifications/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState (Package)/CsWinUiDesktopState (Package).wapproj
+++ b/Samples/AppLifecycle/StateNotifications/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState (Package)/CsWinUiDesktopState (Package).wapproj
@@ -38,7 +38,7 @@
     <ProjectGuid>96f90be4-707b-4bc3-af95-905ea75904e9</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
-    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
+    <AssetTargetFallback>net6.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     <EntryPointProjectUniqueName>..\CsWinUiDesktopState\CsWinUiDesktopState.csproj</EntryPointProjectUniqueName>

--- a/Samples/AppLifecycle/StateNotifications/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/CsWinUiDesktopState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/CsWinUiDesktopState.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsWinUiDesktopState</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Samples/AppLifecycle/StateNotifications/cs-wpf-packaged/CsWpfState/CsWpfState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs-wpf-packaged/CsWpfState/CsWpfState.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win-x86;win-x64</RuntimeIdentifiers>

--- a/Samples/DeploymentManager/cs-winui/SampleApp (Package)/SampleApp (Package).wapproj
+++ b/Samples/DeploymentManager/cs-winui/SampleApp (Package)/SampleApp (Package).wapproj
@@ -38,7 +38,7 @@
     <ProjectGuid>81509950-46b8-4625-8a61-f5135d9a9c56</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
+    <AssetTargetFallback>net6.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
     <EntryPointProjectUniqueName>..\SampleApp\SampleApp.csproj</EntryPointProjectUniqueName>

--- a/Samples/DeploymentManager/cs-winui/SampleApp/SampleApp.csproj
+++ b/Samples/DeploymentManager/cs-winui/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>SampleApp</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Samples/DeploymentManager/cs-winui/SampleApp/SampleApp.csproj
+++ b/Samples/DeploymentManager/cs-winui/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>SampleApp</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.6.4" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/Samples/Input/cs-winui/Input.csproj
+++ b/Samples/Input/cs-winui/Input.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Input</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications.csproj
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsUnpackagedAppNotifications</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Samples/Unpackaged/cs-console-unpackaged/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Samples/Unpackaged/cs-console-unpackaged/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishDir>bin\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Unpackaged/cs-console-unpackaged/Unpackaged.csproj
+++ b/Samples/Unpackaged/cs-console-unpackaged/Unpackaged.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <Platforms>x64;x86;arm64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <!-- Set WindowsPackageType=None to auto-intialize access to the WinAppSDK framework -->

--- a/Samples/Windowing/cs-wpf/wpf_packaged_app/wpf_packaged_app.csproj
+++ b/Samples/Windowing/cs-wpf/wpf_packaged_app/wpf_packaged_app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Platforms>x86;x64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>


### PR DESCRIPTION
## Description

Update samples from net5 to net6. This is needed for the update to CsWinRT 2.0.0 as part of compat testing.

## Target Release

1.2

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [x] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [x] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
