### PR TITLE
Update to released CsWinRT versions

### DIFF
--- a/Samples/CustomControls/WinUIComponentCs/WinUIComponentCs.csproj
+++ b/Samples/CustomControls/WinUIComponentCs/WinUIComponentCs.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.0-prerelease.240517.1" />
+		<PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
 	</ItemGroup>

--- a/Samples/Directory.Build.targets
+++ b/Samples/Directory.Build.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WindowsSdkPackageVersion>$(TargetPlatformVersion.TrimEnd('0'))35-preview</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>$(TargetPlatformVersion.TrimEnd('0'))38</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Workaround issue affecting publishing with R2R on ARM64 for .NET 6 with the preview CsWinRT builds. -->

--- a/Samples/Islands/DrawingIsland/DrawingCppTestApp/DrawingCppTestApp.vcxproj
+++ b/Samples/Islands/DrawingIsland/DrawingCppTestApp/DrawingCppTestApp.vcxproj
@@ -148,7 +148,4 @@
     <Error Condition="!Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.targets'))" />
   </Target>
-  <PropertyGroup>
-    <WindowsSdkPackageVersion>10.0.22621.35-preview</WindowsSdkPackageVersion>
-  </PropertyGroup>
 </Project>

--- a/Samples/Islands/DrawingIsland/DrawingCppTestPackage/DrawingCppTestPackage.wapproj
+++ b/Samples/Islands/DrawingIsland/DrawingCppTestPackage/DrawingCppTestPackage.wapproj
@@ -65,6 +65,6 @@
     <ProjectReference Include="..\DrawingCppTestApp\DrawingCppTestApp.vcxproj" />
   </ItemGroup>
   <PropertyGroup>
-    <WindowsSdkPackageVersion>10.0.22621.35-preview</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/Samples/Islands/DrawingIsland/DrawingCsTestApp/DrawingCsTestApp.csproj
+++ b/Samples/Islands/DrawingIsland/DrawingCsTestApp/DrawingCsTestApp.csproj
@@ -34,7 +34,7 @@
     <!-- Added CsWinRT reference to avoid WinMD error as a result of WinMD leaking via project reference. -->
     <PackageReference Include="CommunityToolkit.WinAppSDK.LottieWinRT" Version="8.0.230819-rc-LottieIsland.7.g92a87e1883" />
     <PackageReference Include="CommunityToolkit.WinUI.Lottie" Version="8.0.230819-rc-LottieIsland.7.g92a87e1883" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.0-prerelease.240722.1" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240701003-experimental2" />
 
     <!-- Reference WASDK for types -->

--- a/Samples/Islands/DrawingIsland/DrawingCsTestPackage/DrawingCsTestPackage.wapproj
+++ b/Samples/Islands/DrawingIsland/DrawingCsTestPackage/DrawingCsTestPackage.wapproj
@@ -64,6 +64,6 @@
     <ProjectReference Include="..\DrawingCsTestApp\DrawingCsTestApp.csproj" />
   </ItemGroup>
   <PropertyGroup>
-    <WindowsSdkPackageVersion>10.0.22621.35-preview</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/Samples/Islands/DrawingIsland/DrawingIslandCsProjection/DrawingIslandCsProjection.csproj
+++ b/Samples/Islands/DrawingIsland/DrawingIslandCsProjection/DrawingIslandCsProjection.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.0-prerelease.240722.1" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240701003-experimental2" />
   </ItemGroup>
 

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications.csproj
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.0-prerelease.240517.1" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
   </ItemGroup>


### PR DESCRIPTION
## Description

Update to released CsWinRT and Windows SDK projection versions

## Target Release

1.6

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
