### PR TITLE
Refactor UIA

### DIFF
--- a/Samples/Islands/DrawingIsland/DrawingCppTestApp/WinMain.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingCppTestApp/WinMain.cpp
@@ -40,6 +40,11 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
     siteBridge.Show();
     siteBridge.Connect(drawing.Island());
 
+    // Move initial focus to the island.
+    auto focusNavigationHost = winrt::InputFocusNavigationHost::GetForSiteBridge(siteBridge);
+    focusNavigationHost.NavigateFocus(winrt::FocusNavigationRequest::Create(
+        winrt::FocusNavigationReason::Programmatic));
+
     queue.RunEventLoop();
 
     controller.ShutdownQueue();

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/DrawingIsland.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/DrawingIsland.cpp
@@ -616,7 +616,19 @@ namespace winrt::DrawingIslandComponents::implementation
             m_items.Visuals.Remove(m_items.SelectedVisual);
             m_items.Visuals.InsertAtTop(m_items.SelectedVisual);
 
-            // TODO: The m_uia.FragmentRoots child should be removed and added to the end as well.
+            // Update automation.
+            // First find the existing automation peer.
+            auto iterator = std::find_if(
+                m_uia.AutomationPeers.begin(), m_uia.AutomationPeers.end(), [visual = m_items.SelectedVisual](auto const& automationPeer)
+                {
+                    return automationPeer.Match(visual);
+                });
+            if (m_uia.AutomationPeers.end() != iterator)
+            {
+                // Mirror the change to the visuals above.
+                m_uia.FragmentRoot->RemoveChild(iterator->GetAutomationProvider());
+                m_uia.FragmentRoot->AddChildToEnd(iterator->GetAutomationProvider());
+            }
         }
         else
         {

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/DrawingIsland.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/DrawingIsland.cpp
@@ -387,8 +387,7 @@ namespace winrt::DrawingIslandComponents::implementation
                 Input_OnPointerReleased();
             });
 
-        // Set up the keyboard source. We store this in a member variable so we can easily call 
-        // TrySetFocus() in response to left clicks in the content later on.
+        // Set up the keyboard source.
         m_input.KeyboardSource = winrt::InputKeyboardSource::GetForIsland(m_island);
 
         m_input.KeyboardSource.KeyDown(
@@ -508,6 +507,11 @@ namespace winrt::DrawingIslandComponents::implementation
             case winrt::Windows::System::VirtualKey::Escape:
             {
                 m_items.Visuals.RemoveAll();
+
+                // Update accessibility.
+                m_uia.FragmentRoot->RemoveAllChildren();
+                m_uia.AutomationPeers.clear();
+
                 handled = true;
                 break;
             }

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/DrawingIsland.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/DrawingIsland.cpp
@@ -56,8 +56,6 @@ namespace winrt::DrawingIslandComponents::implementation
 
     DrawingIsland::~DrawingIsland()
     {
-        m_uia.FragmentRoot = nullptr;
-        m_uia.FragmentFactory = nullptr;
         m_output.Compositor = nullptr;
     }
 
@@ -104,9 +102,18 @@ namespace winrt::DrawingIslandComponents::implementation
         }
 #endif
 
-        m_uia.FragmentFactory = nullptr;
-        m_uia.FragmentRoot = nullptr;
-        m_uia.VisualToFragmentMap.clear();
+        // Make sure automation is destroyed.
+        for (auto& automationPeer : m_uia.AutomationPeers)
+        {
+            automationPeer.GetAutomationProvider()->SetCallbackHandler(nullptr);
+        }
+        m_uia.AutomationPeers.clear();
+
+        if (nullptr != m_uia.FragmentRoot)
+        {
+            m_uia.FragmentRoot->SetCallbackHandler(nullptr);
+            m_uia.FragmentRoot = nullptr;
+        }
 
 
         // Destroy Content:
@@ -173,9 +180,105 @@ namespace winrt::DrawingIslandComponents::implementation
     }
 
 
+    winrt::Windows::Graphics::RectInt32
+    DrawingIsland::GetScreenBoundsForAutomationFragment(
+        _In_::IUnknown const* const sender) const
+    {
+        // Check if the automation provider that has sent this callback is the fragment root.
+        if (m_uia.FragmentRoot.as<::IUnknown>().get() == sender)
+        {
+            winrt::Rect logicalRect;
+            logicalRect.X = 0;
+            logicalRect.Y = 0;
+            logicalRect.Width = m_island.ActualSize().x;
+            logicalRect.Height = m_island.ActualSize().y;
+
+            // This will convert from the logical coordinate space of the ContentIsland to
+            // Win32 screen coordinates that are needed by Accessibility.
+            return m_island.CoordinateConverter().ConvertLocalToScreen(logicalRect);
+        }
+
+        // Else find the matching automation peer entry for the sending fragment.
+        auto iterator = std::find_if(
+            m_uia.AutomationPeers.begin(), m_uia.AutomationPeers.end(), [&sender](auto const& automationPeer)
+            {
+                return automationPeer.Match(sender);
+            });
+
+        if (m_uia.AutomationPeers.end() == iterator)
+        {
+            // Did not find any match for this automation provider.
+            return { 0, 0, 0, 0 };
+        }
+
+        auto const& visualPeer = iterator->GetVisual();
+        winrt::Rect logicalRect;
+        logicalRect.X = visualPeer.Offset().x;
+        logicalRect.Y = visualPeer.Offset().y;
+        logicalRect.Width = visualPeer.Size().x;
+        logicalRect.Height = visualPeer.Size().y;
+
+        // This will convert from the logical coordinate space of the ContentIsland to
+        // Win32 screen coordinates that are needed by Accessibility.
+        return m_island.CoordinateConverter().ConvertLocalToScreen(logicalRect);
+    }
+
+
+    winrt::com_ptr<IRawElementProviderFragment>
+    DrawingIsland::GetFragmentFromPoint(
+        _In_ double x,
+        _In_ double y) const
+    {
+        // UIA provides hit test points in screen space.
+        // Convert the point into a dummy empty rectangle to use with the coordinate converter.
+        winrt::Windows::Graphics::RectInt32 screenRect{ static_cast<int>(x + 0.5), static_cast<int>(y + 0.5), 0, 0 };
+        auto logicalRect = m_island.CoordinateConverter().ConvertScreenToLocal(screenRect);
+        float2 localPoint{ logicalRect.X, logicalRect.Y };
+        auto hitTestVisual = HitTestVisual(localPoint);
+
+        // Find the automation peer for the hit test visual if any.
+        if (nullptr != hitTestVisual)
+        {
+            auto iterator = std::find_if(
+                m_uia.AutomationPeers.begin(), m_uia.AutomationPeers.end(), [&hitTestVisual](auto const& automationPeer)
+                {
+                    return automationPeer.Match(hitTestVisual);
+                });
+
+            if (m_uia.AutomationPeers.end() != iterator)
+            {
+                // Return the automation provider if we found an automation peer for the hit test visual.
+                return iterator->GetAutomationProvider().as<IRawElementProviderFragment>();
+            }
+        }
+
+        return nullptr;
+    }
+
+
+    winrt::com_ptr<IRawElementProviderFragment>
+    DrawingIsland::GetFragmentInFocus() const
+    {
+        // Find the currently selected visual's automation peer.
+        auto iterator = std::find_if(
+            m_uia.AutomationPeers.begin(), m_uia.AutomationPeers.end(), [visual = m_items.SelectedVisual](auto const& automationPeer)
+            {
+                return automationPeer.Match(visual);
+            });
+
+        if (m_uia.AutomationPeers.end() != iterator)
+        {
+            // Return the automation provider if we found an automation peer for the selected visual.
+            return iterator->GetAutomationProvider().as<IRawElementProviderFragment>();
+        }
+
+        return nullptr;
+    }
+
+
     winrt::Visual
     DrawingIsland::HitTestVisual(
-        float2 const point)
+        float2 const& point) const
     {
         winrt::Visual selectedVisual{ nullptr };
         for (winrt::Visual visual : m_items.Visuals)
@@ -199,10 +302,13 @@ namespace winrt::DrawingIslandComponents::implementation
     void
     DrawingIsland::Accessibility_Initialize()
     {
-        m_uia.FragmentRoot = winrt::make_self<IslandFragmentRoot>(m_island);
+        // Create an UI automation fragment root for our island's content.
+        m_uia.FragmentRoot = winrt::make_self<IslandFragmentRoot>();
         m_uia.FragmentRoot->SetName(L"Drawing Squares");
-
-        m_uia.FragmentFactory = winrt::make_self<NodeSimpleFragmentFactory>();
+        m_uia.FragmentRoot->SetProviderOptions(
+            ProviderOptions_ServerSideProvider | ProviderOptions_UseComThreading | ProviderOptions_RefuseNonClientSupport);
+        m_uia.FragmentRoot->SetUiaControlTypeId(UIA_WindowControlTypeId);
+        m_uia.FragmentRoot->SetCallbackHandler(this);
 
         (void)m_island.AutomationProviderRequested(
             { this, &DrawingIsland::Accessibility_OnAutomationProviderRequested });
@@ -210,42 +316,37 @@ namespace winrt::DrawingIslandComponents::implementation
 
 
     void
-    DrawingIsland::Accessibility_CreateItemFragment()
+    DrawingIsland::Accessibility_CreateItemFragment(
+        const winrt::Visual& itemVisual)
     {
-        // Create a new fragment for the new item.
-        winrt::com_ptr<NodeSimpleFragment> fragment = m_uia.FragmentFactory->Create(
-            s_colorNames[m_output.CurrentColorIndex].c_str(), m_uia.FragmentRoot);
+        // Create a new automation fragment.
+        auto fragment = winrt::make_self<NodeSimpleFragment>();
+        fragment->SetName(s_colorNames[m_output.CurrentColorIndex].c_str());
+        fragment->SetCallbackHandler(this);
 
-        // Store the mapping between the Visual and the Fragment:
+        // Add an entry to our automation peers which is a mapping between the Visual and the Fragment:
         // - This is keeping the UIA objects alive.
         // - Although not used yet, the lookup would be used to get back to the item Fragment for
         //   specific operations, such as hit-testing or tree walking.  This avoids adding to more
         //   expensive data storage, such as the Visual.CustomProperties map.
+        m_uia.AutomationPeers.push_back(AutomationPeer{ itemVisual, fragment });
 
-        m_uia.VisualToFragmentMap[m_items.SelectedVisual] = fragment;
-
-        // Give the fragment a backpointer to the Visual to get real-time information.
-        fragment->SetVisual(m_items.SelectedVisual);
-
-        // Add the new fragment into the UIA tree.
-        m_uia.FragmentRoot->AddChild(fragment);
-
-        // Finally set up parent chain
-        fragment->SetParent(m_uia.FragmentRoot);
+        // Connect the automation fragment to our fragment root.
+        m_uia.FragmentRoot->AddChildToEnd(fragment);
     }
 
 
     void
     DrawingIsland::Accessibility_OnAutomationProviderRequested(
-        const winrt::ContentIsland& /*island*/,
+        const winrt::ContentIsland& island,
         const winrt::ContentIslandAutomationProviderRequestedEventArgs& args)
     {
-        IInspectable providerAsIInspectable;
-        m_uia.FragmentRoot->QueryInterface(
-            winrt::guid_of<IInspectable>(),
-            winrt::put_abi(providerAsIInspectable));
+        // Make sure the host provider is up to date.
+        m_uia.FragmentRoot->SetHostProvider(
+            island.GetAutomationHostProvider().as<IRawElementProviderSimple>());
 
-        args.AutomationProvider(std::move(providerAsIInspectable));
+        // Return the fragment root as an IInspectable.
+        args.AutomationProvider(m_uia.FragmentRoot.as<IInspectable>());
 
         args.Handled(true);
     }
@@ -644,7 +745,7 @@ namespace winrt::DrawingIslandComponents::implementation
         m_items.Offset.x = -BlockSize / 2.0f;
         m_items.Offset.y = -BlockSize / 2.0f;
 
-        Accessibility_CreateItemFragment();
+        Accessibility_CreateItemFragment(visual);
     }
 
 

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/IslandFragmentRoot.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/IslandFragmentRoot.cpp
@@ -4,300 +4,51 @@
 #include "pch.h"
 #include "IslandFragmentRoot.h"
 
-#include "NodeSimpleFragment.h"
-
-using unique_safearray = wil::unique_any<SAFEARRAY*, decltype(&::SafeArrayDestroy), ::SafeArrayDestroy>;
-
 namespace winrt::DrawingIslandComponents
 {
-    void
-    IslandFragmentRoot::AddChild(
-        winrt::com_ptr<NodeSimpleFragment> child)
+    HRESULT __stdcall IslandFragmentRoot::ElementProviderFromPoint(
+        _In_ double x,
+        _In_ double y,
+        _COM_Outptr_opt_result_maybenull_ IRawElementProviderFragment** fragment)
     {
-        m_children.push_back(child);
-    }
-
-    std::vector<winrt::com_ptr<NodeSimpleFragment>>
-    IslandFragmentRoot::GetChildren()
-    {
-        return m_children;
-    }
-
-    winrt::ContentIsland
-    IslandFragmentRoot::GetIsland()
-    {
-        return m_island;
-    }
-
-    void
-    IslandFragmentRoot::SetParent(
-        winrt::com_ptr<NodeSimpleFragment> parent)
-    {
-        m_parent = (parent);
-    }
-
-    void
-    IslandFragmentRoot::SetName(
-        std::wstring name)
-    {
-        m_name = std::move(name);
-    }
-
-    // IRawElementProviderSimple methods
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::get_ProviderOptions(
-        _Out_ ProviderOptions* retVal)
-    {
-        *retVal = ProviderOptions_ServerSideProvider | ProviderOptions_UseComThreading | ProviderOptions_RefuseNonClientSupport;
-        return S_OK;
-    }
-
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::GetPatternProvider(
-        PATTERNID /* idPattern */,
-        _Outptr_result_maybenull_ IUnknown** retVal) try
-    {
-        *retVal = nullptr;
-        return S_OK;
-    }
-    CATCH_RETURN();
-
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::GetPropertyValue(
-        PROPERTYID idProp,
-        _Out_ VARIANT* retVal) try
-    {
-        ::VariantInit(retVal);
-
-        switch (idProp)
+        try
         {
-        case UIA_NamePropertyId:
-        {
-            retVal->bstrVal = wil::make_bstr(m_name.c_str()).release();
-            retVal->vt = VT_BSTR;
-            break;
-        }
-
-        case UIA_IsContentElementPropertyId:
-        case UIA_IsControlElementPropertyId:
-            retVal->boolVal = VARIANT_TRUE;
-            retVal->vt = VT_BOOL;
-            break;
-
-        case UIA_ControlTypePropertyId:
-            retVal->vt = VT_I4;
-            retVal->lVal = UIA_WindowControlTypeId;
-            break;
-        }
-
-        return S_OK;
-    }
-    CATCH_RETURN();
-
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::get_HostRawElementProvider(
-        _Outptr_ IRawElementProviderSimple** retVal) try
-    {
-        *retVal = nullptr;
-
-        winrt::Windows::Foundation::IInspectable host = m_island.GetAutomationHostProvider();
-        *retVal = host.as<IRawElementProviderSimple>().detach();
-
-        return S_OK;
-    }
-    CATCH_RETURN();
-
-    winrt::com_ptr<IslandFragmentRoot>
-    IslandFragmentRoot::GetPreviousSibling()
-    {
-        winrt::com_ptr<IslandFragmentRoot> previous = nullptr;
-        if (m_parent != nullptr)
-        {
-            std::vector<winrt::com_ptr<IslandFragmentRoot>> siblings = m_parent->GetChildren();
-            int index = GetCurrentIndexFromSiblings(siblings);
- 
-            if (index != -1)
+            std::unique_lock lock{ m_mutex };
+            if (nullptr != fragment)
             {
-                if (index > 0)
+                *fragment = nullptr;
+
+                // This provider might still be alive in a UIA callback when the DrawingIsland is being torn down.
+                // Make sure we still have a valid owner before proceeding to query the DrawingIsland for this information.
+                if (nullptr != m_ownerNoRef)
                 {
-                    previous = siblings[index - 1];
+                    m_ownerNoRef->GetFragmentFromPoint(x, y).copy_to(fragment);
                 }
             }
         }
-        return previous;
+        catch (...) { return UIA_E_ELEMENTNOTAVAILABLE; }
+        return S_OK;
     }
 
-    winrt::com_ptr<IslandFragmentRoot>
-    IslandFragmentRoot::GetNextSibling()
+    HRESULT __stdcall IslandFragmentRoot::GetFocus(
+        _COM_Outptr_opt_result_maybenull_ IRawElementProviderFragment** fragmentInFocus)
     {
-        winrt::com_ptr<IslandFragmentRoot> next = nullptr;
-        if (m_parent != nullptr)
+        try
         {
-            std::vector<winrt::com_ptr<IslandFragmentRoot>> siblings = m_parent->GetChildren();
-            int index = GetCurrentIndexFromSiblings(siblings);
-
-            if (index != -1)
+            std::unique_lock lock{ m_mutex };
+            if (nullptr != fragmentInFocus)
             {
-                if ((index+1) < static_cast<int>(siblings.size()))
+                *fragmentInFocus = nullptr;
+
+                // This provider might still be alive in a UIA callback when the DrawingIsland is being torn down.
+                // Make sure we still have a valid owner before proceeding to query the DrawingIsland for this information.
+                if (nullptr != m_ownerNoRef)
                 {
-                    next = siblings[index + 1];
+                    m_ownerNoRef->GetFragmentInFocus().copy_to(fragmentInFocus);
                 }
             }
         }
-        return next;
-    }
-
-    int
-    IslandFragmentRoot::GetCurrentIndexFromSiblings(
-        std::vector<winrt::com_ptr<IslandFragmentRoot>> siblings)
-    {
-        auto it = find_if(
-                    siblings.begin(),
-                    siblings.end(),
-                    [this](const winrt::com_ptr<IslandFragmentRoot>& v) -> bool { return (v.get() == this); });
-
-        int index = -1;
-        if (it != siblings.end())
-        {
-            index = (int)(it - siblings.begin());
-        }
-
-        return index;
-    }
- 
-    // IRawElementProviderFragment methods
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::Navigate(
-        NavigateDirection direction,
-        _Outptr_result_maybenull_ IRawElementProviderFragment** retVal)
-    {
-        direction;
-        *retVal = nullptr;
-
-        winrt::com_ptr<IRawElementProviderFragment> element;
-
-        switch (direction)
-        {
-        case NavigateDirection_Parent:
-            if (m_parent)
-            {
-                element = m_parent.as<IRawElementProviderFragment>();
-            }
-            break;
-
-        case NavigateDirection_FirstChild:
-            if (!m_children.empty())
-            {
-                element = m_children.front().as<IRawElementProviderFragment>();
-            }
-            break;
-
-        case NavigateDirection_LastChild:
-            if (!m_children.empty())
-            {
-                element = m_children.back().as<IRawElementProviderFragment>();
-            }
-            break;
-
-        case NavigateDirection_NextSibling:
-        {
-            winrt::com_ptr<IslandFragmentRoot> nextSibling = GetNextSibling();
-            if (nextSibling)
-            {
-                element = nextSibling.as<IRawElementProviderFragment>();
-            }
-        }
-        break;
-
-        case NavigateDirection_PreviousSibling:
-        {
-            winrt::com_ptr<IslandFragmentRoot> previousSibling = GetPreviousSibling();
-            if (previousSibling)
-            {
-                element = previousSibling.as<IRawElementProviderFragment>();
-            }
-            break;
-        }
-        }
-
-        if (element)
-        {
-
-            *retVal = element.as<IRawElementProviderFragment>().detach();
-        }
-
+        catch (...) { return UIA_E_ELEMENTNOTAVAILABLE; }
         return S_OK;
     }
-
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::GetRuntimeId(
-        _Outptr_ SAFEARRAY** retVal) try
-    {
-        *retVal = nullptr;
-        std::array<int, 2> runtimeId = { UiaAppendRuntimeId, 0x1 };
-
-        unique_safearray runtimeIdArray{ ::SafeArrayCreateVector(
-            VT_I4,
-            0,
-            static_cast<unsigned long>(runtimeId.size())) };
-        THROW_HR_IF_NULL(E_FAIL, runtimeIdArray.get());
-        for (long i = 0; i < static_cast<long>(runtimeId.size()); ++i)
-        {
-            ::SafeArrayPutElement(runtimeIdArray.get(), &i, &runtimeId[i]);
-        }
-
-        *retVal = runtimeIdArray.release();
-        return S_OK;
-    }
-    CATCH_RETURN();
-
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::get_BoundingRectangle(
-        _Out_ UiaRect* /*retVal*/)
-    {
-        return S_OK;
-    }
-
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::GetEmbeddedFragmentRoots(
-        _Outptr_result_maybenull_ SAFEARRAY** retVal)
-    {
-        *retVal = nullptr;
-        return S_OK;
-    }
-
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::SetFocus()
-    {
-        return S_OK;
-    }
-
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::get_FragmentRoot(
-        _Outptr_ IRawElementProviderFragmentRoot** retVal)
-    {
-        *retVal = nullptr;
-        RETURN_IF_FAILED(QueryInterface(IID_PPV_ARGS(retVal)));
-        return S_OK;
-    }
-
-    // IRawElementProviderFragmentRoot methods
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::ElementProviderFromPoint(
-        double /* x */,
-        double /* y */,
-        _Outptr_result_maybenull_ IRawElementProviderFragment** retVal)
-    {
-        *retVal = nullptr;
-        return S_OK;
-    }
-
-    HRESULT STDMETHODCALLTYPE
-    IslandFragmentRoot::GetFocus(
-        _Outptr_result_maybenull_ IRawElementProviderFragment** retVal)
-    {
-        *retVal = nullptr;
-        return S_OK;
-    }
-
 }

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/IslandFragmentRoot.h
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/IslandFragmentRoot.h
@@ -2,92 +2,21 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include "NodeSimpleFragment.h"
 
 namespace winrt::DrawingIslandComponents
 {
-    class NodeSimpleFragment;
-
-    class IslandFragmentRoot  :
-        public winrt::implements<IslandFragmentRoot,
-                                 IRawElementProviderSimple,
-                                 IRawElementProviderFragment,
-                                 IRawElementProviderFragmentRoot,
-                                 IInspectable>
+    struct IslandFragmentRoot : winrt::implements<IslandFragmentRoot,
+        NodeSimpleFragment,
+        IRawElementProviderFragmentRoot>
     {
-    public:
-        explicit IslandFragmentRoot(
-            winrt::ContentIsland island) : m_island(island) {}
+        // IRawElementProviderFragmentRoot overrides.
+        HRESULT __stdcall ElementProviderFromPoint(
+            _In_ double x,
+            _In_ double y,
+            _COM_Outptr_opt_result_maybenull_ IRawElementProviderFragment** fragment) final override;
 
-        void AddChild(
-            winrt::com_ptr<NodeSimpleFragment> child);
-
-        std::vector<winrt::com_ptr<NodeSimpleFragment>> GetChildren();
-
-        void SetParent(
-            winrt::com_ptr<NodeSimpleFragment> parent);
-
-        void SetName(
-            std::wstring name);
-
-        winrt::ContentIsland GetIsland();
-
-        // IRawElementProviderSimple methods
-        HRESULT STDMETHODCALLTYPE get_ProviderOptions(
-            _Out_ ProviderOptions* retVal) override final;
-
-        HRESULT STDMETHODCALLTYPE GetPatternProvider(
-            PATTERNID /* idPattern */,
-            _Outptr_result_maybenull_ IUnknown** retVal) override final;
-
-        HRESULT STDMETHODCALLTYPE GetPropertyValue(
-            PROPERTYID idProp,
-            _Out_ VARIANT* retVal) override final;
-
-        HRESULT STDMETHODCALLTYPE get_HostRawElementProvider(
-            _Outptr_ IRawElementProviderSimple** retVal) override final;
- 
-        // IRawElementProviderFragment methods
-        HRESULT STDMETHODCALLTYPE Navigate(
-            NavigateDirection direction,
-            _Outptr_result_maybenull_ IRawElementProviderFragment** retVal) override final;
-
-        HRESULT STDMETHODCALLTYPE GetRuntimeId(
-            _Outptr_ SAFEARRAY** retVal) override final;
-
-        HRESULT STDMETHODCALLTYPE get_BoundingRectangle(
-            _Out_ UiaRect* retVal) override final;
-
-        HRESULT STDMETHODCALLTYPE GetEmbeddedFragmentRoots(
-            _Outptr_result_maybenull_ SAFEARRAY** retVal) override final;
-
-        HRESULT STDMETHODCALLTYPE SetFocus() override final;
-
-        HRESULT STDMETHODCALLTYPE get_FragmentRoot(
-            _Outptr_ IRawElementProviderFragmentRoot** retVal) override final;
-
-        // IRawElementProviderFragmentRoot methods
-        HRESULT STDMETHODCALLTYPE ElementProviderFromPoint(
-            double /* x */,
-            double /* y */,
-            _Outptr_result_maybenull_ IRawElementProviderFragment** retVal) override final;
-
-        HRESULT STDMETHODCALLTYPE GetFocus(
-            _Outptr_result_maybenull_ IRawElementProviderFragment** retVal) override final;
-
-    private:
-        // Helper methods
-        winrt::com_ptr<IslandFragmentRoot> GetPreviousSibling();
-
-        winrt::com_ptr<IslandFragmentRoot> GetNextSibling();
-
-        int GetCurrentIndexFromSiblings(
-            std::vector<winrt::com_ptr<IslandFragmentRoot>> siblings);
-
-    private:
-        HWND m_hwnd{};
-        winrt::ContentIsland m_island{ nullptr };
-        std::wstring m_name;
-        std::vector<winrt::com_ptr<NodeSimpleFragment>> m_children;
-        winrt::com_ptr<NodeSimpleFragment> m_parent;
+        HRESULT __stdcall GetFocus(
+            _COM_Outptr_opt_result_maybenull_ IRawElementProviderFragment** fragmentInFocus) final override;
     };
 }

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/NodeSimpleFragment.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/NodeSimpleFragment.cpp
@@ -4,291 +4,436 @@
 #include "pch.h"
 #include "NodeSimpleFragment.h"
 
-#include "IslandFragmentRoot.h"
-
 using unique_safearray = wil::unique_any<SAFEARRAY*, decltype(&::SafeArrayDestroy), ::SafeArrayDestroy>;
 
 namespace winrt::DrawingIslandComponents
 {
-    NodeSimpleFragment::NodeSimpleFragment(
-        _In_z_ const wchar_t* name,
-        int id) :
-        m_name(name),
-        m_id(id)
+    void NodeSimpleFragment::AddChildToEnd(
+        _In_ winrt::com_ptr<NodeSimpleFragment> const& child)
     {
-    }
+        std::unique_lock lock{ m_mutex };
 
-    void
-    NodeSimpleFragment::AddChild(
-        const winrt::com_ptr<IslandFragmentRoot> & child)
-    {
+        if (nullptr == child)
+        {
+            // Nothing to do.
+            return;
+        }
+
+        // The child should not already have a parent.
+        winrt::check_bool(nullptr == child->GetParent());
+
+        // Set us up as the parent for the new child.
+        child->SetParent(get_weak());
+
+        // Set up the sibling relationships.
+        if (!m_children.empty())
+        {
+            auto& previousSiblingForNewChild = m_children.back();
+            previousSiblingForNewChild->SetNextSibling(child);
+            child->SetPreviousSibling(previousSiblingForNewChild);
+        }
+
+        // Finally add the child.
         m_children.push_back(child);
     }
 
-    std::vector<winrt::com_ptr<IslandFragmentRoot>>
-    NodeSimpleFragment::GetChildren()
+    void NodeSimpleFragment::RemoveChild(
+        _In_ winrt::com_ptr<NodeSimpleFragment> const& child)
     {
-        return m_children;
-    }
+        std::unique_lock lock{ m_mutex };
 
-    void
-    NodeSimpleFragment::SetVisual(
-        const winrt::Visual & visual)
-    {
-        m_visual = visual;
-    }
-
-    void
-    NodeSimpleFragment::SetParent(
-        const winrt::com_ptr<IslandFragmentRoot> & parent)
-    {
-        m_parent = (parent);
-    }
-
-    // IRawElementProviderSimple methods
-    IFACEMETHODIMP
-    NodeSimpleFragment::get_ProviderOptions(
-        _Out_ ProviderOptions* retVal)
-    {
-        *retVal = (ProviderOptions_ServerSideProvider | ProviderOptions_UseComThreading);
-        return S_OK;
-    }
-
-    IFACEMETHODIMP
-    NodeSimpleFragment::GetPatternProvider(
-        PATTERNID /*patternId*/,
-        _Outptr_ IUnknown** retVal) try
-    {
-        *retVal = nullptr;
-        return S_OK;
-    }
-    CATCH_RETURN();
-
-    IFACEMETHODIMP
-    NodeSimpleFragment::GetPropertyValue(
-        PROPERTYID propertyId,
-        _Out_ VARIANT* retVal) try
-    {
-        ::VariantInit(retVal);
-
-        if (propertyId == UIA_NamePropertyId)
+        if (nullptr == child)
         {
-            retVal->bstrVal = wil::make_bstr(m_name.c_str()).release();
-            retVal->vt = VT_BSTR;
+            // Nothing to do.
+            return;
         }
 
-        return S_OK;
-    }
-    CATCH_RETURN();
-
-    IFACEMETHODIMP
-    NodeSimpleFragment::get_HostRawElementProvider(
-        _Outptr_ IRawElementProviderSimple** retVal)
-    {
-        *retVal = nullptr;
-        return S_OK;
-    }
-
-    winrt::com_ptr<NodeSimpleFragment>
-    NodeSimpleFragment::GetPreviousSibling()
-    {
-        winrt::com_ptr<NodeSimpleFragment> previous = nullptr;
-        if (m_parent != nullptr)
-        {
-            std::vector<winrt::com_ptr<NodeSimpleFragment>> siblings = m_parent->GetChildren();
-            int index = GetCurrentIndexFromSiblings(siblings);
-
-            if (index != -1)
+        auto iterator = std::find_if(m_children.begin(), m_children.end(), [&child](auto const& childEntry)
             {
-                if (index > 0)
+                // See if we find a matching child entry in our children.
+                return (childEntry.get() == child.get());
+            });
+
+        // We cannot remove a child that isn't ours.
+        winrt::check_bool(m_children.end() != iterator);
+
+        // Remove us from the parent relationship with the child.
+        child->SetParent(nullptr);
+
+        // Reset the sibling relationships.
+        auto previousSibling = child->GetPreviousSibling();
+        auto nextSibling = child->GetNextSibling();
+        if (nullptr != previousSibling)
+        {
+            previousSibling->SetNextSibling(nextSibling);
+        }
+        if (nullptr != nextSibling)
+        {
+            nextSibling->SetPreviousSibling(previousSibling);
+        }
+        child->SetPreviousSibling(nullptr);
+        child->SetNextSibling(nullptr);
+
+        // Finally, remove the child.
+        m_children.erase(iterator);
+    }
+
+    void NodeSimpleFragment::SetCallbackHandler(
+        _In_opt_ IAutomationCallbackHandler const* const owner)
+    {
+        std::unique_lock lock{ m_mutex };
+        m_ownerNoRef = owner;
+    }
+
+    void NodeSimpleFragment::SetProviderOptions(
+        _In_ ProviderOptions const& providerOptions)
+    {
+        std::unique_lock lock{ m_mutex };
+        m_providerOptions = providerOptions;
+    }
+
+    void NodeSimpleFragment::SetName(
+        _In_ std::wstring_view const& name)
+    {
+        std::unique_lock lock{ m_mutex };
+        m_name = name;
+    }
+
+    void NodeSimpleFragment::SetIsContent(
+        _In_ bool const& isContent)
+    {
+        std::unique_lock lock{ m_mutex };
+        m_isContent = isContent;
+    }
+
+    void NodeSimpleFragment::SetIsControl(
+        _In_ bool const& isControl)
+    {
+        std::unique_lock lock{ m_mutex };
+        m_isControl = isControl;
+    }
+
+    void NodeSimpleFragment::SetUiaControlTypeId(
+        _In_ long const& uiaControlTypeId)
+    {
+        std::unique_lock lock{ m_mutex };
+        m_uiaControlTypeId = uiaControlTypeId;
+    }
+
+    void NodeSimpleFragment::SetHostProvider(
+        _In_ winrt::com_ptr<IRawElementProviderSimple> const& hostProvider)
+    {
+        std::unique_lock lock{ m_mutex };
+        m_hostProvider = hostProvider;
+    }
+
+    HRESULT __stdcall NodeSimpleFragment::get_ProviderOptions(
+        _Out_ ProviderOptions* providerOptions)
+    {
+        try
+        {
+            std::unique_lock lock{ m_mutex };
+            if (nullptr != providerOptions)
+            {
+                *providerOptions = m_providerOptions;
+            }
+        }
+        catch (...) { return UIA_E_ELEMENTNOTAVAILABLE; }
+        return S_OK;
+    }
+
+    HRESULT __stdcall NodeSimpleFragment::GetPatternProvider(
+        _In_ PATTERNID patternId,
+        _COM_Outptr_opt_result_maybenull_ IUnknown** patternProvider)
+    {
+        try
+        {
+            std::unique_lock lock{ m_mutex };
+            if (nullptr != patternProvider)
+            {
+                *patternProvider = nullptr;
+                switch (patternId)
                 {
-                    previous = siblings[index - 1];
+                case UIA_InvokePatternId:
+                {
+                    if (auto invokeProvider = get_strong().try_as<IInvokeProvider>())
+                    {
+                        invokeProvider.as<IUnknown>().copy_to(patternProvider);
+                    }
+                    break;
+                }
                 }
             }
         }
-        return previous;
+        catch (...) { return UIA_E_ELEMENTNOTAVAILABLE; }
+        return S_OK;
     }
 
-    winrt::com_ptr<NodeSimpleFragment>
-    NodeSimpleFragment::GetNextSibling()
+    HRESULT __stdcall NodeSimpleFragment::GetPropertyValue(
+        _In_ PROPERTYID propertyId,
+        _Out_ VARIANT* propertyValue)
     {
-        winrt::com_ptr<NodeSimpleFragment> next = nullptr;
-        if (m_parent != nullptr)
+        try
         {
-            std::vector<winrt::com_ptr<NodeSimpleFragment>> siblings = m_parent->GetChildren();
-            int index = GetCurrentIndexFromSiblings(siblings);
-
-            if (index != -1)
+            std::unique_lock lock{ m_mutex };
+            if (nullptr != propertyValue)
             {
-                if ((index + 1) < static_cast<int>(siblings.size()))
+                ::VariantInit(propertyValue);
+                switch (propertyId)
                 {
-                    next = siblings[index + 1];
+                case UIA_NamePropertyId:
+                {
+                    propertyValue->bstrVal = wil::make_bstr(m_name.c_str()).release();
+                    propertyValue->vt = VT_BSTR;
+                    break;
+                }
+
+                case UIA_IsContentElementPropertyId:
+                {
+                    propertyValue->boolVal = m_isContent ? VARIANT_TRUE : VARIANT_FALSE;
+                    propertyValue->vt = VT_BOOL;
+                    break;
+                }
+
+                case UIA_IsControlElementPropertyId:
+                {
+                    propertyValue->boolVal = m_isControl ? VARIANT_TRUE : VARIANT_FALSE;
+                    propertyValue->vt = VT_BOOL;
+                    break;
+                }
+
+                case UIA_ControlTypePropertyId:
+                {
+                    if (m_isControl)
+                    {
+                        propertyValue->vt = VT_I4;
+                        propertyValue->lVal = m_uiaControlTypeId;
+                    }
+                    break;
+                }
                 }
             }
         }
-        return next;
+        catch (...) { return UIA_E_ELEMENTNOTAVAILABLE; }
+        return S_OK;
     }
 
-    int
-    NodeSimpleFragment::GetCurrentIndexFromSiblings(
-        std::vector<winrt::com_ptr<NodeSimpleFragment>> siblings)
+    HRESULT __stdcall NodeSimpleFragment::get_HostRawElementProvider(
+        _COM_Outptr_opt_result_maybenull_ IRawElementProviderSimple** hostRawElementProviderSimple)
     {
-        auto it = std::find_if(
-                    siblings.begin(),
-                    siblings.end(),
-                    [this](const winrt::com_ptr<NodeSimpleFragment>& v) -> bool { return (v.get() == this); });
-
-        int index = -1;
-        if (it != siblings.end())
+        try
         {
-            index = (int)(it - siblings.begin());
+            std::unique_lock lock{ m_mutex };
+            if (nullptr != hostRawElementProviderSimple)
+            {
+                m_hostProvider.copy_to(hostRawElementProviderSimple);
+            }
         }
-
-        return index;
+        catch (...) { return UIA_E_ELEMENTNOTAVAILABLE; }
+        return S_OK;
     }
 
-    // IRawElementProviderFragment methods
-    IFACEMETHODIMP
-    NodeSimpleFragment::Navigate(
+    HRESULT __stdcall NodeSimpleFragment::Navigate(
         _In_ NavigateDirection direction,
-        _Outptr_ IRawElementProviderFragment** retVal) try
+        _COM_Outptr_opt_result_maybenull_ IRawElementProviderFragment** fragment)
     {
-        *retVal = nullptr;
-
-        winrt::com_ptr<IRawElementProviderFragment> result;
-        switch (direction)
+        try
         {
-        case NavigateDirection_Parent:
-            if (m_parent)
+            std::unique_lock lock{ m_mutex };
+            if (nullptr != fragment)
             {
-                result = m_parent.as<IRawElementProviderFragment>();
-            }
-            break;
-
-        case NavigateDirection_FirstChild:
-            if (!m_children.empty())
-            {
-                result = m_children.front().as<IRawElementProviderFragment>();
-            }
-            break;
-
-        case NavigateDirection_LastChild:
-            if (!m_children.empty())
-            {
-                result = m_children.back().as<IRawElementProviderFragment>();
-            }
-            break;
-
-        case NavigateDirection_NextSibling:
-            {
-                winrt::com_ptr<NodeSimpleFragment> nextSibling = GetNextSibling();
-                if (nextSibling)
+                *fragment = nullptr;
+                switch (direction)
                 {
-                    result = nextSibling.as<IRawElementProviderFragment>();
+                case NavigateDirection_Parent:
+                {
+                    if (auto strongParent = m_parent.get())
+                    {
+                        strongParent.as<IRawElementProviderFragment>().copy_to(fragment);
+                    }
+                    break;
+                }
+                case NavigateDirection_NextSibling:
+                {
+                    if (auto strongSibling = m_nextSibling.get())
+                    {
+                        strongSibling.as<IRawElementProviderFragment>().copy_to(fragment);
+                    }
+                    break;
+                }
+                case NavigateDirection_PreviousSibling:
+                {
+                    if (auto strongSibling = m_previousSibling.get())
+                    {
+                        strongSibling.as<IRawElementProviderFragment>().copy_to(fragment);
+                    }
+                    break;
+                }
+                case NavigateDirection_FirstChild:
+                {
+                    if (!m_children.empty())
+                    {
+                        m_children.front().as<IRawElementProviderFragment>().copy_to(fragment);
+                    }
+                    break;
+                }
+                case NavigateDirection_LastChild:
+                {
+                    if (!m_children.empty())
+                    {
+                        m_children.back().as<IRawElementProviderFragment>().copy_to(fragment);
+                    }
+                    break;
+                }
                 }
             }
-            break;
+        }
+        catch (...) { return UIA_E_ELEMENTNOTAVAILABLE; }
+        return S_OK;
+    }
 
-        case NavigateDirection_PreviousSibling:
+    HRESULT __stdcall NodeSimpleFragment::GetRuntimeId(
+        _Outptr_opt_result_maybenull_ SAFEARRAY** runtimeId)
+    {
+        try
+        {
+            std::unique_lock lock{ m_mutex };
+            if (nullptr != runtimeId)
             {
-                winrt::com_ptr<NodeSimpleFragment> previousSibling = GetPreviousSibling();
-                if (previousSibling)
+                *runtimeId = nullptr;
+
+                std::array<unsigned __int32, 2> id{ UiaAppendRuntimeId, m_internalRuntimeId };
+                unsigned long arraySizeAsUnsignedLong = static_cast<unsigned long>(id.size());
+
+                unique_safearray runtimeIdArray{ ::SafeArrayCreateVector(VT_I4, 0, arraySizeAsUnsignedLong) };
+                SAFEARRAY* rawPointerToSafeArray = runtimeIdArray.get();
+                winrt::check_pointer(rawPointerToSafeArray);
+
+                for (long i = 0; i < static_cast<long>(arraySizeAsUnsignedLong); ++i)
                 {
-                    result = previousSibling.as<IRawElementProviderFragment>();
+                    winrt::check_hresult(::SafeArrayPutElement(rawPointerToSafeArray, &i, &(id[i])));
+                }
+
+                *runtimeId = runtimeIdArray.release();
+            }
+        }
+        catch (...) { return UIA_E_ELEMENTNOTAVAILABLE; }
+        return S_OK;
+    }
+
+    HRESULT __stdcall NodeSimpleFragment::get_BoundingRectangle(
+        _Out_ UiaRect* boundingRectangle)
+    {
+        try
+        {
+            std::unique_lock lock{ m_mutex };
+            if (nullptr != boundingRectangle)
+            {
+                *boundingRectangle = { 0, 0, 0, 0 };
+
+                // This provider might still be alive in a UIA callback when the DrawingIsland is being torn down.
+                // Make sure we still have a valid owner before proceeding to query the DrawingIsland for this information.
+                if (nullptr != m_ownerNoRef)
+                {
+                    auto screenRectangle =
+                        m_ownerNoRef->GetScreenBoundsForAutomationFragment(get_strong().as<::IUnknown>().get());
+
+                    boundingRectangle->left = screenRectangle.X;
+                    boundingRectangle->top = screenRectangle.Y;
+                    boundingRectangle->width = screenRectangle.Width;
+                    boundingRectangle->height = screenRectangle.Height;
                 }
             }
-            break;
-
         }
-
-        *retVal = result.detach();
+        catch (...) { return UIA_E_ELEMENTNOTAVAILABLE; }
         return S_OK;
     }
-    CATCH_RETURN();
 
-    IFACEMETHODIMP
-    NodeSimpleFragment::GetRuntimeId(
-        _Outptr_ SAFEARRAY** retVal)
+    HRESULT __stdcall NodeSimpleFragment::GetEmbeddedFragmentRoots(
+        _Outptr_opt_result_maybenull_ SAFEARRAY** embeddedFragmentRoots)
     {
-        *retVal = nullptr;
-
-        std::array<int, 2> runtimeId = { UiaAppendRuntimeId, m_id };
-
-        unique_safearray runtimeIdArray{ ::SafeArrayCreateVector(
-                VT_I4,
-                0,
-                static_cast<unsigned long>(runtimeId.size())) };
-        THROW_HR_IF_NULL(E_FAIL, runtimeIdArray.get());
-        for (long i = 0; i < static_cast<long>(runtimeId.size()); ++i)
+        if (nullptr != embeddedFragmentRoots)
         {
-            ::SafeArrayPutElement(runtimeIdArray.get(), &i, &runtimeId[i]);
+            *embeddedFragmentRoots = nullptr;
         }
-
-        *retVal = runtimeIdArray.release();
         return S_OK;
     }
 
-    IFACEMETHODIMP
-    NodeSimpleFragment::get_BoundingRectangle(
-        _Out_ UiaRect* retVal)
+    HRESULT __stdcall NodeSimpleFragment::SetFocus()
     {
-        if (retVal == NULL) return E_INVALIDARG;
+        return S_OK;
+    }
 
-
-        // Convert from local coordinates to screen coordinates for UIA:
-        // - The computation is done in real-time rather than caching because most of the time,
-        //   UIA won't be executing, or won't be asking for updated coordinates on every object
-        //   move.
-        // - This could use a more elaborate caching mechanism to detect dirtiness if performance
-        //   was an issue.
-
-        winrt::ContentIsland island = m_parent->GetIsland();
-
-        winrt::Windows::Foundation::Rect rect =
+    HRESULT __stdcall NodeSimpleFragment::get_FragmentRoot(
+        _COM_Outptr_opt_result_maybenull_ IRawElementProviderFragmentRoot** fragmentRoot)
+    {
+        try
         {
-            m_visual.Offset().x,
-            m_visual.Offset().y,
-            m_visual.Size().x,
-            m_visual.Size().y
-        };
+            std::unique_lock lock{ m_mutex };
+            if (nullptr != fragmentRoot)
+            {
+                *fragmentRoot = nullptr;
 
-        winrt::Windows::Graphics::RectInt32 rectInt32 =
-            island.CoordinateConverter().ConvertLocalToScreen(rect);
+                // Walk up our fragment tree until we find our fragment root.
+                auto fragmentRootCandidate = get_strong();
+                bool currentCandidateIsThisObject = true;
+                while (nullptr != fragmentRootCandidate && nullptr == fragmentRootCandidate.try_as<IRawElementProviderFragmentRoot>())
+                {
+                    // Haven't found the fragment root yet, keep walking up our tree.
+                    fragmentRootCandidate = currentCandidateIsThisObject ?
+                        m_parent.get() : fragmentRootCandidate->GetParent();
 
-        retVal->left = rectInt32.X;
-        retVal->top = rectInt32.Y;
-        retVal->width = rectInt32.Width;
-        retVal->height = rectInt32.Height;
+                    // Once we start walking up the tree, we must ensure we're thread-safe and call through GetParent on the other objects.
+                    currentCandidateIsThisObject = false;
+                }
 
-        return S_OK;
-    }
-
-    IFACEMETHODIMP
-    NodeSimpleFragment::GetEmbeddedFragmentRoots(
-        _Outptr_ SAFEARRAY** retVal)
-    {
-        *retVal = nullptr;
-        return S_OK;
-    }
-
-    IFACEMETHODIMP
-    NodeSimpleFragment::SetFocus()
-    {
-        return S_OK;
-    }
-
-    IFACEMETHODIMP
-    NodeSimpleFragment::get_FragmentRoot(
-        _Outptr_ IRawElementProviderFragmentRoot** retVal) try
-    {
-        if (m_parent)
-        {
-            winrt::com_ptr<IRawElementProviderFragmentRoot> result = m_parent.as<IRawElementProviderFragmentRoot>();
-            *retVal = result.detach();
+                if (nullptr != fragmentRootCandidate)
+                {
+                    // Found the fragment root, return it.
+                    fragmentRootCandidate.as<IRawElementProviderFragmentRoot>().copy_to(fragmentRoot);
+                }
+            }
         }
-
+        catch (...) { return UIA_E_ELEMENTNOTAVAILABLE; }
         return S_OK;
     }
-    CATCH_RETURN();
 
+    void NodeSimpleFragment::SetParent(
+        _In_ winrt::weak_ref<NodeSimpleFragment> const& parent)
+    {
+        std::unique_lock lock{ m_mutex };
+        m_parent = parent;
+    }
+
+    winrt::com_ptr<NodeSimpleFragment> NodeSimpleFragment::GetParent() const
+    {
+        std::unique_lock lock{ m_mutex };
+        return m_parent.get();
+    }
+
+    void NodeSimpleFragment::SetPreviousSibling(
+        _In_ winrt::weak_ref<NodeSimpleFragment> const& previousSibling)
+    {
+        std::unique_lock lock{ m_mutex };
+        m_previousSibling = previousSibling;
+    }
+
+    winrt::com_ptr<NodeSimpleFragment> NodeSimpleFragment::GetPreviousSibling() const
+    {
+        std::unique_lock lock{ m_mutex };
+        return m_previousSibling.get();
+    }
+
+    void NodeSimpleFragment::SetNextSibling(
+        _In_ winrt::weak_ref<NodeSimpleFragment> const& nextSibling)
+    {
+        std::unique_lock lock{ m_mutex };
+        m_nextSibling = nextSibling;
+    }
+
+    winrt::com_ptr<NodeSimpleFragment> NodeSimpleFragment::GetNextSibling() const
+    {
+        std::unique_lock lock{ m_mutex };
+        return m_nextSibling.get();
+    }
 }

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/NodeSimpleFragment.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/NodeSimpleFragment.cpp
@@ -48,7 +48,8 @@ namespace winrt::DrawingIslandComponents
             return;
         }
 
-        auto iterator = std::find_if(m_children.begin(), m_children.end(), [&child](auto const& childEntry)
+        auto iterator = std::find_if(
+            m_children.begin(), m_children.end(), [&child](auto const& childEntry)
             {
                 // See if we find a matching child entry in our children.
                 return (childEntry.get() == child.get());
@@ -76,6 +77,22 @@ namespace winrt::DrawingIslandComponents
 
         // Finally, remove the child.
         m_children.erase(iterator);
+    }
+
+    void NodeSimpleFragment::RemoveAllChildren()
+    {
+        std::unique_lock lock{ m_mutex };
+
+        for (auto& child : m_children)
+        {
+            // Disconnect the relationships from all our children.
+            child->SetParent(nullptr);
+            child->SetPreviousSibling(nullptr);
+            child->SetNextSibling(nullptr);
+        }
+
+        // Remove all the children.
+        m_children.clear();
     }
 
     void NodeSimpleFragment::SetCallbackHandler(

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/NodeSimpleFragment.h
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/NodeSimpleFragment.h
@@ -2,108 +2,129 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include <mutex>
 
 namespace winrt::DrawingIslandComponents
 {
-    class IslandFragmentRoot;
-
-    class NodeSimpleFragment :
-        public winrt::implements<NodeSimpleFragment,
-                                 IRawElementProviderSimple,
-                                 IRawElementProviderFragment>
+    struct __declspec(novtable) IAutomationCallbackHandler
     {
-    public:
-        NodeSimpleFragment(
-            _In_z_ const wchar_t* name,
-            int id);
+        virtual ~IAutomationCallbackHandler() noexcept = default;
 
-        void AddChild(
-            const winrt::com_ptr<IslandFragmentRoot> & child);
+        virtual winrt::Windows::Graphics::RectInt32 GetScreenBoundsForAutomationFragment(
+            _In_ ::IUnknown const* const sender) const = 0;
 
-        std::vector<winrt::com_ptr<IslandFragmentRoot>> GetChildren();
+        virtual winrt::com_ptr<IRawElementProviderFragment> GetFragmentFromPoint(
+            _In_ double x,
+            _In_ double y) const = 0;
 
-        void SetId(
-            int id);
-
-        void SetVisual(
-            const winrt::Visual & visual);
-
-        void SetName(
-            const std::wstring& name)
-        {
-            m_name = name;
-        }
-
-        void SetParent(
-            const winrt::com_ptr<IslandFragmentRoot> & parent);
-
-        // IRawElementProviderSimple methods
-        IFACEMETHODIMP get_ProviderOptions(
-            _Out_ ProviderOptions* retVal) override final;
-
-        IFACEMETHODIMP GetPatternProvider(
-            PATTERNID patternId,
-            _Outptr_ IUnknown** retVal) override final;
-
-        IFACEMETHODIMP GetPropertyValue(
-            PROPERTYID propertyId,
-            _Out_ VARIANT* retVal) override final;
-
-        IFACEMETHODIMP get_HostRawElementProvider(
-            _Outptr_ IRawElementProviderSimple** retVal) override final;
-
-        // IRawElementProviderFragment methods
-        IFACEMETHODIMP Navigate(
-            _In_ NavigateDirection direction,
-            _Outptr_ IRawElementProviderFragment** retVal) override final;
-
-        IFACEMETHODIMP GetRuntimeId(
-            _Outptr_ SAFEARRAY** retVal) override final;
-
-        IFACEMETHODIMP get_BoundingRectangle(
-            _Out_ UiaRect* retVal) override final;
-
-        IFACEMETHODIMP GetEmbeddedFragmentRoots(
-            _Outptr_ SAFEARRAY** retVal) override final;
-
-        IFACEMETHODIMP SetFocus();
-
-        IFACEMETHODIMP get_FragmentRoot(
-            _Outptr_ IRawElementProviderFragmentRoot** retVal) override final;
-
-    private:
-        // Helper methods
-        // For the below 3 methods create a generic function instead so that they can be reused.
-        winrt::com_ptr<NodeSimpleFragment> GetPreviousSibling();
-
-        winrt::com_ptr<NodeSimpleFragment> GetNextSibling();
-
-        int GetCurrentIndexFromSiblings(
-            std::vector<winrt::com_ptr<NodeSimpleFragment>> siblings);
-
-    private:
-        winrt::com_ptr<IslandFragmentRoot> m_parent;
-        std::vector<winrt::com_ptr<IslandFragmentRoot>> m_children;
-
-        winrt::Visual m_visual = nullptr;
-        int m_id = 0xff;
-        std::wstring m_name;
+        virtual winrt::com_ptr<IRawElementProviderFragment> GetFragmentInFocus() const = 0;
     };
 
-    // A helper class that creates Fragments that are part of the same hierarchy. Most importantly,
-    // it ensures that each NodeSimpleFragment gets assigned a unique ID.
-    class NodeSimpleFragmentFactory :
-        public winrt::implements<NodeSimpleFragmentFactory, winrt::IInspectable>
+    struct NodeSimpleFragment : winrt::implements<NodeSimpleFragment,
+        IInspectable,
+        IRawElementProviderSimple,
+        IRawElementProviderFragment>
+
     {
-    public:
-        winrt::com_ptr<NodeSimpleFragment> Create(
-            _In_z_ const wchar_t* name,
-            winrt::com_ptr<IslandFragmentRoot> fragmentRoot)
-        {
-            return winrt::make_self<NodeSimpleFragment>(name, ++m_nextId);
-        }
+        void AddChildToEnd(
+            _In_ winrt::com_ptr<NodeSimpleFragment> const& child);
+
+        void RemoveChild(
+            _In_ winrt::com_ptr<NodeSimpleFragment> const& child);
+
+        void SetCallbackHandler(
+            _In_opt_ IAutomationCallbackHandler const* const owner);
+
+        void SetProviderOptions(
+            _In_ ProviderOptions const& providerOptions);
+
+        void SetName(
+            _In_ std::wstring_view const& name);
+
+        void SetIsContent(
+            _In_ bool const& isContent);
+
+        void SetIsControl(
+            _In_ bool const& isControl);
+
+        void SetUiaControlTypeId(
+            _In_ long const& uiaControlTypeId);
+
+        void SetHostProvider(
+            _In_ winrt::com_ptr<IRawElementProviderSimple> const& hostProvider);
+
+        // IRawElementProviderSimple overrides.
+        HRESULT __stdcall get_ProviderOptions(
+            _Out_ ProviderOptions* providerOptions) final override;
+
+        HRESULT __stdcall GetPatternProvider(
+            _In_ PATTERNID patternId,
+            _COM_Outptr_opt_result_maybenull_ IUnknown** patternProvider) final override;
+
+        HRESULT __stdcall GetPropertyValue(
+            _In_ PROPERTYID propertyId,
+            _Out_ VARIANT* propertyValue) final override;
+
+        HRESULT __stdcall get_HostRawElementProvider(
+            _COM_Outptr_opt_result_maybenull_ IRawElementProviderSimple** hostRawElementProviderSimple) final override;
+
+        // IRawElementProviderFragment overrides.
+        HRESULT __stdcall Navigate(
+            _In_ NavigateDirection direction,
+            _COM_Outptr_opt_result_maybenull_ IRawElementProviderFragment** fragment) final override;
+
+        HRESULT __stdcall GetRuntimeId(
+            _Outptr_opt_result_maybenull_ SAFEARRAY** runtimeId) final override;
+
+        HRESULT __stdcall get_BoundingRectangle(
+            _Out_ UiaRect* boundingRectangle) final override;
+
+        HRESULT __stdcall GetEmbeddedFragmentRoots(
+            _Outptr_opt_result_maybenull_ SAFEARRAY** embeddedFragmentRoots) final override;
+
+        HRESULT __stdcall SetFocus() final override;
+
+        HRESULT __stdcall get_FragmentRoot(
+            _COM_Outptr_opt_result_maybenull_ IRawElementProviderFragmentRoot** fragmentRoot) final override;
+
+    protected:
+        mutable std::mutex m_mutex{};
+
+        // We do not hold a strong reference to the object that owns us.
+        // However we do need to be able to call back into it to get information.
+        // The owner is responsible for unsetting itself when it gets destroyed.
+        IAutomationCallbackHandler const* m_ownerNoRef{ nullptr };
 
     private:
-        int m_nextId = 0;
+        void SetParent(
+            _In_ winrt::weak_ref<NodeSimpleFragment> const& parent);
+
+        winrt::com_ptr<NodeSimpleFragment> GetParent() const;
+
+        void SetPreviousSibling(
+            _In_ winrt::weak_ref<NodeSimpleFragment> const& previousSibling);
+
+        winrt::com_ptr<NodeSimpleFragment> GetPreviousSibling() const;
+
+        void SetNextSibling(
+            _In_ winrt::weak_ref<NodeSimpleFragment> const& nextSibling);
+
+        winrt::com_ptr<NodeSimpleFragment> GetNextSibling() const;
+
+        // Automatically generate unique runtime IDs per fragment.
+        inline static unsigned __int32 s_nextAvailableInternalRuntimeId{ 0 };
+        unsigned __int32 m_internalRuntimeId{ ++s_nextAvailableInternalRuntimeId };
+
+        ProviderOptions m_providerOptions{ ProviderOptions_ServerSideProvider | ProviderOptions_UseComThreading };
+        std::wstring m_name{ L"" };
+        bool m_isContent{ true };
+        bool m_isControl{ true };
+        long m_uiaControlTypeId{ UIA_CustomControlTypeId };
+        winrt::com_ptr<IRawElementProviderSimple> m_hostProvider{ nullptr };
+
+        winrt::weak_ref<NodeSimpleFragment> m_parent{ nullptr };
+        winrt::weak_ref<NodeSimpleFragment> m_previousSibling{ nullptr };
+        winrt::weak_ref<NodeSimpleFragment> m_nextSibling{ nullptr };
+        std::vector<winrt::com_ptr<NodeSimpleFragment>> m_children{};
     };
 }

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/NodeSimpleFragment.h
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/NodeSimpleFragment.h
@@ -32,6 +32,8 @@ namespace winrt::DrawingIslandComponents
         void RemoveChild(
             _In_ winrt::com_ptr<NodeSimpleFragment> const& child);
 
+        void RemoveAllChildren();
+
         void SetCallbackHandler(
             _In_opt_ IAutomationCallbackHandler const* const owner);
 


### PR DESCRIPTION
This change refactors the UIA provider classes to reuse code and clearly delineate what information needs to be provided by the island while encapsulating all the UIA infrastructure and structural setup within the UIA objects themselves.
