### PR TITLE
[WCR Sample] Single dotnet run with unpackage selfcontained as example.

### DIFF
--- a/Samples/WindowsCopilotRuntime/README.md
+++ b/Samples/WindowsCopilotRuntime/README.md
@@ -39,17 +39,12 @@ join the [Windows Insider Program](https://insider.windows.com).
 # Contributing to this project
 - Refer to the [contributing guide](./Contributing.md)
 
-## Special Considerations for Debugging as an Unpackaged App in Visual Studio
+## Special Considerations for Unpackaged & Self-Contained Mode with WCR
 
-- This project is not designed to be fully functional in an unpackaged app. However, Windows Copilot Runtime does support unpackaged app.
-- To enable proper startup as an unpackaged app, you need to bootstrap the Windows App SDK either Programmatically or By adding the following configuration to the `.csproj` file during the build process:
- ```xml
-  <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
-  <WindowsPackageType>None</WindowsPackageType>
- ```
-- Alternatively, if you are using the Developer Command Prompt for Visual Studio, you can run the app as an ARM64 version using the following command, with the bootstrap property provided:
+- This project is not intended to be fully functional when running as an unpackaged app. However, Windows Copilot Runtime (WCR) does support unpackaged apps.
+- Self contained mode is fully supported by WCR apis as well.
+- The following command demonstrates how to run the app as an ARM64 unpackaged application in self-contained mode (for both .NET and WinAppSDK):
 ```powershell
-dotnet run -p:Configuration=Debug -p:Platform=ARM64 -p:WindowsPackageType=None -p:WindowsAppSdkBootstrapInitialize=true
+dotnet run -p:Configuration=Debug -p:Platform=ARM64 -p:WindowsPackageType=None -p:WindowsAppSDKSelfContained=true -p:SelfContained=true
 ```
-- Self contained mode is fully supported by WCR apis.     
 - One careful consideration while using self contained mode. The OS ACL permissions prevent it to run inside any folder in `C:\Users` like `Downloads` because `WorksloadsSessionManager` running as a local service, cannot load WCR dlls from that folder with default permissions. This is by security choice, by design. The two ways to solve it are a) Move the self contained folder out of `C:\Users` where ACLs are not too restrictive or b) provide Local Service to access the said self contained folder within `C:\Users`. Only affects self contained mode, it doesn't affect other config modes.


### PR DESCRIPTION
## Description

Given WCR already support Self-contained in WinAppSDK 1.8 experimental 1, updated the dotnet run command example in readme accordingly.

## Target Release

Please specify which release this PR should align with WCR WinAppSDK 1.8 experimental 1, which is what the project is referencing now.