### PR TITLE
Remove PublishReadyToRun from pubxml to allow Override from MSBuild cmd

### DIFF
--- a/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/CsWinUiDesktopActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/CsWinUiDesktopActivation.csproj
@@ -8,6 +8,7 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing.csproj
@@ -8,6 +8,7 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>

--- a/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/CsWinUiDesktopState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/CsWinUiDesktopState.csproj
@@ -8,6 +8,7 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,7 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,7 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,7 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-arm64.pubxml
@@ -10,9 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-   <!-- 
+    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
     -->

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x64.pubxml
@@ -10,8 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x86.pubxml
@@ -10,8 +10,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/SelfContainedDeployment.csproj
@@ -9,6 +9,8 @@
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="App.xaml" />


### PR DESCRIPTION
We are setting PublishReadyToRun property to false to fix a nuget restore issue on the package that depends on it however the PublishReadyToRun property in the publxml is overriding everything. Hence, these properties should be moved to the csprojs

