### PR TITLE
Update WCR Winforms sample to WASDK version 1.8-exp1

### DIFF
--- a/Samples/WindowsCopilotRuntime/cs-winforms/MainForm.cs
+++ b/Samples/WindowsCopilotRuntime/cs-winforms/MainForm.cs
@@ -111,28 +111,65 @@ namespace WindowsCopilotRuntimeSample
         private async Task LoadAIModels()
         {
             // Load the AI models needed for image processing
-            if (!LanguageModel.IsAvailable())
+            switch (LanguageModel.GetReadyState())
             {
-                var result = await LanguageModel.MakeAvailableAsync();
-                if (result.Status != Microsoft.Windows.Management.Deployment.PackageDeploymentStatus.CompletedSuccess)
-                {
-                    throw new Exception(result.ExtendedError.Message);
-                }
+                case Microsoft.Windows.AI.AIFeatureReadyState.EnsureNeeded:
+                    System.Diagnostics.Debug.WriteLine("Ensure LanguageModel is ready");
+                    var op = await LanguageModel.EnsureReadyAsync();
+                    System.Diagnostics.Debug.WriteLine($"LanguageModel.EnsureReadyAsync completed with status: {op.Status}");
+                    if (op.Status != Microsoft.Windows.AI.AIFeatureReadyResultState.Success)
+                    {
+                        richTextBoxForImageSummary.Text = "Language model not ready for use";
+                        throw new Exception("Language model not ready for use");
+                    }
+                    break;
+                case Microsoft.Windows.AI.AIFeatureReadyState.DisabledByUser:
+                    System.Diagnostics.Debug.WriteLine("Language model disabled by user");
+                    richTextBoxForImageSummary.Text = "Language model disabled by user";
+                    return;
+                case Microsoft.Windows.AI.AIFeatureReadyState.NotSupportedOnCurrentSystem:
+                    System.Diagnostics.Debug.WriteLine("Language model not supported on current system");
+                    richTextBoxForImageSummary.Text = "Language model not supported on current system";
+                    return;
             }
 
-            languageModel = await LanguageModel.CreateAsync();
-            if (languageModel == null)
+            try
             {
-                throw new Exception("Failed to create LanguageModel instance.");
+                // There is a bug in 1.8 where the LanguageModel.GetReadyState() is not
+                // returning the correct state. The call to CreateAsync() will throw
+                // an exception if the state is not ready.The sample application
+                // will log the error and continue for now.
+                languageModel = await LanguageModel.CreateAsync();
+                if (languageModel == null)
+                {
+                    throw new Exception("Failed to create LanguageModel instance.");
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error creating LanguageModel: {ex.Message}");
             }
 
-            if (!TextRecognizer.IsAvailable())
+            switch (TextRecognizer.GetReadyState())
             {
-                var result = await TextRecognizer.MakeAvailableAsync();
-                if (result.Status != Microsoft.Windows.Management.Deployment.PackageDeploymentStatus.CompletedSuccess)
-                {
-                    throw new Exception(result.ExtendedError.Message);
-                }
+                case Microsoft.Windows.AI.AIFeatureReadyState.EnsureNeeded:
+                    System.Diagnostics.Debug.WriteLine("Ensure TextRecognizer is ready");
+                    var op = await TextRecognizer.EnsureReadyAsync();
+                    System.Diagnostics.Debug.WriteLine($"TextRecognizer.EnsureReadyAsync completed with status: {op.Status}");
+                    if (op.Status != Microsoft.Windows.AI.AIFeatureReadyResultState.Success)
+                    {
+                        richTextBoxForImageText.Text = "Text recognizer not ready for use";
+                        throw new Exception("Text recognizer not ready for use");
+                    }
+                    break;
+                case Microsoft.Windows.AI.AIFeatureReadyState.DisabledByUser:
+                    System.Diagnostics.Debug.WriteLine("Text Recognizer disabled by user");
+                    richTextBoxForImageText.Text = "Text recognizer disabled by user";
+                    return;
+                case Microsoft.Windows.AI.AIFeatureReadyState.NotSupportedOnCurrentSystem:
+                    System.Diagnostics.Debug.WriteLine("Text Recognizer not supported on current system");
+                    richTextBoxForImageText.Text = "Text recognizer not supported on current system";
+                    return;
             }
 
             textRecognizer = await TextRecognizer.CreateAsync();
@@ -148,7 +185,10 @@ namespace WindowsCopilotRuntimeSample
             // else it returns an interface not registered error.
             // This issue is currently under investigation.
             string prompt = "What is Windows App SDK?";
-            var output = await languageModel!.GenerateResponseAsync(prompt);
+            if (languageModel != null)
+            {
+                var output = await languageModel.GenerateResponseAsync(prompt);
+            }
 
             ImageBuffer? imageBuffer = await LoadImageBufferFromFileAsync(pathToImage);
 
@@ -184,31 +224,39 @@ namespace WindowsCopilotRuntimeSample
             string systemPrompt = "You summarize user-provided text to a software developer audience." +
                 "Respond only with the summary and no additional text.";
 
-            // To learn more about content moderation, visit https://learn.microsoft.com/windows/ai/apis/content-moderation
-            var promptMinSeverityLevelToBlock = new TextContentFilterSeverity {
-                HateContentSeverity = SeverityLevel.Low,
-                SexualContentSeverity = SeverityLevel.Low,
-                ViolentContentSeverity = SeverityLevel.Low,
-                SelfHarmContentSeverity = SeverityLevel.Low
+            // Update the property names to match the correct ones based on the provided type signature.  
+            var promptMaxAllowedSeverityLevel = new TextContentFilterSeverity {
+                Hate = SeverityLevel.Low,
+                Sexual = SeverityLevel.Low,
+                Violent = SeverityLevel.Low,
+                SelfHarm = SeverityLevel.Low
             };
 
-            var responseMinSeverityLevelToBlock = new TextContentFilterSeverity {
-                HateContentSeverity = SeverityLevel.Low,
-                SexualContentSeverity = SeverityLevel.Low,
-                ViolentContentSeverity = SeverityLevel.Low,
-                SelfHarmContentSeverity = SeverityLevel.Low
+            var responseMaxAllowedSeverityLevel = new TextContentFilterSeverity {
+                Hate = SeverityLevel.Low,
+                Sexual = SeverityLevel.Low,
+                Violent = SeverityLevel.Low,
+                SelfHarm = SeverityLevel.Low
             };
 
             var contentFilterOptions = new ContentFilterOptions {
-                PromptMinSeverityLevelToBlock = promptMinSeverityLevelToBlock,
-                ResponseMinSeverityLevelToBlock = responseMinSeverityLevelToBlock
+                PromptMaxAllowedSeverityLevel = promptMaxAllowedSeverityLevel,
+                ResponseMaxAllowedSeverityLevel = responseMaxAllowedSeverityLevel
             };
 
-            // Create a context for the language model
-            var languageModelContext = languageModel!.CreateContext(systemPrompt, contentFilterOptions);
-            string prompt = "Summarize the following text: " + text;
-            var output = await languageModel!.GenerateResponseAsync(new LanguageModelOptions(), prompt, contentFilterOptions, languageModelContext);
-            richTextBoxForImageSummary.Text = output.Response;
+            if (languageModel != null)
+            {
+                // Create a context for the language model
+                var languageModelContext = languageModel!.CreateContext(systemPrompt, contentFilterOptions);
+                string prompt = "Summarize the following text: " + text;
+                var output = await languageModel.GenerateResponseAsync(languageModelContext, prompt, new LanguageModelOptions());
+                richTextBoxForImageSummary.Text = output.Text;
+            }
+            else
+            {
+                System.Diagnostics.Debug.WriteLine("Error: LanguageModel is null but should have been created during LoadinAIModel stage");
+                richTextBoxForImageSummary.Text = "Error: LanguageModel is null";
+            }
         }
     }
 }

--- a/Samples/WindowsCopilotRuntime/cs-winforms/MainForm.cs
+++ b/Samples/WindowsCopilotRuntime/cs-winforms/MainForm.cs
@@ -254,7 +254,7 @@ namespace WindowsCopilotRuntimeSample
             }
             else
             {
-                System.Diagnostics.Debug.WriteLine("Error: LanguageModel is null but should have been created during LoadinAIModel stage");
+                System.Diagnostics.Debug.WriteLine("Error: LanguageModel is null but should have been created during LoadAIModels()");
                 richTextBoxForImageSummary.Text = "Error: LanguageModel is null";
             }
         }

--- a/Samples/WindowsCopilotRuntime/cs-winforms/MainForm.cs
+++ b/Samples/WindowsCopilotRuntime/cs-winforms/MainForm.cs
@@ -181,15 +181,6 @@ namespace WindowsCopilotRuntimeSample
 
         private async Task<string> PerformTextRecognition()
         {
-            // The OCR model requires the LanguageModel to be used first or
-            // else it returns an interface not registered error.
-            // This issue is currently under investigation.
-            string prompt = "What is Windows App SDK?";
-            if (languageModel != null)
-            {
-                var output = await languageModel.GenerateResponseAsync(prompt);
-            }
-
             ImageBuffer? imageBuffer = await LoadImageBufferFromFileAsync(pathToImage);
 
             if (imageBuffer == null)

--- a/Samples/WindowsCopilotRuntime/cs-winforms/WindowsCopilotRuntimeSample.csproj
+++ b/Samples/WindowsCopilotRuntime/cs-winforms/WindowsCopilotRuntimeSample.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250127003-experimental3" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250410001-experimental1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description
This PR updates the WCR Winforms sample to use WASDK 1.8-experimental1

## Target Release
The example currently targets the 1.8-experimental1 which contains the WCR API. However, this will be updated in the future to target the stable release when it becomes available.

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
