### PR TITLE
Switch Win32 event to .Net Semaphore

### DIFF
--- a/Samples/AppLifecycle/Instancing/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsWinUiDesktopInstancing</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
## Description

In the C# WinUI Instancing example, the code defines pinvokes in order to create a Win32 Event and do a CoWait. I had trouble getting that to work in my app on copy/paste, and in any case it's unnecessarily complicated for C#. So the update here is to use a .Net Semaphore instead.

Also updated the project to .Net6 so that it can be used in VS2022.

## Target Release

1.1

## Checklist

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
