### PR TITLE
Renaming appwindow local property to avoid name conflict with future MUX Window.AppWindow property

### DIFF
--- a/Samples/Windowing/cpp-win32/Windowing/MyAppWindow.cpp
+++ b/Samples/Windowing/cpp-win32/Windowing/MyAppWindow.cpp
@@ -5,7 +5,7 @@
 using namespace winrt::Microsoft::UI::Windowing;
 
 // global
-winrt::Microsoft::UI::Windowing::AppWindow appWindow{ nullptr };
+winrt::Microsoft::UI::Windowing::AppWindow myAppWindow{ nullptr };
 
 namespace winrt
 {
@@ -60,14 +60,14 @@ MyAppWindow::MyAppWindow(const winrt::Compositor& compositor, const std::wstring
     windowId = winrt::GetWindowIdFromWindow(m_window);
 
     // Get the AppWindow for the WindowId
-    appWindow = winrt::Microsoft::UI::Windowing::AppWindow::GetFromWindowId(windowId);
+    myAppWindow = winrt::Microsoft::UI::Windowing::AppWindow::GetFromWindowId(windowId);
 
     //Create Compact Overlay Presenter
     winrt::Microsoft::UI::Windowing::AppWindowPresenterKind newPresenterKind = winrt::Microsoft::UI::Windowing::AppWindowPresenterKind::CompactOverlay;
-    appWindow.SetPresenter(newPresenterKind);
+    myAppWindow.SetPresenter(newPresenterKind);
 
-    appWindow.Create();
-    appWindow.Show();
+    myAppWindow.Create();
+    myAppWindow.Show();
 
     // The Mica controller needs to set a target with a root to recognize the visual base layer
     m_target = CreateWindowTarget(compositor);

--- a/Samples/Windowing/cpp-winui/SampleApp/ConfigPage.xaml.cpp
+++ b/Samples/Windowing/cpp-winui/SampleApp/ConfigPage.xaml.cpp
@@ -24,7 +24,7 @@ namespace winrt::SampleApp::implementation
     {
         Window window = e.Parameter().as<Window>();
         MainWindow mainWindow = window.as<MainWindow>();
-        m_mainAppWindow = mainWindow.AppWindow();
+        m_mainAppWindow = mainWindow.MyAppWindow();
 
         // Disable the switches that control properties only available when Overlapped if we're in any other Presenter state
         if (m_mainAppWindow.Presenter().Kind() != AppWindowPresenterKind::Overlapped)

--- a/Samples/Windowing/cpp-winui/SampleApp/DemoPage.xaml.cpp
+++ b/Samples/Windowing/cpp-winui/SampleApp/DemoPage.xaml.cpp
@@ -22,7 +22,7 @@ namespace winrt::SampleApp::implementation
     {
         Window window = e.Parameter().as<Window>();
         MainWindow mainWindow = window.as<MainWindow>();
-        AppWindow appWindow = mainWindow.AppWindow();
+        AppWindow appWindow = mainWindow.MyAppWindow();
         m_mainAppWindow = appWindow;
     }
 

--- a/Samples/Windowing/cpp-winui/SampleApp/MainWindow.xaml.cpp
+++ b/Samples/Windowing/cpp-winui/SampleApp/MainWindow.xaml.cpp
@@ -25,7 +25,7 @@ namespace winrt::SampleApp::implementation
     }
 
 
-    winrt::AppWindow MainWindow::AppWindow()
+    winrt::AppWindow MainWindow::MyAppWindow()
     {
         return m_mainAppWindow;
     }
@@ -74,7 +74,7 @@ namespace winrt::SampleApp::implementation
 
     void MainWindow::MyWindowIcon_DoubleTapped(winrt::IInspectable const& /*sender*/, winrt::Microsoft::UI::Xaml::Input::DoubleTappedRoutedEventArgs const& /*e*/)
     {
-        this->AppWindow().Destroy();
+        this->MyAppWindow().Destroy();
     }
 
     winrt::AppWindow MainWindow::GetAppWindowForCurrentWindow()

--- a/Samples/Windowing/cpp-winui/SampleApp/MainWindow.xaml.h
+++ b/Samples/Windowing/cpp-winui/SampleApp/MainWindow.xaml.h
@@ -12,8 +12,8 @@ struct MainWindow : MainWindowT<MainWindow>
 {
 public:
     MainWindow();
-
-    winrt::AppWindow AppWindow();
+    // to avoid name conflict with future Microsoft.UI.Xaml.Window.AppWindow property
+    winrt::AppWindow MyAppWindow(); 
 
     void NavigationView_Loaded(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void NavigationView_ItemInvoked(winrt::IInspectable const& sender, winrt::NavigationViewItemInvokedEventArgs const& args);

--- a/Samples/Windowing/cpp-winui/SampleApp/PresenterPage.xaml.cpp
+++ b/Samples/Windowing/cpp-winui/SampleApp/PresenterPage.xaml.cpp
@@ -23,7 +23,7 @@ namespace winrt::SampleApp::implementation
     {
         Window window = e.Parameter().as<Window>();
         MainWindow mainWindow = window.as<MainWindow>();
-        m_mainAppWindow = mainWindow.AppWindow();
+        m_mainAppWindow = mainWindow.MyAppWindow();
     }
 
     void PresenterPage::SwitchPresenter(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& /*e*/)

--- a/Samples/Windowing/cpp-winui/SampleApp/TitlebarPage.xaml.cpp
+++ b/Samples/Windowing/cpp-winui/SampleApp/TitlebarPage.xaml.cpp
@@ -25,7 +25,7 @@ namespace winrt::SampleApp::implementation
     void TitlebarPage::OnNavigatedTo(NavigationEventArgs const& e)
     {
         m_mainWindow = e.Parameter().as<MainWindow>();
-        AppWindow appWindow = m_mainWindow.AppWindow();
+        AppWindow appWindow = m_mainWindow.MyAppWindow();
         m_appWindow = appWindow;
         m_changedToken = m_appWindow.Changed({ this, &TitlebarPage::AppWindowChangedHandler });
     }

--- a/Samples/Windowing/cpp-winui/SampleApp/Types.idl
+++ b/Samples/Windowing/cpp-winui/SampleApp/Types.idl
@@ -1,4 +1,4 @@
-
+﻿
 namespace SampleApp
 {
     [default_interface]
@@ -6,7 +6,7 @@ namespace SampleApp
     {
         MainWindow();
 
-        Microsoft.UI.Windowing.AppWindow AppWindow { get; };
+        Microsoft.UI.Windowing.AppWindow MyAppWindow { get; };
         Microsoft.UI.Xaml.Controls.Grid MyTitleBar{ get; };
         Microsoft.UI.Xaml.Controls.Image MyWindowIcon{ get; };
 

--- a/Samples/Windowing/cs-winui/MainWindow.xaml.cs
+++ b/Samples/Windowing/cs-winui/MainWindow.xaml.cs
@@ -15,12 +15,13 @@ namespace Windowing
 {
     public partial class MainWindow : Window
     {
-        public static AppWindow AppWindow;
+        // to avoid name conflict with future Microsoft.UI.Xaml.Window.AppWindow property
+        public static AppWindow MyAppWindow;
         public string WindowTitle;
         public MainWindow()
         {
             this.InitializeComponent();
-            AppWindow = AppWindowExtensions.GetAppWindow(this);
+            MyAppWindow = AppWindowExtensions.GetAppWindow(this);
             Title = Settings.FeatureName;
             
             HWND hwnd = (HWND)WinRT.Interop.WindowNative.GetWindowHandle(this);

--- a/Samples/Windowing/cs-winui/PresentersPage.xaml.cs
+++ b/Samples/Windowing/cs-winui/PresentersPage.xaml.cs
@@ -17,7 +17,7 @@ namespace Windowing
     /// </summary>
     public sealed partial class Presenters : Page
     {
-        private AppWindow _mainAppWindow = MainWindow.AppWindow;
+        private AppWindow _mainAppWindow = MainWindow.MyAppWindow;
         public Presenters()
         {
             this.InitializeComponent();

--- a/Samples/Windowing/cs-winui/TitleBarPage.xaml.cs
+++ b/Samples/Windowing/cs-winui/TitleBarPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Windowing
 {
     public partial class TitleBar : Page
     {
-        private AppWindow _mainAppWindow = MainWindow.AppWindow;
+        private AppWindow _mainAppWindow = MainWindow.MyAppWindow;
         private bool _isBrandedTitleBar;
         private bool _isTallTitleBar = false;
         private MainPage _mainPage = MainPage.Current;

--- a/Samples/Windowing/cs-winui/WindowBasicsPage.xaml.cs
+++ b/Samples/Windowing/cs-winui/WindowBasicsPage.xaml.cs
@@ -10,7 +10,7 @@ namespace Windowing
 {
     public partial class WindowBasics : Page
     {
-        private AppWindow _mainAppWindow = MainWindow.AppWindow;
+        private AppWindow _mainAppWindow = MainWindow.MyAppWindow;
         public WindowBasics()
         {
             this.InitializeComponent();

--- a/Samples/Windowing/cs-winui/ZOrderPage.xaml.cs
+++ b/Samples/Windowing/cs-winui/ZOrderPage.xaml.cs
@@ -30,7 +30,7 @@ namespace Windowing
     /// </summary>
     public sealed partial class ZOrder : Page
     {
-        private AppWindow _mainAppWindow = MainWindow.AppWindow;
+        private AppWindow _mainAppWindow = MainWindow.MyAppWindow;
         List<WindowId> windowList = new List<WindowId>();
 
         public ZOrder()


### PR DESCRIPTION
## Description
With a future version of WinUI 3, Microsoft.UI.Xaml.Window class is receiving one more property called AppWindow which makes it easy to access AppWindow functions from winui codebase.

However, 2 winui sample projects in this repo are using MainWindow.AppWindow  user defined property. Since MainWindow inherits from Microsoft.UI.Xaml.Window, there would be a name conflict between them. To avoid that, these properties have been renamed to MyAppWindow resulting in MainWindow.MyAppWindow custom property.


## Target Release
It can be merged immediately.

## Checklist

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [x] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
