### PR TITLE
Move to WinAppSDK to 1.8 exp 3

### DIFF
--- a/Samples/WindowsAIFoundry/cs-winui/WindowsAISample.csproj
+++ b/Samples/WindowsAIFoundry/cs-winui/WindowsAISample.csproj
@@ -20,7 +20,6 @@
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundle>Never</AppxBundle>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <PackageCertificateKeyFile>WindowsAISample_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Controls\ModelInitializationControl.xaml" />
@@ -51,8 +50,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.1" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250515001-experimental2" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250610002-experimental3" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 


### PR DESCRIPTION
Moves the sample to winappsdk 1.8 exp 3. no other changes in this PR.