### PR TITLE
Adding build script

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,36 @@
+@echo off
+if "%1"=="/?" goto :usage
+if "%1"=="-?" goto :usage
+if "%VSINSTALLDIR%" == "" goto :usage
+
+set platform=%1
+set configuration=%2
+set sample_filter=%3\
+
+if "%platform%"=="" set platform=x64
+if "%configuration%"=="" set configuration=Release
+
+if not exist ".\.nuget" mkdir ".\.nuget"
+if not exist ".\.nuget\nuget.exe" powershell -Command "Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile .\.nuget\nuget.exe"
+
+for /f "delims=" %%D in ('dir /s/b samples\%sample_filter%*.sln') do (
+    call .nuget\nuget.exe restore "%%D" -configfile Samples\nuget.config
+    call msbuild /p:platform=%platform% /p:configuration=%configuration% "%%D"
+
+    if ERRORLEVEL 1 goto :eof
+)
+goto :eof
+
+:usage
+echo Usage:
+echo     This script should be run under a Visual Studio Developer Command Prompt.
+echo.
+echo     build.cmd [Platform] [Configuration] [Sample]
+echo.
+echo     [Platform] Either x86, x64, or arm64.  Default is x64.
+echo     [Configuration] Either Debug or Release.  Default is Release.
+echo     [Sample] The sample folder under Samples to build.  If none specified, all samples are built.
+echo.
+echo     If no parameters are specified, all samples are built for x64 Release.
+
+exit /b /1


### PR DESCRIPTION
## Description

Adding build script to build the samples via command line.

## Target Release

1.2

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
