### PR TITLE
Marshal OnDirect3DDeviceLost to UI thread.

### DIFF
--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/DrawingIslandComponents.vcxproj.filters
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/DrawingIslandComponents.vcxproj.filters
@@ -33,7 +33,9 @@
     <ClCompile Include="Item.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="DeviceLostHelper.cpp" />
+    <ClCompile Include="DeviceLostHelper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />


### PR DESCRIPTION
## Description

This change fixes a thread safety issue with DrawingIsland::OnDirect3DDeviceLost. This method recreates the D2D device and re-renders text items after device lost. The problem is that this method is called from a threadpool thread, not the UI thread. The fix is to use DispatcherQueue to marshal the call to the UI thread.

I tested this by forcing device loss using `dxcap -forceTDR` and verifying that text still renders correctly. I also verified in the debugger that `TextRenderer::RecreateDirect2DDevice` is called from the UI thread.