### PR TITLE
Bug 55010311: [SFI][Wave2] [ES5.1] Azure Artifacts - Central Feed Services (CFS) - WinAppSDK ES - Agg pipeline

### DIFF
--- a/Samples/nuget.config
+++ b/Samples/nuget.config
@@ -9,9 +9,13 @@
     </packageRestore>
     <packageSources>
         <clear />
-        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-        <add key="CsWinRT" value="https://pkgs.dev.azure.com/microsoft/_packaging/CsWinRT/nuget/v3/index.json" />
-        <add key="MSFTNuget" value="https://pkgs.dev.azure.com/microsoft/_packaging/MSFTNuget/nuget/v3/index.json" />
+        <!--
+            Resort to using this direct reference to nuget.org in case of no access to the internal feed below.
+            <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+            <add key="CsWinRT" value="https://pkgs.dev.azure.com/microsoft/_packaging/CsWinRT/nuget/v3/index.json" />
+            <add key="MSFTNuget" value="https://pkgs.dev.azure.com/microsoft/_packaging/MSFTNuget/nuget/v3/index.json" />
+        -->
+        <add key="ProjectReunion internal" value="https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
 
         <!-- a local directory to allow testing nupkg files without pushing to a remote feed -->
         <add key="localpackages" value="localpackages" />


### PR DESCRIPTION
This is a CP of the following PR from release/experimental to release/1.6-stable to mitigate the said bug.
- [SFI] Avoid download from nuget.org directly in the Agg pipeline (#371)

How built/tested:
- These changes will go through PR validation as usual
- In a private run of the Agg pipeline, pointing to this private branch on the Sample repo, the feed https://api.nuget.org/v3/index.json no longer appears in the logs for the 3 tasks cited in the bug above. 

<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Please include a summary of the change and/or which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Target Release

Please specify which release this PR should align with. e.g., 1.0, 1.1, 1.1 Preview 1.

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
