### PR TITLE
Add Public NuGet Feed to Support Developers Without Private Feed Access

### DIFF
--- a/Samples/nuget.config
+++ b/Samples/nuget.config
@@ -9,11 +9,9 @@
     </packageRestore>
     <packageSources>
         <clear />
-        <!--
-            Resort to using this direct reference to nuget.org in case of no access to the internal feed below.
-            <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-        -->
-        <add key="ProjectReunion internal" value="https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
+        <!-- publicly accessible NuGet feed -->
+        <add key="WinAppSDK-SampleDeps"
+            value="https://pkgs.dev.azure.com/shine-oss/WinAppSDK-Samples/_packaging/WinAppSDK-SampleDeps/nuget/v3/index.json" />
 
         <!-- a local directory to allow testing nupkg files without pushing to a remote feed -->
         <add key="localpackages" value="localpackages" />


### PR DESCRIPTION
cherry-pick from https://github.com/microsoft/WindowsAppSDK-Samples/commit/43a876eebdc987b0cd63fa70131fb9e138490c89

<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

The original NuGet feed lacked public access support. To address this, a new public NuGet feed has been created under the shine-oss organization, utilizing the WinAppSDK Samples project. This feed now serves the WinAppSDK Samples repository, ensuring full open-source compliance and accessibility.

the Feed Link: https://dev.azure.com/shine-oss/WinAppSDK-Samples/_artifacts/feed/WinAppSDK-SampleDeps

## Target Release

main branch

## Checklist

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
