### PR TITLE
Don't override PublishReadyToRun when set

### DIFF
--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>   <!-- 

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>   <!-- 
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>   <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
     -->

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>   <!-- 

--- a/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>   <!-- 
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>   <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
     -->

--- a/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/Input/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Input/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>   <!-- 

--- a/Samples/Input/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Input/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>   <!-- 
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>   <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
     -->

--- a/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>   <!-- 

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>   <!-- 
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>   <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
     -->

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>   <!-- 

--- a/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>   <!-- 
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>   <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
     -->

--- a/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>   <!-- 

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>   <!-- 
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>   <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
     -->

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>   <!-- 

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>   <!-- 
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>   <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
     -->

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>   <!-- 

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>   <!-- 
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>   <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
     -->

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>   <!-- 

--- a/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>   <!-- 
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>   <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
     -->

--- a/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>

--- a/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+      <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+      <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    </PropertyGroup>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PropertyGroup Condition="'$(PublishReadyToRun )' == ''">    
+    <PropertyGroup Condition="'$(PublishReadyToRun)' == ''">    
       <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
       <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     </PropertyGroup>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Please include a summary of the change and/or which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Target Release

Please specify which release this PR should align with. e.g., 1.0, 1.1, 1.1 Preview 1.

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
