### PR TITLE
fix Warning APPX1901 by setting default language

### DIFF
--- a/Samples/AppLifecycle/Activation/cpp/cpp-console-unpackaged/CppWinRtConsoleActivation/CppWinRtConsoleActivation.vcxproj
+++ b/Samples/AppLifecycle/Activation/cpp/cpp-console-unpackaged/CppWinRtConsoleActivation/CppWinRtConsoleActivation.vcxproj
@@ -28,6 +28,7 @@
     <RootNamespace>CppWinRtConsoleActivation</RootNamespace>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/Samples/AppLifecycle/Activation/cpp/cpp-win32-packaged/CppWinMainActivation/CppWinMainActivation.vcxproj
+++ b/Samples/AppLifecycle/Activation/cpp/cpp-win32-packaged/CppWinMainActivation/CppWinMainActivation.vcxproj
@@ -49,6 +49,7 @@
     <RootNamespace>CppWinMainActivation</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
     <ProjectName>CppWinMainActivation</ProjectName>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/AppLifecycle/Activation/cpp/cpp-win32-unpackaged/CppWinMainActivation/CppWinMainActivation.vcxproj
+++ b/Samples/AppLifecycle/Activation/cpp/cpp-win32-unpackaged/CppWinMainActivation/CppWinMainActivation.vcxproj
@@ -49,6 +49,7 @@
     <RootNamespace>CppWinMainActivation</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <ProjectName>CppWinMainActivation</ProjectName>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/AppLifecycle/EnvironmentVariables/cpp-console-unpackaged/CppWinRtConsoleEnv/CppWinRtConsoleEnv.vcxproj
+++ b/Samples/AppLifecycle/EnvironmentVariables/cpp-console-unpackaged/CppWinRtConsoleEnv/CppWinRtConsoleEnv.vcxproj
@@ -29,6 +29,7 @@
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <WindowsPackageType>None</WindowsPackageType>
     <WinUISDKReferences>false</WinUISDKReferences>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/Samples/AppLifecycle/EnvironmentVariables/cpp-win32-unpackaged/CppWinMainEnv/CppWinMainEnv.vcxproj
+++ b/Samples/AppLifecycle/EnvironmentVariables/cpp-win32-unpackaged/CppWinMainEnv/CppWinMainEnv.vcxproj
@@ -50,6 +50,7 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsPackageType>None</WindowsPackageType>
     <WinUISDKReferences>false</WinUISDKReferences>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/AppLifecycle/Instancing/cpp/cpp-console-unpackaged/CppWinRtConsoleInstancing/CppWinRtConsoleInstancing.vcxproj
+++ b/Samples/AppLifecycle/Instancing/cpp/cpp-console-unpackaged/CppWinRtConsoleInstancing/CppWinRtConsoleInstancing.vcxproj
@@ -27,6 +27,7 @@
     <RootNamespace>CppWinRtConsoleInstancing</RootNamespace>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/Samples/AppLifecycle/Instancing/cpp/cpp-win32-packaged/CppWinMainInstancing/CppWinMainInstancing.vcxproj
+++ b/Samples/AppLifecycle/Instancing/cpp/cpp-win32-packaged/CppWinMainInstancing/CppWinMainInstancing.vcxproj
@@ -49,6 +49,7 @@
     <RootNamespace>CppWinMainInstancing</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>CppWinMainInstancing</ProjectName>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/AppLifecycle/Instancing/cpp/cpp-win32-unpackaged/CppWinMainInstancing/CppWinMainInstancing.vcxproj
+++ b/Samples/AppLifecycle/Instancing/cpp/cpp-win32-unpackaged/CppWinMainInstancing/CppWinMainInstancing.vcxproj
@@ -49,6 +49,7 @@
     <RootNamespace>CppWinMainInstancing</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>CppWinMainInstancing</ProjectName>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/AppLifecycle/Restart/cpp-console-unpackaged/cpp-console-unpackaged.vcxproj
+++ b/Samples/AppLifecycle/Restart/cpp-console-unpackaged/cpp-console-unpackaged.vcxproj
@@ -51,6 +51,7 @@
     <RootNamespace>cppconsoleunpackaged</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <LogSDKReferenceResolutionErrorsAsWarnings>true</LogSDKReferenceResolutionErrorsAsWarnings>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/AppLifecycle/StateNotifications/cpp/cpp-console-unpackaged/CppWinRtConsoleState/CppWinRtConsoleState.vcxproj
+++ b/Samples/AppLifecycle/StateNotifications/cpp/cpp-console-unpackaged/CppWinRtConsoleState/CppWinRtConsoleState.vcxproj
@@ -27,6 +27,7 @@
     <RootNamespace>CppWinRtConsoleState</RootNamespace>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/Samples/AppLifecycle/StateNotifications/cpp/cpp-win32-packaged/CppWinMainState/CppWinMainState.vcxproj
+++ b/Samples/AppLifecycle/StateNotifications/cpp/cpp-win32-packaged/CppWinMainState/CppWinMainState.vcxproj
@@ -48,6 +48,7 @@
     <ProjectGuid>{e64edb1a-95f0-48ce-8581-597e0495b7fe}</ProjectGuid>
     <RootNamespace>CppWinMainState</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/AppLifecycle/StateNotifications/cpp/cpp-win32-unpackaged/CppWinMainState/CppWinMainState.vcxproj
+++ b/Samples/AppLifecycle/StateNotifications/cpp/cpp-win32-unpackaged/CppWinMainState/CppWinMainState.vcxproj
@@ -48,6 +48,7 @@
     <ProjectGuid>{e64edb1a-95f0-48ce-8581-597e0495b7fe}</ProjectGuid>
     <RootNamespace>CppWinMainState</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/Insights/cpp-win32/InsightsSample.vcxproj
+++ b/Samples/Insights/cpp-win32/InsightsSample.vcxproj
@@ -49,6 +49,7 @@
     <RootNamespace>InsightsSample</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>Insights</ProjectName>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/Mica/cpp-WebView2/Mica-WebView2/MicaWebView2.vcxproj
+++ b/Samples/Mica/cpp-WebView2/Mica-WebView2/MicaWebView2.vcxproj
@@ -75,6 +75,7 @@
     <ProjectName>Mica-WebView2</ProjectName>
     <WindowsPackageType>None</WindowsPackageType>
 	<LogSDKReferenceResolutionErrorsAsWarnings>true</LogSDKReferenceResolutionErrorsAsWarnings>
+  <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/Mica/cpp-win32/WinAppSDKMicaSample/WinAppSDKMicaSample.vcxproj
+++ b/Samples/Mica/cpp-win32/WinAppSDKMicaSample/WinAppSDKMicaSample.vcxproj
@@ -66,12 +66,13 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <WindowsPackageType>None</WindowsPackageType>
-	<VCProjectVersion>16.0</VCProjectVersion>
+	  <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{3cb3adb7-b8c8-42a1-8f4a-236f77fb40a8}</ProjectGuid>
     <RootNamespace>WinAppSDKMicaSample</RootNamespace>
-     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion> 
-	<LogSDKReferenceResolutionErrorsAsWarnings>true</LogSDKReferenceResolutionErrorsAsWarnings>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion> 
+	  <LogSDKReferenceResolutionErrorsAsWarnings>true</LogSDKReferenceResolutionErrorsAsWarnings>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/Notifications/Push/cpp-console-packaged/cpp-console.vcxproj
+++ b/Samples/Notifications/Push/cpp-console-packaged/cpp-console.vcxproj
@@ -50,6 +50,7 @@
     <RootNamespace>cppconsole</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <LogSDKReferenceResolutionErrorsAsWarnings>true</LogSDKReferenceResolutionErrorsAsWarnings>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/Notifications/Push/cpp-console-unpackaged/cpp-console-unpackaged.vcxproj
+++ b/Samples/Notifications/Push/cpp-console-unpackaged/cpp-console-unpackaged.vcxproj
@@ -51,6 +51,7 @@
     <RootNamespace>cppconsoleunpackaged</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <LogSDKReferenceResolutionErrorsAsWarnings>true</LogSDKReferenceResolutionErrorsAsWarnings>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/ResourceManagement/cpp/cpp-console-unpackaged/console_unpackaged_app.vcxproj
+++ b/Samples/ResourceManagement/cpp/cpp-console-unpackaged/console_unpackaged_app.vcxproj
@@ -52,6 +52,7 @@
     <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <LogSDKReferenceResolutionErrorsAsWarnings>true</LogSDKReferenceResolutionErrorsAsWarnings>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/SelfContainedDeployment/cpp/cpp-console-unpackaged/SelfContainedDeployment.vcxproj
+++ b/Samples/SelfContainedDeployment/cpp/cpp-console-unpackaged/SelfContainedDeployment.vcxproj
@@ -28,6 +28,7 @@
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/Samples/TextRendering/cpp-win32/DWriteCoreGallery/DWriteCoreGallery.vcxproj
+++ b/Samples/TextRendering/cpp-win32/DWriteCoreGallery/DWriteCoreGallery.vcxproj
@@ -48,6 +48,7 @@
     <ProjectGuid>{d8b2b69b-b493-46f8-a8e7-c40a7c41728d}</ProjectGuid>
     <RootNamespace>DWriteCoreGallery</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/Unpackaged/cpp-console-unpackaged/Unpackaged.vcxproj
+++ b/Samples/Unpackaged/cpp-console-unpackaged/Unpackaged.vcxproj
@@ -52,6 +52,7 @@
     <!-- WindowsPackageType=None enables auto-initialization of the WinAppSDK framework-->
     <WindowsPackageType>None</WindowsPackageType>
     <WinUISDKReferences>False</WinUISDKReferences>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Samples/Widgets/cpp-win32-packaged/SampleWidgetProviderApp/SampleWidgetProviderApp.vcxproj
+++ b/Samples/Widgets/cpp-win32-packaged/SampleWidgetProviderApp/SampleWidgetProviderApp.vcxproj
@@ -28,6 +28,7 @@
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ProjectName>SampleWidgetProviderApp</ProjectName>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/Samples/Windowing/cpp/cpp-win32/Windowing/Windowing.vcxproj
+++ b/Samples/Windowing/cpp/cpp-win32/Windowing/Windowing.vcxproj
@@ -73,6 +73,7 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <LogSDKReferenceResolutionErrorsAsWarnings>true</LogSDKReferenceResolutionErrorsAsWarnings>
     <ProjectName>Windowing</ProjectName>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
## Description
Fixed the issue that Warning APPX1901 appears in the ADO pipeline in test projects that use winAppSDK-samples.
For example:
`##[warning]WindowsAppSDK-Samples\Samples\AppLifecycle\Activation\cpp\cpp-console-unpackaged\packages\Microsoft.Windows.SDK.BuildTools.MSIX.1.7.20250508.1\build\Microsoft.Windows.SDK.BuildTools.MSIX.MrtCore.PriGen.targets(1409,5): Warning APPX1901: The DefaultLanguage property is either missing from the project file or does not have a value. The fallback language is set to the Visual Studio language: en-US.
`

## Target Release
Windows App SDK 1.8

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [x] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
