### PR TITLE
Fix namespace issues caused by CsWin32 upgrade

### DIFF
--- a/Samples/CustomControls/CsApp/MainWindow.xaml.cs
+++ b/Samples/CustomControls/CsApp/MainWindow.xaml.cs
@@ -6,9 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
-using Windows.Win32.UI.Controls;
 using Windows.Win32.UI.WindowsAndMessaging;
-using static Windows.Win32.Constants;
 using static Windows.Win32.PInvoke;
 
 namespace CsApp

--- a/Samples/DeploymentManager/cs-winui/MainWindow.xaml.cs
+++ b/Samples/DeploymentManager/cs-winui/MainWindow.xaml.cs
@@ -6,9 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
-using Windows.Win32.UI.Controls;
 using Windows.Win32.UI.WindowsAndMessaging;
-using static Windows.Win32.Constants;
 using static Windows.Win32.PInvoke;
 
 namespace DeploymentManagerSample

--- a/Samples/Input/cs-winui/MainWindow.xaml.cs
+++ b/Samples/Input/cs-winui/MainWindow.xaml.cs
@@ -6,9 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
-using Windows.Win32.UI.Controls;
 using Windows.Win32.UI.WindowsAndMessaging;
-using static Windows.Win32.Constants;
 using static Windows.Win32.PInvoke;
 
 namespace Input

--- a/Samples/SelfContainedDeployment/cs-winui-packaged-wap/SelfContainedDeployment/MainWindow.xaml.cs
+++ b/Samples/SelfContainedDeployment/cs-winui-packaged-wap/SelfContainedDeployment/MainWindow.xaml.cs
@@ -6,9 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
-using Windows.Win32.UI.Controls;
 using Windows.Win32.UI.WindowsAndMessaging;
-using static Windows.Win32.Constants;
 using static Windows.Win32.PInvoke;
 
 namespace SelfContainedDeployment

--- a/Samples/SelfContainedDeployment/cs-winui-packaged/MainWindow.xaml.cs
+++ b/Samples/SelfContainedDeployment/cs-winui-packaged/MainWindow.xaml.cs
@@ -6,9 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
-using Windows.Win32.UI.Controls;
 using Windows.Win32.UI.WindowsAndMessaging;
-using static Windows.Win32.Constants;
 using static Windows.Win32.PInvoke;
 
 namespace SelfContainedDeployment

--- a/Samples/SelfContainedDeployment/cs-winui-unpackaged/MainWindow.xaml.cs
+++ b/Samples/SelfContainedDeployment/cs-winui-unpackaged/MainWindow.xaml.cs
@@ -6,9 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
-using Windows.Win32.UI.Controls;
 using Windows.Win32.UI.WindowsAndMessaging;
-using static Windows.Win32.Constants;
 using static Windows.Win32.PInvoke;
 
 namespace SelfContainedDeployment

--- a/Templates/VSIX/Project Templates/cs-winui-template/MainWindow.xaml.cs
+++ b/Templates/VSIX/Project Templates/cs-winui-template/MainWindow.xaml.cs
@@ -6,11 +6,8 @@ using System;
 using System.Runtime.InteropServices;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
-using Windows.Win32.UI.Controls;
 using Windows.Win32.UI.WindowsAndMessaging;
-
 using static Windows.Win32.PInvoke;
-using static Windows.Win32.Constants;
 
 namespace $safeprojectname$
 {


### PR DESCRIPTION
## Description
This fixes an issue similar to https://github.com/microsoft/CsWin32/issues/532, in the same way that https://github.com/microsoft/WindowsAppSDK-Samples/pull/197 does.


## Target Release
1.2

## Checklist

- [X] Samples build clean with no warnings or errors.
- [X] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
