### PR TITLE
Fix WCRForWPF Sparse Pacakge App crashing on ImageBuffer.CreateCopyFromBitmap(softwareBitmap);

### DIFF
--- a/Samples/WindowsCopilotRuntime/cs-wpf-sparse/BuildSparsePackage.ps1
+++ b/Samples/WindowsCopilotRuntime/cs-wpf-sparse/BuildSparsePackage.ps1
@@ -21,7 +21,7 @@ if ($Clean) {
         Remove-Item $CleanTargetPath -recurse
       }
     }
-    Get-AppxPackage -AllUsers -Name "WCRforWPFSparse" | Remove-AppxPackage -AllUsers
+    Get-AppxPackage -Name "WCRforWPFSparse" | Remove-AppxPackage
 }
 
 function Get-UserPath

--- a/Samples/WindowsCopilotRuntime/cs-wpf-sparse/BuildSparsePackage.ps1
+++ b/Samples/WindowsCopilotRuntime/cs-wpf-sparse/BuildSparsePackage.ps1
@@ -2,13 +2,31 @@ Param(
     [Parameter(Mandatory=$true)]
     [string]$Platform = "x64",
     [Parameter(Mandatory=$true)]
-    [string]$Configuration = "release"
+    [string]$Configuration = "release",
+    [switch]$Clean
 )
 
+# FUTURE(YML2PS): Update build to no longer place generated files in sources directory
+if ($Clean) {
+    $CleanTargets = @(
+      'bin'
+      'obj'
+    )
+    
+    $ProjectRoot = (Join-Path $PSScriptRoot "WCRforWPF")
+    foreach ($CleanTarget in $CleanTargets)
+    {
+      $CleanTargetPath = (Join-Path $ProjectRoot $CleanTarget)
+      if (Test-Path ($CleanTargetPath)) {
+        Remove-Item $CleanTargetPath -recurse
+      }
+    }
+    Get-AppxPackage -AllUsers -Name "WCRforWPFSparse" | Remove-AppxPackage -AllUsers
+}
 
 function Get-UserPath
 {
-    $root = Join-Path (Get-Item $PSScriptRoot ).FullName "WCRforWPF"
+    $root = Join-Path (Get-Item $PSScriptRoot).FullName "WCRforWPF"
     $user = Join-Path $root '.user'
     if (-not(Test-Path -Path $user -PathType Container))
     {

--- a/Samples/WindowsCopilotRuntime/cs-wpf-sparse/WCRforWPF/AppxManifest.xml
+++ b/Samples/WindowsCopilotRuntime/cs-wpf-sparse/WCRforWPF/AppxManifest.xml
@@ -10,7 +10,6 @@
   IgnorableNamespaces="uap uap2 uap3 rescap desktop uap10">
   <Identity
     Name="WCRforWPFSparse"
-    ProcessorArchitecture="x64"
     Publisher="CN=Fabrikam Corporation, O=Fabrikam Corporation, L=Redmond, S=Washington, C=US"
     Version="1.0.0.0" />
 

--- a/Samples/WindowsCopilotRuntime/cs-wpf-sparse/WCRforWPF/AppxManifest.xml
+++ b/Samples/WindowsCopilotRuntime/cs-wpf-sparse/WCRforWPF/AppxManifest.xml
@@ -26,6 +26,10 @@
   </Resources>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19000.0" MaxVersionTested="10.0.19000.0" />
+      <PackageDependency
+          Name="Microsoft.WindowsAppRuntime.1.7-experimental3"
+          Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+          MinVersion="7000.392.2319.0" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />


### PR DESCRIPTION
## Description
The AppxManifest needs to define the dependency on the WindowsAppRuntime.

I've also implemented an -clean option on the Build script to ensure that the MSIX will get replaced too. 