### PR TITLE
Fix Prefast C6387 on SimpleIslandApp.cpp

### DIFF
--- a/Samples/Islands/cpp-win32-unpackaged/SimpleIslandApp.cpp
+++ b/Samples/Islands/cpp-win32-unpackaged/SimpleIslandApp.cpp
@@ -192,13 +192,16 @@ void MyRegisterClass(HINSTANCE hInstance, const wchar_t* szWindowClass)
 //
 HWND InitInstance(HINSTANCE /*hInstance*/, int nCmdShow, const wchar_t* szTitle, const wchar_t* szWindowClass)
 {
-   HWND hWnd = CreateWindowW(szWindowClass, szTitle, WS_OVERLAPPEDWINDOW,
-      CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, nullptr, nullptr, ::GetModuleHandle(NULL), nullptr);
-   winrt::check_bool(hWnd != NULL);
-
-   ShowWindow(hWnd, nCmdShow);
-   UpdateWindow(hWnd);
-   return hWnd;
+    HWND hWnd = CreateWindowW(szWindowClass, szTitle, WS_OVERLAPPEDWINDOW,
+       CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, nullptr, nullptr, ::GetModuleHandle(NULL), nullptr);
+    winrt::check_bool(hWnd != NULL);
+    if(!hWnd)
+    {
+        throw new Exception("Fatal crash!");
+    }
+    ShowWindow(hWnd, nCmdShow);
+    UpdateWindow(hWnd);
+    return hWnd;
 }
 
 //

--- a/Samples/Islands/cpp-win32-unpackaged/SimpleIslandApp.cpp
+++ b/Samples/Islands/cpp-win32-unpackaged/SimpleIslandApp.cpp
@@ -197,7 +197,7 @@ HWND InitInstance(HINSTANCE /*hInstance*/, int nCmdShow, const wchar_t* szTitle,
     winrt::check_bool(hWnd != NULL);
     if(!hWnd)
     {
-        throw new Exception("Fatal crash!");
+        throw E_FAIL;
     }
     ShowWindow(hWnd, nCmdShow);
     UpdateWindow(hWnd);

--- a/Samples/Islands/cpp-win32-unpackaged/SimpleIslandApp.cpp
+++ b/Samples/Islands/cpp-win32-unpackaged/SimpleIslandApp.cpp
@@ -197,7 +197,7 @@ HWND InitInstance(HINSTANCE /*hInstance*/, int nCmdShow, const wchar_t* szTitle,
     winrt::check_bool(hWnd != NULL);
     if(!hWnd)
     {
-        throw E_FAIL;
+        throw E_HANDLE;
     }
     ShowWindow(hWnd, nCmdShow);
     UpdateWindow(hWnd);


### PR DESCRIPTION
Prefast results shows

hWnd' could be '0':  this does not adhere to the specification for the function 'ShowWindow
hWnd' could be '0':  this does not adhere to the specification for the function 'UpdateWindow'. See line 199 for an earlier location where this can occur

The fix was to add a null check and throw if null