### PR TITLE
Restore global.json in WindowsCopilotRuntime\cs-winui sample

### DIFF
--- a/Samples/WindowsCopilotRuntime/cs-winui/global.json
+++ b/Samples/WindowsCopilotRuntime/cs-winui/global.json
@@ -1,0 +1,10 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "allowPrerelease": true,
+    "rollForward": "latestFeature"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "3.7.0"
+  }
+}


### PR DESCRIPTION
Revert #459, which is causing problems in the pipelines (which are seemingly finding and applying this to all samples, not just the one it is in the folder for).