### PR TITLE
Restore the localpackages folder of nuget.config

### DIFF
--- a/Samples/nuget.config
+++ b/Samples/nuget.config
@@ -10,7 +10,10 @@
     <packageSources>
         <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+
         <!-- a local directory to allow testing nupkg files without pushing to a remote feed -->
+        <!-- This is also used by WinAppSDK's pipelines to validate a nupkg from a build -->
+        <add key="localpackages" value="localpackages" />
     </packageSources>
     <disabledPackageSources />
 </configuration>


### PR DESCRIPTION
## Description

Restore the localpackages folder of nuget.config.  WinAppSDK automation places a freshly-built WinAppSDK nupkg in this folder to test it.

## Target Release

WinAppSDK 1.6

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
