### PR TITLE
Update C# Background Task samples for trimming and AOT

### DIFF
--- a/Samples/BackgroundTask/InProc BackgroundTask/cs-winui/BackgroundTaskBuilder/App.xaml.cs
+++ b/Samples/BackgroundTask/InProc BackgroundTask/cs-winui/BackgroundTaskBuilder/App.xaml.cs
@@ -37,8 +37,8 @@ namespace BackgroundTaskBuilder
         {
             this.InitializeComponent();
             Guid taskGuid = typeof(BackgroundTask).GUID;
-            ComServer.CoRegisterClassObject(ref taskGuid,
-                                            new ComServer.BackgroundTaskFactory<BackgroundTask, IBackgroundTask>(),
+            ComServer.CoRegisterClassObject(in taskGuid,
+                                            new ComServer.BackgroundTaskFactory(),
                                             ComServer.CLSCTX_LOCAL_SERVER,
                                             ComServer.REGCLS_MULTIPLEUSE,
                                             out _RegistrationToken);

--- a/Samples/BackgroundTask/InProc BackgroundTask/cs-winui/BackgroundTaskBuilder/BackgroundTask.cs
+++ b/Samples/BackgroundTask/InProc BackgroundTask/cs-winui/BackgroundTaskBuilder/BackgroundTask.cs
@@ -14,11 +14,8 @@ namespace BackgroundTaskBuilder
 {
     // Background task implementation.
     // {87654321-1234-1234-1234-1234567890AE} is GUID to register this task with BackgroundTaskBuilder. Generate a random GUID before implementing.
-    [ComVisible(true)]
-    [ClassInterface(ClassInterfaceType.None)]
     [Guid("87654321-1234-1234-1234-1234567890AA")]
-    [ComSourceInterfaces(typeof(IBackgroundTask))]
-    public class BackgroundTask : IBackgroundTask
+    public partial class BackgroundTask : IBackgroundTask
     {
         /// <summary>
         /// This method is the main entry point for the background task. The system will believe this background task

--- a/Samples/BackgroundTask/InProc BackgroundTask/cs-winui/BackgroundTaskBuilder/BackgroundTaskBuilder.csproj
+++ b/Samples/BackgroundTask/InProc BackgroundTask/cs-winui/BackgroundTaskBuilder/BackgroundTaskBuilder.csproj
@@ -14,6 +14,7 @@
     <!-- This tag is required for the usage of WinAppSDK Background Task API -->
     <WindowsAppSDKBackgroundTask>true</WindowsAppSDKBackgroundTask>
     <StartupObject></StartupObject>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -50,14 +51,5 @@
   -->
   <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
-  </PropertyGroup>
-
-  <!-- Publish Properties -->
-  <PropertyGroup>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-    <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 </Project>

--- a/Samples/BackgroundTask/OutOfProc BackgroundTask/cs-winui/BackgroundTaskBuilder/BackgroundTask.cs
+++ b/Samples/BackgroundTask/OutOfProc BackgroundTask/cs-winui/BackgroundTaskBuilder/BackgroundTask.cs
@@ -14,11 +14,8 @@ namespace BackgroundTaskBuilder
 {
     // Background task implementation.
     // {87654321-1234-1234-1234-1234567890AE} is GUID to register this task with BackgroundTaskBuilder. Generate a random GUID before implementing.
-    [ComVisible(true)]
-    [ClassInterface(ClassInterfaceType.None)]
     [Guid("87654321-1234-1234-1234-1234567890AE")]
-    [ComSourceInterfaces(typeof(IBackgroundTask))]
-    public class BackgroundTask : IBackgroundTask, IDisposable
+    public partial class BackgroundTask : IBackgroundTask, IDisposable
     {
         private bool disposed = false;
 

--- a/Samples/BackgroundTask/OutOfProc BackgroundTask/cs-winui/BackgroundTaskBuilder/BackgroundTaskBuilder.csproj
+++ b/Samples/BackgroundTask/OutOfProc BackgroundTask/cs-winui/BackgroundTaskBuilder/BackgroundTaskBuilder.csproj
@@ -15,6 +15,7 @@
     <WindowsAppSDKBackgroundTask>true</WindowsAppSDKBackgroundTask>
     <DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
     <StartupObject>BackgroundTaskBuilder.Program</StartupObject>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,7 +41,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.2454" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.241114004-experimental1" />
   </ItemGroup>
 	
@@ -51,14 +52,5 @@
   -->
   <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
-  </PropertyGroup>
-
-  <!-- Publish Properties -->
-  <PropertyGroup>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-    <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 </Project>

--- a/Samples/BackgroundTask/OutOfProc BackgroundTask/cs-winui/BackgroundTaskBuilder/ComServer.cs
+++ b/Samples/BackgroundTask/OutOfProc BackgroundTask/cs-winui/BackgroundTaskBuilder/ComServer.cs
@@ -3,16 +3,18 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Windows.ApplicationModel.Background;
 using WinRT;
 
 namespace BackgroundTaskBuilder
 {
     // COM server startup code.
-    internal class ComServer
+    internal partial class ComServer
     {
-        [DllImport("ole32.dll")]
-        public static extern int CoRegisterClassObject(
-            ref Guid classId,
+        [LibraryImport("ole32.dll")]
+        public static partial int CoRegisterClassObject(
+            in Guid classId,
             [MarshalAs(UnmanagedType.Interface)] IClassFactory objectAsUnknown,
             uint executionContext,
             uint flags,
@@ -28,26 +30,25 @@ namespace BackgroundTaskBuilder
         public const string IID_IUnknown = "00000000-0000-0000-C000-000000000046";
         public const string IID_IClassFactory = "00000001-0000-0000-C000-000000000046";
 
-        [ComImport]
-        [ComVisible(false)]
+        [GeneratedComInterface]
         [Guid(IID_IClassFactory)]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IClassFactory
+        public partial interface IClassFactory
         {
             [PreserveSig]
-            uint CreateInstance(IntPtr objectAsUnknown, ref Guid interfaceId, out IntPtr objectPointer);
+            uint CreateInstance(IntPtr objectAsUnknown, in Guid interfaceId, out IntPtr objectPointer);
 
             [PreserveSig]
-            uint LockServer(bool Lock);
+            uint LockServer([MarshalAs(UnmanagedType.Bool)] bool Lock);
         }
 
-        internal class BackgroundTaskFactory<TaskType, TaskInterface> : IClassFactory where TaskType : TaskInterface, new()
+        [GeneratedComClass]
+        internal partial class BackgroundTaskFactory : IClassFactory
         {
             public BackgroundTaskFactory()
             {
             }
 
-            public uint CreateInstance(IntPtr objectAsUnknown, ref Guid interfaceId, out IntPtr objectPointer)
+            public uint CreateInstance(IntPtr objectAsUnknown, in Guid interfaceId, out IntPtr objectPointer)
             {
                 if (objectAsUnknown != IntPtr.Zero)
                 {
@@ -55,13 +56,13 @@ namespace BackgroundTaskBuilder
                     return CLASS_E_NOAGGREGATION;
                 }
 
-                if ((interfaceId != typeof(TaskType).GUID) && (interfaceId != new Guid(IID_IUnknown)))
+                if ((interfaceId != typeof(IBackgroundTask).GUID) && (interfaceId != new Guid(IID_IUnknown)))
                 {
                     objectPointer = IntPtr.Zero;
                     return E_NOINTERFACE;
                 }
 
-                objectPointer = MarshalInterface<TaskInterface>.FromManaged(new TaskType());
+                objectPointer = MarshalInterface<IBackgroundTask>.FromManaged(new BackgroundTask());
                 return S_OK;
             }
 

--- a/Samples/BackgroundTask/OutOfProc BackgroundTask/cs-winui/BackgroundTaskBuilder/Program.cs
+++ b/Samples/BackgroundTask/OutOfProc BackgroundTask/cs-winui/BackgroundTaskBuilder/Program.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation and Contributors.
+﻿// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 using System;
@@ -22,8 +22,8 @@ namespace BackgroundTaskBuilder
             if (args.Contains("-RegisterForBGTaskServer"))
             {
                 Guid taskGuid = typeof(BackgroundTask).GUID;
-                ComServer.CoRegisterClassObject(ref taskGuid,
-                                                new ComServer.BackgroundTaskFactory<BackgroundTask, IBackgroundTask>(),
+                ComServer.CoRegisterClassObject(in taskGuid,
+                                                new ComServer.BackgroundTaskFactory(),
                                                 ComServer.CLSCTX_LOCAL_SERVER,
                                                 ComServer.REGCLS_MULTIPLEUSE,
                                                 out _RegistrationToken);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Update the C# Background Task samples so that they are trimming and AOT compatible.

## Target Release

Windows App SDK 1.7

## Checklist

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
