### PR TITLE
Remove workaround for WindowsCopilotRuntime/cs-winforms-sparse sample

### DIFF
--- a/Samples/WindowsCopilotRuntime/cs-winforms-sparse/WCRforWinforms/MainForm.cs
+++ b/Samples/WindowsCopilotRuntime/cs-winforms-sparse/WCRforWinforms/MainForm.cs
@@ -183,12 +183,6 @@ namespace WindowsCopilotRuntimeSample
 
         private async Task<string> PerformTextRecognition()
         {
-            // The OCR model requires the LanguageModel to be used first or
-            // else it returns an interface not registered error.
-            // This issue is currently under investigation.
-            string prompt = "What is Windows App SDK?";
-            var output = await languageModel!.GenerateResponseAsync(prompt);
-
             ImageBuffer? imageBuffer = await LoadImageBufferFromFileAsync(pathToImage);
 
             if (imageBuffer == null)


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

This PR removes the workaround for a bug where the OCR model returns with an "interface not registered" error. This sample was updated to WindowsAppSDK version 1.8-exp1 where the issue no longer reproduces. 

## Target Release
The example currently targets the 1.8-experimental1 which contains the WCR API. However, this will be updated in the future to target the stable release when it becomes available.

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
