### PR TITLE
Update TextRenderer::DrawGlyphRun.

### DIFF
--- a/Samples/TextRendering/cpp-win32/DWriteCoreGallery/TextRenderer.h
+++ b/Samples/TextRendering/cpp-win32/DWriteCoreGallery/TextRenderer.h
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 #pragma once
@@ -147,13 +147,13 @@ private:
 
     private:
         IDWriteBitmapRenderTarget1* m_renderTarget = nullptr;
-        DWRITE_MATRIX m_oldTransform;
+        DWRITE_MATRIX m_oldTransform = {};
     };
 
     uint32_t m_refCount = 0;
     float m_dpiScale = 1.0f;
     wil::com_ptr<IDWriteRenderingParams> m_renderingParams;
-    wil::com_ptr<IDWriteBitmapRenderTarget1> m_renderTarget;
+    wil::com_ptr<IDWriteBitmapRenderTarget3> m_renderTarget;
     wil::com_ptr<IDWriteTextAnalyzer2> m_textAnalyzer;
     HDC m_targetHdc = nullptr;
     SIZE m_targetPixelSize = {};


### PR DESCRIPTION
## Description

This changes the IDWriteTextRenderer::DrawGlyphRun implementation in the DWriteCoreGallery sample to use the new `IDWriteBitmapRenderTarget3::DrawGlyphRunWithColor` method. This is a much simpler way of supporting color fonts than the old way of calling `TranslateColorGlyphRun`. For more information, see https://github.com/microsoft/WindowsAppSDK/blob/main/specs/dwritecore/DWriteCore.md#color-font-support

This also default-initializes the m_oldTransformMember of the TextRenderer::OrientationTransform class to resolve static analysis warnings.

## Target Release

1.3 Preview 1

## Checklist

- [X] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [X] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [X] Samples set the minimum supported OS version to Windows 10 version 1809.
- [X] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
