### PR TITLE
Improve text sharpness in DrawingIsland sample

### DIFF
--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/TextRenderer.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/TextRenderer.cpp
@@ -186,6 +186,9 @@ namespace winrt::DrawingIslandComponents::implementation
             auto surfaceBrush = m_compositor.CreateSurfaceBrush();
             surfaceBrush.Surface(drawingSurface);
             visual.Brush(surfaceBrush);
+
+            surfaceBrush.SnapToPixels(true);
+            visual.IsPixelSnappingEnabled(true);
         }
         catch (winrt::hresult_error& e)
         {

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/TextRenderer.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/TextRenderer.cpp
@@ -133,8 +133,6 @@ namespace winrt::DrawingIslandComponents::implementation
         const float width = textMetrics.width + (marginLeft + marginRight);
         const float height = textMetrics.height + (marginTop + marginBottom);
 
-        visual.Size(float2(width, height));
-
         try
         {
             // Create a composition surface to draw to.
@@ -185,12 +183,10 @@ namespace winrt::DrawingIslandComponents::implementation
             // Create the surface brush and set it as the visual's brush.
             auto surfaceBrush = m_compositor.CreateSurfaceBrush();
             surfaceBrush.Surface(drawingSurface);
-            surfaceBrush.HorizontalAlignmentRatio(0.0f);
-            surfaceBrush.VerticalAlignmentRatio(0.0f);
-            surfaceBrush.Stretch(CompositionStretch::None);
-            visual.Brush(surfaceBrush);
 
-            surfaceBrush.SnapToPixels(true);
+            // Ensure surface is snapped to pixels and not stretched/aligned.
+            visual.Brush(surfaceBrush);
+            visual.Size(drawingSurface.Size());
             visual.IsPixelSnappingEnabled(true);
         }
         catch (winrt::hresult_error& e)

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/TextRenderer.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/TextRenderer.cpp
@@ -185,6 +185,9 @@ namespace winrt::DrawingIslandComponents::implementation
             // Create the surface brush and set it as the visual's brush.
             auto surfaceBrush = m_compositor.CreateSurfaceBrush();
             surfaceBrush.Surface(drawingSurface);
+            surfaceBrush.HorizontalAlignmentRatio(0.0f);
+            surfaceBrush.VerticalAlignmentRatio(0.0f);
+            surfaceBrush.Stretch(CompositionStretch::None);
             visual.Brush(surfaceBrush);
 
             surfaceBrush.SnapToPixels(true);

--- a/Samples/Islands/DrawingIsland/DrawingIslandComponents/TextRenderer.cpp
+++ b/Samples/Islands/DrawingIsland/DrawingIslandComponents/TextRenderer.cpp
@@ -126,18 +126,20 @@ namespace winrt::DrawingIslandComponents::implementation
             /*maxHeight*/ 0,
             /*out*/ textLayout.put()));
 
-        // Get the metrics from the text layout, and add the margins to compute the
-        // width and height of the visual.
+        // Get the metrics from the text layout.
         DWRITE_TEXT_METRICS textMetrics;
         winrt::check_hresult(textLayout->GetMetrics(/*out*/ &textMetrics));
-        const float width = textMetrics.width + (marginLeft + marginRight);
-        const float height = textMetrics.height + (marginTop + marginBottom);
+
+        // Compute the size of the drawing surface in pixels.
+        // This is the text size plus margins, multiplied by the DPI scale and rounded up.
+        const float pixelWidth = ceilf((textMetrics.width + (marginLeft + marginRight)) * m_dpiScale);
+        const float pixelHeight = ceilf((textMetrics.height + (marginTop + marginBottom)) * m_dpiScale);
 
         try
         {
             // Create a composition surface to draw to.
             CompositionDrawingSurface drawingSurface = m_compositionGraphicsDevice.CreateDrawingSurface(
-                winrt::Windows::Foundation::Size(width * m_dpiScale, height * m_dpiScale),
+                Size(pixelWidth, pixelHeight),
                 winrt::Microsoft::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized,
                 winrt::Microsoft::Graphics::DirectX::DirectXAlphaMode::Premultiplied);
             auto drawingSurfaceInterop = drawingSurface.as<ICompositionDrawingSurfaceInterop>();
@@ -183,10 +185,13 @@ namespace winrt::DrawingIslandComponents::implementation
             // Create the surface brush and set it as the visual's brush.
             auto surfaceBrush = m_compositor.CreateSurfaceBrush();
             surfaceBrush.Surface(drawingSurface);
-
-            // Ensure surface is snapped to pixels and not stretched/aligned.
             visual.Brush(surfaceBrush);
-            visual.Size(drawingSurface.Size());
+
+            // Set the visual size to match the surface size (but in DIPs rather than pixels).
+            // This ensures there is no scaling.
+            visual.Size(Size(pixelWidth / m_dpiScale, pixelHeight / m_dpiScale));
+
+            // Ensure the visual is snapped to a pixel boundary.
             visual.IsPixelSnappingEnabled(true);
         }
         catch (winrt::hresult_error& e)


### PR DESCRIPTION
## Description

This improves text sharpness of text in the DrawingIsland sample by ensuring the surface brush is not scaled or subpixel-positioned. The specific changes are:

- Set the drawing surface width and height to be a multiple of 1 pixel.
- Set the visual width and height to exactly match (but in DIPs rather than pixels).
- Enable pixel snapping for the visual.
