### PR TITLE
Draw the background color visual on top of the item visuals.

### DIFF
--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/DrawingIsland.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/DrawingIsland.cpp
@@ -766,13 +766,13 @@ namespace winrt::DrawingIslandComponents::implementation
             m_output.HalfTransparentColorBrushes[i] = m_output.Compositor.CreateColorBrush(halfTransparent);
         }
 
-        m_items.CurrentColorVisual = m_output.Compositor.CreateSpriteVisual();
-        m_items.CurrentColorVisual.Offset({0.0f, 0.0f, 0.0f});
-        m_background.Visual.Children().InsertAtTop(m_items.CurrentColorVisual);
-
         winrt::ContainerVisual drawingVisualsRoot = m_output.Compositor.CreateContainerVisual();
         m_items.Visuals = drawingVisualsRoot.Children();
         m_background.Visual.Children().InsertAtTop(drawingVisualsRoot);
+
+        m_items.CurrentColorVisual = m_output.Compositor.CreateSpriteVisual();
+        m_items.CurrentColorVisual.Offset({0.0f, 0.0f, 0.0f});
+        m_background.Visual.Children().InsertAtTop(m_items.CurrentColorVisual);
 
         SystemBackdrop_EvaluateUsage();
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Change order of the visuals in the DrawingIslands sample such that the visual showing the background color (the bar across the bottom of the window) is on top.