### PR TITLE
Remove unnecessary explicit Close

### DIFF
--- a/Samples/Islands/DrawingIsland/DrawingCppTestApp/WinMain.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingCppTestApp/WinMain.cpp
@@ -24,24 +24,27 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
     auto compositor = winrt::Compositor();
     auto island = winrt::DrawingIsland(compositor).Island();
 
+    // Associating the AppWindow with the DispatcherQueue on which the ContentIsland is created
+    // will ensure that the ContentIsland is Closed when the AppWindow closes.
     auto window = winrt::AppWindow::Create();
     window.AssociateWithDispatcherQueue(queue);
     window.Closing(
-        [island, queue](auto&&, auto&&)
+        [queue](auto&&, auto&&)
         {
-            island.Close();
+            // Ensure the DispatcherQueue exits the event loop on close.
             queue.EnqueueEventLoopExit();
         });
 
     window.Title(L"Drawing C++ TestApp");
     window.Show();
 
+    // Create a ContentSiteBridge and connect the ContentIsland to it.
     auto siteBridge = winrt::DesktopChildSiteBridge::Create(compositor, window.Id());
     siteBridge.ResizePolicy(winrt::ContentSizePolicy::ResizeContentToParentWindow);
     siteBridge.Show();
     siteBridge.Connect(island);
 
-    // Move initial focus to the island.
+    // Move initial focus to the ContentIsland.
     auto focusNavigationHost = winrt::InputFocusNavigationHost::GetForSiteBridge(siteBridge);
     focusNavigationHost.NavigateFocus(winrt::FocusNavigationRequest::Create(
         winrt::FocusNavigationReason::Programmatic));


### PR DESCRIPTION
Do not show an explicit call to Close during AppWindow.Closing since it is done implicitly.