### PR TITLE
[Build][CP to 1.6] Fix BinSkim issues in 1.6-Stable

### DIFF
--- a/Samples/Directory.Build.props
+++ b/Samples/Directory.Build.props
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) /Qspectre</AdditionalOptions>
+      <!-- /GS Enable Control Flow Guard -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <!-- Setting this to be compatible with CFG -->
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <!-- dynamicbase is required for enabling CFG -->
+      <AdditionalOptions>%(AdditionalOptions) /dynamicbase</AdditionalOptions>
+      <!-- /GS Enable Control Flow Guard -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/Samples/SelfContainedDeployment/cpp/cpp-console-unpackaged/Directory.Build.props
+++ b/Samples/SelfContainedDeployment/cpp/cpp-console-unpackaged/Directory.Build.props
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="$(MSBuildThisFileDirectory)HybridCRT.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <Import Project="$(MSBuildThisFileDirectory)HybridCRT.props" />
 </Project>

--- a/Samples/SelfContainedDeployment/cpp/cpp-winui-packaged/Directory.Build.props
+++ b/Samples/SelfContainedDeployment/cpp/cpp-winui-packaged/Directory.Build.props
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="$(MSBuildThisFileDirectory)HybridCRT.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <Import Project="$(MSBuildThisFileDirectory)HybridCRT.props" />
 </Project>

--- a/Samples/SelfContainedDeployment/cpp/cpp-winui-unpackaged/Directory.Build.props
+++ b/Samples/SelfContainedDeployment/cpp/cpp-winui-unpackaged/Directory.Build.props
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="$(MSBuildThisFileDirectory)HybridCRT.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <Import Project="$(MSBuildThisFileDirectory)HybridCRT.props" />
 </Project>


### PR DESCRIPTION
Cherry pick existing fixes for 2 BinSkim issue (BA2008 and BA2021) from release/experimental to release/1.6-stable to unblock building of sample apps on Agg repo's 1.6-stable branch:
- [Add Directory.Build.props (](https://github.com/microsoft/WindowsAppSDK-Samples/commit/805e71c93dd44d2d70101dbf496d4ce0bc9e101f)https://github.com/microsoft/WindowsAppSDK-Samples/pull/378[)](https://github.com/microsoft/WindowsAppSDK-Samples/commit/805e71c93dd44d2d70101dbf496d4ce0bc9e101f)
- [[Build] Ensure chaining of directory.build.props files reaches the new central one for Sample apps (](https://github.com/microsoft/WindowsAppSDK-Samples/commit/7941eef8ce3cf112edb9cf0296a99913cfae7bff)https://github.com/microsoft/WindowsAppSDK-Samples/pull/380[)](https://github.com/microsoft/WindowsAppSDK-Samples/commit/7941eef8ce3cf112edb9cf0296a99913cfae7bff)

How built/tested:
- With these changes, a [private Agg pipeline run](https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=110426568&view=results) successfully passed the Build Sample Apps stage
- Without these changes, BinSkim errors were hit in the Build Samples Apps Stage: [Pipelines - Run 1.6.241108005-preview](https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=110411793&view=results).
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Please include a summary of the change and/or which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Target Release

Please specify which release this PR should align with. e.g., 1.0, 1.1, 1.1 Preview 1.

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
