### PR TITLE
Retarget winui_desktop_packaged_app_cpp.vcxproj to 22621

### DIFF
--- a/Samples/ResourceManagement/cpp-winui/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp.vcxproj
+++ b/Samples/ResourceManagement/cpp-winui/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp.vcxproj
@@ -23,8 +23,8 @@
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <IsWinUIAlpha Condition="'$(IsWinUIAlpha)' == ''">true</IsWinUIAlpha>
     <WindowsKitsPath Condition="'$(IsWinUIAlpha)' == 'true'">WinUI-Alpha-Projects-Don-t-Use-SDK-Xaml-Tools</WindowsKitsPath>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.22621.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/Samples/ResourceManagement/cpp-winui/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp.vcxproj
+++ b/Samples/ResourceManagement/cpp-winui/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp.vcxproj
@@ -24,7 +24,7 @@
     <IsWinUIAlpha Condition="'$(IsWinUIAlpha)' == ''">true</IsWinUIAlpha>
     <WindowsKitsPath Condition="'$(IsWinUIAlpha)' == 'true'">WinUI-Alpha-Projects-Don-t-Use-SDK-Xaml-Tools</WindowsKitsPath>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.22621.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">


### PR DESCRIPTION
## Description

Retarget winui_desktop_packaged_app_cpp.vcxproj to 22621 SDK to fix the issue with the Foundation ingestion with the error below.

##[error]midlrt(0,0): Error MIDL1002: [msg]error while reading input file [context]Error processing WinMD metadata. Custom attribute Windows.Foundation.Metadata.ExperimentalAttribute: Attribute Windows.Foundation.Metadata.ExperimentalAttribute could not be found.


## Target Release

1.4

## Checklist

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
