### PR TITLE
Port UXFrameworksOnIslands sample to WindowsAppSDK 1.7.0.

### DIFF
--- a/Samples/Islands/UXFrameworksOnIslands/FocusManager.cpp
+++ b/Samples/Islands/UXFrameworksOnIslands/FocusManager.cpp
@@ -35,14 +35,14 @@ void FocusManager::InitializeWithFocusController(
 
     m_focusController.GotFocus(
         [this](auto&& /*sender*/, auto&& /*args*/)
-        {
-            RestoreFocus();
+    {
+        RestoreFocus();
         });
 
     m_focusController.LostFocus(
         [this](auto&& /*sender*/, auto&& /*args*/)
-        {
-            ClearFocus();
+    {
+        ClearFocus();
         });
 }
 
@@ -52,7 +52,7 @@ void FocusManager::InitializeWithFocusHost(
     m_focusHost = focusHost;
 }
 
-void FocusManager::SetFocusFromClick(
+void FocusManager::SetFocusToVisual(
     const std::shared_ptr<VisualTreeNode>& node,
     const std::shared_ptr<FocusList>& list)
 {
@@ -62,6 +62,7 @@ void FocusManager::SetFocusFromClick(
 
     m_focusedList = list;
     m_focusedIndex = list->IndexOf(node);
+    EnsureWin32Focus();
 }
 
 void FocusManager::ClearFocus()

--- a/Samples/Islands/UXFrameworksOnIslands/FocusManager.h
+++ b/Samples/Islands/UXFrameworksOnIslands/FocusManager.h
@@ -26,7 +26,7 @@ public:
     void InitializeWithFocusHost(
         IFocusHost* focusHost);
 
-    void SetFocusFromClick(
+    void SetFocusToVisual(
         const std::shared_ptr<VisualTreeNode>& node,
         const std::shared_ptr<FocusList>& list);
 

--- a/Samples/Islands/UXFrameworksOnIslands/HitTestContext.cpp
+++ b/Samples/Islands/UXFrameworksOnIslands/HitTestContext.cpp
@@ -54,7 +54,7 @@ void HitTestContext::RunHitTest(
             auto focusList = currentNode->OwningFocusList();
             if (focusList != nullptr)
             {
-                m_focusManager.SetFocusFromClick(currentNode, focusList);
+                m_focusManager.SetFocusToVisual(currentNode, focusList);
                 m_foundFocusNode = true;
             }
         }

--- a/Samples/Islands/UXFrameworksOnIslands/IFrame.h
+++ b/Samples/Islands/UXFrameworksOnIslands/IFrame.h
@@ -22,6 +22,11 @@ struct IFrame
 
     [[nodiscard]] virtual bool IsLiftedFrame() const = 0;
 
+    virtual bool SystemPreTranslateMessage(
+        UINT message,
+        WPARAM wParam,
+        LPARAM lParam) = 0;
+
     virtual LRESULT HandleMessage(
         UINT message,
         WPARAM wParam,

--- a/Samples/Islands/UXFrameworksOnIslands/LiftedFrame.cpp
+++ b/Samples/Islands/UXFrameworksOnIslands/LiftedFrame.cpp
@@ -58,8 +58,8 @@ winrt::ChildSiteLink LiftedFrame::ConnectChildFrame(
     if (!frame->IsLiftedFrame())
     {
         childSiteLink.AutomationOption(winrt::ContentAutomationOptions::None);
-        childSiteLink.ProcessKeyboardInput(false);
-        childSiteLink.ProcessPointerInput(false);
+        childSiteLink.ProcessesKeyboardInput(false);
+        childSiteLink.ProcessesPointerInput(false);
     }
     else
     {

--- a/Samples/Islands/UXFrameworksOnIslands/LiftedFrame.h
+++ b/Samples/Islands/UXFrameworksOnIslands/LiftedFrame.h
@@ -28,6 +28,15 @@ public:
 
     [[nodiscard]] bool IsLiftedFrame() const final { return true; }
 
+    bool SystemPreTranslateMessage(
+        UINT /*message*/,
+        WPARAM /*wParam*/,
+        LPARAM /*lParam*/) override
+    {
+        // We don't expect to receive pretranslate messages in a lifted frame.
+        return false;
+    }
+
     LRESULT HandleMessage(
         UINT /*message*/,
         WPARAM /*wParam*/,

--- a/Samples/Islands/UXFrameworksOnIslands/NetUIFrame.h
+++ b/Samples/Islands/UXFrameworksOnIslands/NetUIFrame.h
@@ -13,6 +13,11 @@ public:
         const winrt::WUC::Compositor& systemCompositor,
         const std::shared_ptr<SettingCollection>& settings);
 
+    bool SystemPreTranslateMessage(
+        UINT message,
+        WPARAM wParam,
+        LPARAM lParam) override;
+    
     void ConnectFrame(
         IFrame* frame);
 
@@ -39,6 +44,8 @@ private:
     winrt::ChildSiteLink m_childSiteLink = nullptr;
     winrt::WUC::ContainerVisual m_childContentVisual{nullptr};
     SystemTextVisual m_labelVisual;
+    SystemTextVisual m_acceleratorVisual;
+    bool m_acceleratorActive = false;
 
     // Interaction tracker
     winrt::WUCI::InteractionTracker m_interactionTracker{nullptr};

--- a/Samples/Islands/UXFrameworksOnIslands/ReactNativeFrame.cpp
+++ b/Samples/Islands/UXFrameworksOnIslands/ReactNativeFrame.cpp
@@ -9,7 +9,7 @@
 ReactNativeFrame::ReactNativeFrame(const winrt::Compositor& compositor, const std::shared_ptr<SettingCollection>& settings) :
     LiftedFrame(compositor, settings),
     m_labelVisual(GetOutput(), k_frameName),
-    m_acceleratorVisual(GetOutput(), L"1"),
+    m_acceleratorVisual(GetOutput(), L"3"),
     m_focusManager(m_focusList)
 {
     InitializeVisualTree(compositor);
@@ -220,10 +220,9 @@ void ReactNativeFrame::OnPreTranslateTreeMessage(
     _Inout_ bool* handled)
 {
     *handled = false;
-
     if (msg->message == WM_SYSKEYDOWN || msg->message == WM_KEYDOWN)
     {
-        if (static_cast<winrt::Windows::System::VirtualKey>(msg->wParam) == winrt::Windows::System::VirtualKey::Control)
+        if (static_cast<winrt::Windows::System::VirtualKey>(msg->wParam) == winrt::Windows::System::VirtualKey::Menu)
         {
             m_acceleratorActive = !m_acceleratorActive;
             m_acceleratorVisual.GetVisual().IsVisible(m_acceleratorActive);
@@ -231,10 +230,10 @@ void ReactNativeFrame::OnPreTranslateTreeMessage(
         else {
             m_acceleratorActive = false;
             m_acceleratorVisual.GetVisual().IsVisible(false);
-            if (static_cast<winrt::Windows::System::VirtualKey>(msg->wParam) == winrt::Windows::System::VirtualKey::Number1)
+            if (static_cast<winrt::Windows::System::VirtualKey>(msg->wParam) == winrt::Windows::System::VirtualKey::Number3)
             {
                 // Take focus
-                m_focusController.TrySetFocus();
+                m_focusManager.SetFocusToVisual(GetRootVisualTreeNode(), GetRootVisualTreeNode()->OwningFocusList());
             }
         }
     }

--- a/Samples/Islands/UXFrameworksOnIslands/RootFrame.h
+++ b/Samples/Islands/UXFrameworksOnIslands/RootFrame.h
@@ -15,6 +15,11 @@ public:
         const winrt::WUC::Compositor& systemCompositor,
         const std::shared_ptr<SettingCollection>& settings);
 
+    bool SystemPreTranslateMessage(
+        UINT message,
+        WPARAM wParam,
+        LPARAM lParam) override;
+    
     LRESULT HandleMessage(
         UINT message,
         WPARAM wParam,
@@ -87,6 +92,8 @@ private:
     SystemTextVisual m_ribbonLabel;
     SystemTextVisual m_backLabel;
     SystemTextVisual m_frontLabel;
+    SystemTextVisual m_acceleratorLabel;
+    bool m_acceleratorActive = false;
     SystemCheckBox m_forceAliasedTextCheckBox;
     SystemCheckBox m_disablePixelSnappingCheckBox;
     SystemCheckBox m_showSpriteBoundsCheckBox;

--- a/Samples/Islands/UXFrameworksOnIslands/SystemFrame.cpp
+++ b/Samples/Islands/UXFrameworksOnIslands/SystemFrame.cpp
@@ -62,8 +62,8 @@ winrt::ChildSiteLink SystemFrame::ConnectChildFrame(
     if (!frame->IsLiftedFrame())
     {
         childSiteLink.AutomationOption(winrt::ContentAutomationOptions::None);
-        childSiteLink.ProcessKeyboardInput(false);
-        childSiteLink.ProcessPointerInput(false);
+        childSiteLink.ProcessesKeyboardInput(false);
+        childSiteLink.ProcessesPointerInput(false);
     }
     else
     {

--- a/Samples/Islands/UXFrameworksOnIslands/SystemFrame.h
+++ b/Samples/Islands/UXFrameworksOnIslands/SystemFrame.h
@@ -31,6 +31,15 @@ public:
 
     [[nodiscard]] bool IsLiftedFrame() const final { return false; }
 
+    bool SystemPreTranslateMessage(
+        UINT /*message*/,
+        WPARAM /*wParam*/,
+        LPARAM /*lParam*/) override
+    {
+        // Default implementation does nothing.
+        return false;
+    }
+
     LRESULT HandleMessage(
         UINT /*message*/,
         WPARAM /*wParam*/,

--- a/Samples/Islands/UXFrameworksOnIslands/TopLevelWindow.cpp
+++ b/Samples/Islands/UXFrameworksOnIslands/TopLevelWindow.cpp
@@ -19,8 +19,8 @@ void TopLevelWindow::ConnectFrameToWindow(
 {
     // Mark the bridge with no keyboard or pointer input processing capabilities 
     // so that input doesn't go to the island but instead goes to the window.
-    m_bridge.ProcessKeyboardInput(false);
-    m_bridge.ProcessPointerInput(false);
+    m_bridge.ProcessesKeyboardInput(false);
+    m_bridge.ProcessesPointerInput(false);
 
     m_bridge.Connect(frame->GetIsland());
 
@@ -135,7 +135,7 @@ winrt::com_ptr<::IRawElementProviderFragmentRoot> TopLevelWindow::GetFragmentRoo
 
 winrt::com_ptr<::IRawElementProviderFragment> TopLevelWindow::GetNextSiblingProviderForChildFrame(_In_ IFrame const* const) const
 {
-    // The RootFrame is the only frame directly connected to the ReadOnlyDesktopSiteBridge.
+    // The RootFrame is the only frame directly connected to the DesktopAttachedSiteBridge.
     return nullptr;
 }
 
@@ -146,7 +146,7 @@ winrt::com_ptr<::IRawElementProviderFragment> TopLevelWindow::GetParentProviderF
 
 winrt::com_ptr<::IRawElementProviderFragment> TopLevelWindow::GetPreviousSiblingProviderForChildFrame(_In_ IFrame const* const) const
 {
-    // The RootFrame is the only frame directly connected to the ReadOnlyDesktopSiteBridge.
+    // The RootFrame is the only frame directly connected to the DesktopAttachedSiteBridge.
     return nullptr;
 }
 
@@ -295,7 +295,7 @@ void TopLevelWindow::InitializeBridge(
     const winrt::DispatcherQueue& queue)
 {
     auto windowId = m_window.Id();
-    m_bridge = winrt::ReadOnlyDesktopSiteBridge::Create(queue, windowId);
+    m_bridge = winrt::DesktopAttachedSiteBridge::CreateFromWindowId(queue, windowId);
     m_bridge.OverrideScale(1.0f);
 }
 

--- a/Samples/Islands/UXFrameworksOnIslands/TopLevelWindow.h
+++ b/Samples/Islands/UXFrameworksOnIslands/TopLevelWindow.h
@@ -103,7 +103,7 @@ private:
     winrt::AppWindow m_window = nullptr;
     AppWindowClosing_revoker m_closingRevoker{};
 
-    winrt::ReadOnlyDesktopSiteBridge m_bridge = nullptr;
+    winrt::DesktopAttachedSiteBridge m_bridge = nullptr;
 
     bool m_windowAutomationRootRegisteredWithUIA = false;
     std::unique_ptr<AutomationHelpers::AutomationCallbackRevoker> m_fragmentRevoker = nullptr;

--- a/Samples/Islands/UXFrameworksOnIslands/UXFrameworksOnIslands.vcxproj
+++ b/Samples/Islands/UXFrameworksOnIslands/UXFrameworksOnIslands.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.WindowsAppSDK.1.7.250127003-experimental3\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('packages\Microsoft.WindowsAppSDK.1.7.250127003-experimental3\build\native\Microsoft.WindowsAppSDK.props')" />
+  <Import Project="packages\Microsoft.WindowsAppSDK.1.7.250310001\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('packages\Microsoft.WindowsAppSDK.1.7.250310001\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
@@ -226,8 +226,8 @@
     <Import Project="packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
     <Import Project="packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.targets" Condition="Exists('packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.targets')" />
-    <Import Project="packages\Microsoft.Web.WebView2.1.0.2792.45\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('packages\Microsoft.Web.WebView2.1.0.2792.45\build\native\Microsoft.Web.WebView2.targets')" />
-    <Import Project="packages\Microsoft.WindowsAppSDK.1.7.250127003-experimental3\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('packages\Microsoft.WindowsAppSDK.1.7.250127003-experimental3\build\native\Microsoft.WindowsAppSDK.targets')" />
+    <Import Project="packages\Microsoft.Web.WebView2.1.0.2903.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('packages\Microsoft.Web.WebView2.1.0.2903.40\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="packages\Microsoft.WindowsAppSDK.1.7.250310001\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('packages\Microsoft.WindowsAppSDK.1.7.250310001\build\native\Microsoft.WindowsAppSDK.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -238,8 +238,8 @@
     <Error Condition="!Exists('packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.props'))" />
     <Error Condition="!Exists('packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.Web.WebView2.1.0.2792.45\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Web.WebView2.1.0.2792.45\build\native\Microsoft.Web.WebView2.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.WindowsAppSDK.1.7.250127003-experimental3\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.WindowsAppSDK.1.7.250127003-experimental3\build\native\Microsoft.WindowsAppSDK.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.WindowsAppSDK.1.7.250127003-experimental3\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.WindowsAppSDK.1.7.250127003-experimental3\build\native\Microsoft.WindowsAppSDK.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Web.WebView2.1.0.2903.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Web.WebView2.1.0.2903.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.WindowsAppSDK.1.7.250310001\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.WindowsAppSDK.1.7.250310001\build\native\Microsoft.WindowsAppSDK.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.WindowsAppSDK.1.7.250310001\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.WindowsAppSDK.1.7.250310001\build\native\Microsoft.WindowsAppSDK.targets'))" />
   </Target>
 </Project>

--- a/Samples/Islands/UXFrameworksOnIslands/UXFrameworksOnIslands.vcxproj.filters
+++ b/Samples/Islands/UXFrameworksOnIslands/UXFrameworksOnIslands.vcxproj.filters
@@ -72,6 +72,11 @@
     <ClCompile Include="VisualUtils.cpp" />
     <ClCompile Include="WebViewFrame.cpp" />
     <ClCompile Include="WinUIFrame.cpp" />
+    <ClCompile Include="FocusList.cpp" />
+    <ClCompile Include="FocusManager.cpp" />
+    <ClCompile Include="HitTestContext.cpp" />
+    <ClCompile Include="PopupFrame.cpp" />
+    <ClCompile Include="PreTranslateHandler.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AutomationBase.h" />
@@ -109,5 +114,11 @@
     <ClInclude Include="VisualUtils.h" />
     <ClInclude Include="WebViewFrame.h" />
     <ClInclude Include="WinUIFrame.h" />
+    <ClInclude Include="FocusList.h" />
+    <ClInclude Include="FocusManager.h" />
+    <ClInclude Include="HitTestContext.h" />
+    <ClInclude Include="IFocusHost.h" />
+    <ClInclude Include="PopupFrame.h" />
+    <ClInclude Include="PreTranslateHandler.h" />
   </ItemGroup>
 </Project>

--- a/Samples/Islands/UXFrameworksOnIslands/WebViewFrame.cpp
+++ b/Samples/Islands/UXFrameworksOnIslands/WebViewFrame.cpp
@@ -5,6 +5,7 @@
 #include "ColorUtils.h"
 #include "VisualUtils.h"
 #include "TextRenderer.h"
+#include "FocusManager.h"
 
 WebViewFrame::WebViewFrame(
         const winrt::DispatcherQueue& queue,
@@ -13,6 +14,33 @@ WebViewFrame::WebViewFrame(
     SystemFrame(queue, systemCompositor, settings)
 {
     InitializeVisualTree(systemCompositor);
+}
+
+bool WebViewFrame::SystemPreTranslateMessage(
+    UINT message,
+    WPARAM wParam,
+    LPARAM /*lParam*/)
+{
+    if (message == WM_SYSKEYDOWN || message == WM_KEYDOWN)
+    {
+        if (static_cast<winrt::Windows::System::VirtualKey>(wParam) == winrt::Windows::System::VirtualKey::Menu)
+        {
+            m_acceleratorActive = !m_acceleratorActive;
+            m_acceleratorVisual->GetVisual().IsVisible(m_acceleratorActive);
+            HandleContentLayout();
+        }
+        else {
+            m_acceleratorActive = false;
+            m_acceleratorVisual->GetVisual().IsVisible(false);
+            if (static_cast<winrt::Windows::System::VirtualKey>(wParam) == winrt::Windows::System::VirtualKey::Number5)
+            {
+                // Take focus
+                GetFocusList()->GetManager()->SetFocusToVisual(GetRootVisualTreeNode(), GetRootVisualTreeNode()->OwningFocusList());
+            }
+            HandleContentLayout();
+        }
+    }
+    return false;
 }
 
 void WebViewFrame::InitializeVisualTree(
@@ -36,6 +64,8 @@ void WebViewFrame::InitializeVisualTree(
     // Add the content.
     m_content.reserve(6);
     AddContent(L"WebView", nullptr);
+    m_acceleratorVisual = AddContent(L"(Hotkey: 5)", nullptr);
+    m_acceleratorVisual->GetVisual().IsVisible(false);
     AddContent(L"UXFrameworksOnIslands Sample", headingTextFormat.get());
     AddContent(
         L"This sample application demonstrates how multiple UX frameworks could be a used in the "
@@ -59,12 +89,13 @@ void WebViewFrame::InitializeVisualTree(
         codeTextFormat.get());
 }
 
-void WebViewFrame::AddContent(_In_z_ WCHAR const* text, IDWriteTextFormat* textFormat)
+std::shared_ptr<SystemTextVisual> WebViewFrame::AddContent(_In_z_ WCHAR const* text, IDWriteTextFormat* textFormat)
 {
     auto textLayout = CreateTextLayout(text, textFormat);
-    auto block = std::make_unique<SystemTextVisual>(GetOutput(), text, textLayout);
-    m_content.push_back(std::move(block));
+    auto block = std::make_shared<SystemTextVisual>(GetOutput(), text, textLayout);
+    m_content.push_back(block);
     InsertTextVisual(*m_content.back(), m_automationTree, m_colorVisualPeer);
+    return block;
 }
 
 void WebViewFrame::HandleContentLayout()
@@ -76,11 +107,14 @@ void WebViewFrame::HandleContentLayout()
 
     for (auto& block : m_content)
     {
-        block->SetFormatWidth(columnWidth);
-
-        auto& visual = block->GetVisual();
-        visual.Offset({k_leftMargin, y, 0.0f});
-        y += visual.Size().y + k_paraGap;
+        if (block->IsVisible())
+        {
+            block->SetFormatWidth(columnWidth);
+    
+            auto& visual = block->GetVisual();
+            visual.Offset({k_leftMargin, y, 0.0f});
+            y += visual.Size().y + k_paraGap;
+        }
     }
 
     SystemFrame::HandleContentLayout();

--- a/Samples/Islands/UXFrameworksOnIslands/WebViewFrame.h
+++ b/Samples/Islands/UXFrameworksOnIslands/WebViewFrame.h
@@ -13,6 +13,11 @@ public:
         const winrt::WUC::Compositor& systemCompositor,
         const std::shared_ptr<SettingCollection>& settings);
 
+    bool SystemPreTranslateMessage(
+        UINT message,
+        WPARAM wParam,
+        LPARAM lParam) override;
+
 private:
     void InitializeVisualTree(
         const winrt::WUC::Compositor& compositor);
@@ -21,7 +26,7 @@ private:
 
     static constexpr wchar_t k_frameName[] = L"WebView";
 
-    void AddContent(_In_z_ WCHAR const* text, IDWriteTextFormat* textFormat);
+    std::shared_ptr<SystemTextVisual> AddContent(_In_z_ WCHAR const* text, IDWriteTextFormat* textFormat);
 
     static constexpr float k_leftMargin = 10;
     static constexpr float k_topMargin = 10;
@@ -30,5 +35,8 @@ private:
     static constexpr float k_minColumNWidth = 200;
 
     std::shared_ptr<AutomationPeer> m_colorVisualPeer;
-    std::vector<std::unique_ptr<SystemTextVisual>> m_content;
+    std::vector<std::shared_ptr<SystemTextVisual>> m_content;
+    
+    std::shared_ptr<SystemTextVisual> m_acceleratorVisual;
+    bool m_acceleratorActive = false;
 };

--- a/Samples/Islands/UXFrameworksOnIslands/WinUIFrame.cpp
+++ b/Samples/Islands/UXFrameworksOnIslands/WinUIFrame.cpp
@@ -8,7 +8,7 @@
 WinUIFrame::WinUIFrame(const winrt::Compositor& compositor, const std::shared_ptr<SettingCollection>& settings) :
     LiftedFrame(compositor, settings),
     m_labelVisual(GetOutput(), k_frameName),
-    m_acceleratorVisual(GetOutput(), L"2"),
+    m_acceleratorVisual(GetOutput(), L"4"),
     m_focusManager(m_focusList)
 {
     m_labelVisual.SetBackgroundColor(ColorUtils::LightYellow());
@@ -62,7 +62,7 @@ void WinUIFrame::OnPreTranslateTreeMessage(
 
     if (msg->message == WM_SYSKEYDOWN || msg->message == WM_KEYDOWN)
     {
-        if (static_cast<winrt::Windows::System::VirtualKey>(msg->wParam) == winrt::Windows::System::VirtualKey::Control)
+        if (static_cast<winrt::Windows::System::VirtualKey>(msg->wParam) == winrt::Windows::System::VirtualKey::Menu)
         {
             m_acceleratorActive = !m_acceleratorActive;
             m_acceleratorVisual.GetVisual().IsVisible(m_acceleratorActive);
@@ -70,10 +70,10 @@ void WinUIFrame::OnPreTranslateTreeMessage(
         else {
             m_acceleratorActive = false;
             m_acceleratorVisual.GetVisual().IsVisible(false);
-            if (static_cast<winrt::Windows::System::VirtualKey>(msg->wParam) == winrt::Windows::System::VirtualKey::Number2)
+            if (static_cast<winrt::Windows::System::VirtualKey>(msg->wParam) == winrt::Windows::System::VirtualKey::Number4)
             {
                 // Take focus
-                m_focusController.TrySetFocus();
+                m_focusManager.SetFocusToVisual(GetRootVisualTreeNode(), GetRootVisualTreeNode()->OwningFocusList());
             }
         }
     }

--- a/Samples/Islands/UXFrameworksOnIslands/packages.config
+++ b/Samples/Islands/UXFrameworksOnIslands/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Web.WebView2" version="1.0.2792.45" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.2903.40" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.22621.756" targetFramework="native" />
-  <package id="Microsoft.WindowsAppSDK" version="1.7.250127003-experimental3" targetFramework="native" />
+  <package id="Microsoft.WindowsAppSDK" version="1.7.250310001" targetFramework="native" />
 </packages>

--- a/Samples/Islands/UXFrameworksOnIslands/readme.txt
+++ b/Samples/Islands/UXFrameworksOnIslands/readme.txt
@@ -5,10 +5,10 @@
 This project demonstrates how to get started developing Win32 apps using 
 standard C++, leveraging the Windows App SDK and C++/WinRT packages.
 
-The application highlights experimental features from the 
-Microsoft::UI::Content namespace, such as the ReadOnlyDesktopSiteBridge 
-class, the ChildContentLink class, and the ContentIsland class 
-incorporating the Windows::UI::Composition::Visual class as content.
+The application demonstrates how to integrate different UX frameworks 
+within a single application using APIs from the Microsoft.UI.Content
+namespace. It provides practical examples and best practices to achieve a 
+seamless state-of-the-art user experience across multiple UX frameworks. 
 
 ========================================================================
 Learn more about Windows App SDK here:


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Updates for the UXFrameworksOnIslands sample to match refinements in the features from Microsof.UI.Content namespace in WindowsAppSDK 1.7.0.

## Target Release

The PR aligns with the WindowsAppSDK 1.7.0 release aka. 1.7.250310001.

## Checklist

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] If I am onboarding a new feature, then I must have correctly setup a new CI pipeline for my feature with the correct triggers and path filters laid out in the "Onboarding Samples CI Pipeline for new feature" section in samples-guidelines.md.
- [ ] I have commented on my PR `/azp run SamplesCI-<FeatureName>` to have the CI build run on my branch for each of my FeatureName my PR is modifying. This must be done on the latest commit on the PR before merging to ensure the build is up to date and accurate. Warning: the PR will not block automatically if this is not run due to '/azp run' limitation on triggering more than 10 pipelines.
