### PR TITLE
Update WCRForWPF Dotnet Sample to have a new identity and better instructions

### DIFF
--- a/Samples/WindowsCopilotRuntime/cs-wpf-dotnet/README.md
+++ b/Samples/WindowsCopilotRuntime/cs-wpf-dotnet/README.md
@@ -1,6 +1,43 @@
-# DotNet CLI with WCRforWPF
+---
+page_type: sample
+languages:
+- csharp
+products:
+- windows
+- windows-app-sdk
+name: cs-wpf-dotnet
+description: Shows how "dotnet build" command can be used to integrate the Windows Copilot Runtime APIs in a SingleProject MSIX package
+urlFragment: cs-wpf-dotnet
+extendedZipContent:
+- path: LICENSE
+  target: LICENSE
+---
 
-Because DotNet CLI is incompatible with WAPProj, we must first convert the WAPProj to a
+## Prerequisites
+- For system requirements, see [System requirements for Windows app development](https://docs.microsoft.com/windows/apps/windows-app-sdk/system-requirements).
+- To ensure your development environment is set up correctly, see [Install tools for developing apps for Windows 10 and Windows 11](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment).
+- Running this sample does require a [Windows Copilot + PC](https://learn.microsoft.com/windows/ai/npu-devices/)
+- This sample requires [Windows App SDK 1.7 Experimental3](https://learn.microsoft.com/windows/apps/windows-app-sdk/downloads#windows-app-sdk-17-experimental), which should be installed by Visual Studio when deploying or launching the app.
+- This sample requires .NET and .NET CLI [Install .NET on Windows](https://learn.microsoft.com/en-us/dotnet/core/install/windows)
+
+### Suggested Environment
+
+Use "Developer Command Prompt for VS2022" as your command prompt environment
+
+## Build and Run the sample
+In the command line, cd to the root of the solution and run
+```
+runDotNetBuild.cmd or runDotNetBuild.ps1
+```
+
+runDotNetBuild.ps1 will generate the MSIX with a self-signed cert which you will need to install to
+LocalMachine TrustedPeople Certificate Store.
+
+It will then run dotnet build on 
+
+## Sample Overview
+
+Because .NET CLI is incompatible with WAPProj, we must first convert the WAPProj to a
 SingleProjectMSIX This project was converted from a WAPProj to SingleProjectMSIX using the steps
 below https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/single-project-msix?tabs=csharp
 
@@ -28,12 +65,10 @@ Summary of the steps done:
 - In configuration manager, check the deploy box in each of the configuration/platform you want to
   deploy on
 
-# Building with DotNetCLI
 
-In the command line, cd to the root of the solution and run
-```
-runDotNetBuild.cmd
-```
+### Additional Notes
 
-This will build and generate the MSIX with a self-signed cert which you will need to install to
-LocalMachine TrustedPeople Certificate Store.
+## Related Links
+- [Windows Copilot Runtime Overview](https://learn.microsoft.com/windows/ai/apis/)
+- [single-project-msix]https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/single-project-msix?tabs=csharp
+- [Install .NET on Windows](https://learn.microsoft.com/en-us/dotnet/core/install/windows)

--- a/Samples/WindowsCopilotRuntime/cs-wpf-dotnet/WCRforWPF/Package.appxmanifest
+++ b/Samples/WindowsCopilotRuntime/cs-wpf-dotnet/WCRforWPF/Package.appxmanifest
@@ -7,8 +7,8 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="6a6263cd-0e36-45b0-85cd-1a9555a405d5"
-    Publisher="CN=Windows App SDK Samples"
+    Name="SingleProjWCRforWPFSparseDotNet"
+    Publisher="CN=Fabrikam Corporation, O=Fabrikam Corporation, L=Redmond, S=Washington, C=US"
     Version="1.0.0.0" />
 
   <Properties>

--- a/Samples/WindowsCopilotRuntime/cs-wpf-dotnet/WCRforWPF/WCRforWPF.csproj
+++ b/Samples/WindowsCopilotRuntime/cs-wpf-dotnet/WCRforWPF/WCRforWPF.csproj
@@ -49,13 +49,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RepoTestCertificatePFX)' == ''">
-    <RepoTestCertificatePFX>$(MSBuildThisFileDirectory).user\wcrforwpf.certificate.test.pfx</RepoTestCertificatePFX>
+    <RepoTestCertificatePFX>$(MSBuildThisFileDirectory).user\wcrforwpf.certificate.sample.pfx</RepoTestCertificatePFX>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RepoTestCertificatePWD)' == ''">
-    <RepoTestCertificatePWD>$(MSBuildThisFileDirectory).user\wcrforwpf.certificate.test.pwd</RepoTestCertificatePWD>
+    <RepoTestCertificatePWD>$(MSBuildThisFileDirectory).user\wcrforwpf.certificate.sample.pwd</RepoTestCertificatePWD>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RepoTestCertificateCer)' == ''">
-    <RepoTestCertificateCer>$(MSBuildThisFileDirectory).user\wcrforwpf.certificate.test.cer</RepoTestCertificateCer>
+    <RepoTestCertificateCer>$(MSBuildThisFileDirectory).user\wcrforwpf.certificate.sample.cer</RepoTestCertificateCer>
   </PropertyGroup>
   <PropertyGroup Condition="('$(RepoTestCertificatePWD)' != '') and Exists('$(RepoTestCertificatePWD)')">
     <RepoTestCertificatePassword>$([System.IO.File]::ReadAllText('$(RepoTestCertificatePWD)').TrimEnd())</RepoTestCertificatePassword>

--- a/Samples/WindowsCopilotRuntime/cs-wpf-dotnet/runDotNetBuild.ps1
+++ b/Samples/WindowsCopilotRuntime/cs-wpf-dotnet/runDotNetBuild.ps1
@@ -82,4 +82,4 @@ Write-Host "Running 'dotnet build /p:platform=$Platform /p:configuration=$Config
 dotnet build /p:platform=$Platform /p:configuration=$Configuration
 
 Write-Host "`nPlease Install '$PSScriptRoot\WCRforWPF\.user\wcrforwpf.certificate.sample.cer' to Local Machine/Trusted People Store before running"
-Write-Host "`nYou can find the MSIX at $PSScriptRootWCRforWPF\bin\x64\Release\net9.0-windows10.0.22621.0\win-x64\AppPackages\WCRforWPF_Test"
+Write-Host "`nYou can find the MSIX at $PSScriptRoot\WCRforWPF\bin\$Platform\$Configuration\net9.0-windows10.0.22621.0\win-$Platform\AppPackages\WCRforWPF_Test"

--- a/Samples/WindowsCopilotRuntime/cs-wpf-dotnet/runDotNetBuild.ps1
+++ b/Samples/WindowsCopilotRuntime/cs-wpf-dotnet/runDotNetBuild.ps1
@@ -1,8 +1,9 @@
 Param(
     [Parameter(Mandatory=$true)]
-    [string]$Platform = "x64"
+    [string]$Platform = "x64",
+    [Parameter(Mandatory=$true)]
+    [string]$Configuration = "release"
 )
-
 
 function Get-UserPath
 {
@@ -17,10 +18,10 @@ function Get-UserPath
 }
 
 $user_path = Get-UserPath
-$pwd_file = Join-Path $user_path 'wcrforwpf.certificate.test.pwd'
-$cert_thumbprint = Join-Path $user_path 'wcrforwpf.certificate.test.thumbprint'
-$cer = Join-Path $user_path 'wcrforwpf.certificate.test.cer'
-$pfx = Join-Path $user_path 'wcrforwpf.certificate.test.pfx'
+$pwd_file = Join-Path $user_path 'wcrforwpf.certificate.sample.pwd'
+$cert_thumbprint = Join-Path $user_path 'wcrforwpf.certificate.sample.thumbprint'
+$cer = Join-Path $user_path 'wcrforwpf.certificate.sample.cer'
+$pfx = Join-Path $user_path 'wcrforwpf.certificate.sample.pfx'
 
 if (-not (Test-Path $pfx))
 {
@@ -56,10 +57,10 @@ if (-not (Test-Path $pfx))
     $cert_path = "cert:\CurrentUser\My"
     $now = Get-Date
     $expiration = $now.AddMonths(12)
-    $subject = 'CN=Windows App SDK Samples'
-    $friendly_name = "Microsoft.WindowsAppSDK Test Certificate Create=$now"
-    $key_friendly_name = "Microsoft.WindowsAppSDK Test PrivateKey Create=$now"
-    $key_description = "Microsoft.WindowsAppSDK Test PrivateKey Create=$now"
+    $subject = "CN=Fabrikam Corporation, O=Fabrikam Corporation, L=Redmond, S=Washington, C=US"
+    $friendly_name = "Microsoft.WindowsAppSDK Samples Certificate Create=$now"
+    $key_friendly_name = "Microsoft.WindowsAppSDK Samples PrivateKey Create=$now"
+    $key_description = "Microsoft.WindowsAppSDK Samples PrivateKey Create=$now"
     $eku_oid = '2.5.29.37'
     $eku_value = '1.3.6.1.5.5.7.3.3,1.3.6.1.4.1.311.10.3.13'
     $eku = "$eku_oid={text}$eku_value"
@@ -70,12 +71,15 @@ if (-not (Test-Path $pfx))
     Set-Content -Path $cert_thumbprint -Value $thumbprint -Force
     
     # Export the certificate
-    $cer = Join-Path $user_path 'wcrforwpf.certificate.test.cer'
+    $cer = Join-Path $user_path 'wcrforwpf.certificate.sample.cer'
     $export_cer = Export-Certificate -Cert $cert -FilePath $cer -Force
     $cert_personal = "cert:\CurrentUser\My\$thumbprint"
-    $pfx = Join-Path $user_path 'wcrforwpf.certificate.test.pfx'
+    $pfx = Join-Path $user_path 'wcrforwpf.certificate.sample.pfx'
     $export_pfx = Export-PfxCertificate -Cert $cert_personal -FilePath $pfx -Password $password    
 }
 
-Write-Host "Running 'dotnet build /p:platform=$Platform'"
-dotnet build /p:platform=$Platform
+Write-Host "Running 'dotnet build /p:platform=$Platform /p:configuration=$Configuration'"
+dotnet build /p:platform=$Platform /p:configuration=$Configuration
+
+Write-Host "`nPlease Install '$PSScriptRoot\WCRforWPF\.user\wcrforwpf.certificate.sample.cer' to Local Machine/Trusted People Store before running"
+Write-Host "`nYou can find the MSIX at $PSScriptRootWCRforWPF\bin\x64\Release\net9.0-windows10.0.22621.0\win-x64\AppPackages\WCRforWPF_Test"

--- a/Samples/WindowsCopilotRuntime/cs-wpf-sparse/README.md
+++ b/Samples/WindowsCopilotRuntime/cs-wpf-sparse/README.md
@@ -19,6 +19,10 @@ extendedZipContent:
 - Running this sample does require a [Windows Copilot + PC](https://learn.microsoft.com/windows/ai/npu-devices/)
 - This sample requires [Windows App SDK 1.7 Experimental3](https://learn.microsoft.com/windows/apps/windows-app-sdk/downloads#windows-app-sdk-17-experimental), which should be installed by Visual Studio when deploying or launching the app.
 
+### Suggested Environment
+
+Use "Developer Command Prompt for VS2022" as your command prompt environment
+
 ## Build and Run the sample
 
 This folder contains the cs-wpf-sparse sample which uses sparse package built on top of the WPF


### PR DESCRIPTION
## Description

Give a new Identity to the package so it doesn't not conflict with other WCRForWPF packages in the repo

Update Cert Subject Name to be consistent with there WCRForWPF Sparse Package sample. 

Better instructions when running runDotNetBuild.ps1

Update README.md
