### PR TITLE
fix warnings caused by samples repo

### DIFF
--- a/Samples/Notifications/Badge/cpp-winui/Scenario2_GlyphBadge.xaml.cpp
+++ b/Samples/Notifications/Badge/cpp-winui/Scenario2_GlyphBadge.xaml.cpp
@@ -28,7 +28,7 @@ namespace winrt::cpp_winui::implementation
         Scenario2_GlyphBadge::rootPage = MainPage::Current();
     }
 
-    void Scenario2_GlyphBadge::badgeButton_Click(IInspectable const& sender, RoutedEventArgs const& e) {
+    void Scenario2_GlyphBadge::badgeButton_Click(IInspectable const& sender, [[maybe_unused]] RoutedEventArgs const& e) {
         auto button = sender.as<Button>();
         auto tag = button.Tag().as<hstring>();
 

--- a/Samples/WindowsAIFoundry/cs-winui/Models/LanguageModelModel.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/Models/LanguageModelModel.cs
@@ -19,7 +19,7 @@ internal class LanguageModelModel : IModelManager
     private TextSummarizer? _sessionTextSummarize;
     private TextRewriter? _sessionTextRewrite;
     private TextToTableConverter? _sessionTextToTable;
-    private LanguageModelExperimental _languageModelExperimental;
+    private LanguageModelExperimental? _languageModelExperimental;
 
     public async Task CreateModelSessionWithProgress(IProgress<double> progress,
                                                             CancellationToken cancellationToken = default)
@@ -52,6 +52,7 @@ internal class LanguageModelModel : IModelManager
     private TextSummarizer SessionTextSummarize => _sessionTextSummarize ?? throw new InvalidOperationException("Text summarizer session was not created yet");
     private TextRewriter SessionTextRewrite => _sessionTextRewrite ?? throw new InvalidOperationException("Text Rewriter session was not created yet");
     private TextToTableConverter SessionTextToTable => _sessionTextToTable ?? throw new InvalidOperationException("TextToTable converter session was not created yet");
+    private LanguageModelExperimental SessionLanguageModelExperimental => _languageModelExperimental ?? throw new InvalidOperationException("Language Model Experimental session was not created yet");
 
     public IAsyncOperationWithProgress<LanguageModelResponseResult, string> 
         GenerateResponseWithProgressAsync(string prompt, CancellationToken cancellationToken = default)
@@ -175,7 +176,7 @@ internal class LanguageModelModel : IModelManager
     {
         IAsyncOperationWithProgress<LanguageModelResponseResult, string> response;
 
-        var loraAdapter = _languageModelExperimental.LoadAdapter(filePath);
+        var loraAdapter = SessionLanguageModelExperimental.LoadAdapter(filePath);
         var options = new LanguageModelOptionsExperimental {
             LoraAdapter = !string.IsNullOrEmpty(filePath) ? loraAdapter : null
         };
@@ -184,11 +185,11 @@ internal class LanguageModelModel : IModelManager
         {
             var contentFilterOptions = new ContentFilterOptions();
             var languageModelContext = Session.CreateContext(contextPrompt, contentFilterOptions);
-            response = _languageModelExperimental.GenerateResponseAsync(languageModelContext, prompt, options);
+            response = SessionLanguageModelExperimental.GenerateResponseAsync(languageModelContext, prompt, options);
         }
         else
         {
-            response = _languageModelExperimental.GenerateResponseAsync(prompt, options);
+            response = SessionLanguageModelExperimental.GenerateResponseAsync(prompt, options);
         }
 
         return new AsyncOperationWithProgressAdapter<LanguageModelResponseResult, string, LanguageModelResponseResult, string>(

--- a/Samples/WindowsAIFoundry/cs-winui/ViewModels/LanguageModelViewModel.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/ViewModels/LanguageModelViewModel.cs
@@ -187,7 +187,7 @@ internal partial class LanguageModelViewModel : CopilotModelBase<LanguageModelMo
                 _responseProgressWithLoRA.Clear();
                 DispatchPropertyChanged(nameof(ResponseProgressWithLoRA));
 
-                return Session.GenerateResponseWithLoraAdapterAndContextAsync(Context, prompt!, AdapterFilePath!);
+                return Session.GenerateResponseWithLoraAdapterAndContextAsync(Context ?? string.Empty, prompt!, AdapterFilePath!);
             },
             (prompt) => IsAvailable && !string.IsNullOrEmpty(LoRAPrompt));
 
@@ -229,7 +229,7 @@ internal partial class LanguageModelViewModel : CopilotModelBase<LanguageModelMo
             var file = await picker.PickSingleFileAsync();
             if (file != null)
             {
-                DispatcherQueue.EnqueueAsync(async () =>
+                await DispatcherQueue.EnqueueAsync(() =>
                 {
                     AdapterFilePath = file.Path;
                 });

--- a/Samples/WindowsAIFoundry/cs-wpf-sparse/WindowsAISampleForWPF/App.xaml.cs
+++ b/Samples/WindowsAIFoundry/cs-wpf-sparse/WindowsAISampleForWPF/App.xaml.cs
@@ -104,11 +104,11 @@ public partial class App : Application
     // proved to be a proper solution to avoid this issue.
     private void OnStartUp(Object sender, StartupEventArgs e)
     {
-        RestartWithIdentityIfNecessary();
+        _ = RestartWithIdentityIfNecessaryAsync();
         InitializeComponent();
     }
 
-    private async Task RestartWithIdentityIfNecessary()
+    private async Task RestartWithIdentityIfNecessaryAsync()
     {
         // If we are in the packaged process, then present the MainWindow
         if (IsPackagedProcess())
@@ -128,7 +128,12 @@ public partial class App : Application
     private async Task RegisterSparsePackage()
     {
         // We expect the MSIX to be in the same directory as the exe. 
-        string exePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        string? exePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        if (exePath == null)
+        {
+            throw new InvalidOperationException("Could not determine the directory of the executing assembly.");
+        }
+        
         string externalLocation = exePath;
         string sparsePkgPath = exePath + "\\WindowsAISampleForWPFSparse.msix";
 
@@ -172,13 +177,13 @@ public partial class App : Application
             throw new Exception("Failed to create ApplicationActivationManager!");
         }
         var applicationActivationManager = (NativeMethods.IApplicationActivationManager)applicationActivationManagerAsObject;
-        applicationActivationManager.ActivateApplication(appUserModelId, null, NativeMethods.ActivateOptions.None, out uint processId);
+        applicationActivationManager.ActivateApplication(appUserModelId, string.Empty, NativeMethods.ActivateOptions.None, out uint processId);
     }
 
     private static bool IsPackagedProcess()
     {
         int length = 0;
-        int result = NativeMethods.GetCurrentPackageFullName(ref length, null);
+        int result = NativeMethods.GetCurrentPackageFullName(ref length, null!);
         if (result == 15700) // APPMODEL_ERROR_NO_PACKAGE
         {
             return false;

--- a/Samples/WindowsAIFoundry/cs-wpf-sparse/WindowsAISampleForWPF/MainWindow.xaml.cs
+++ b/Samples/WindowsAIFoundry/cs-wpf-sparse/WindowsAISampleForWPF/MainWindow.xaml.cs
@@ -81,7 +81,7 @@ public partial class MainWindow : Window
             this.Description.Text = this.FileContent.Text;
             await LoadAIModels();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             this.FileContent.Text = "An error has occured: Loading AI models...";
             this.Description.Text = this.FileContent.Text;
@@ -94,7 +94,7 @@ public partial class MainWindow : Window
             this.FileContent.Text = "Performing Text Recognition";
             textInImage = await PerformTextRecognition();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             this.FileContent.Text = "An error has occured: Performing Text Recognition...";
             return;
@@ -105,7 +105,7 @@ public partial class MainWindow : Window
             this.Description.Text = "Performing Text Description";
             await SummarizeImageText(textInImage);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             this.Description.Text = "An error has occured: Performing Text Description...";
             return;
@@ -172,7 +172,7 @@ public partial class MainWindow : Window
         }
     }
 
-    private async Task<string> PerformTextRecognition()
+    private Task<string> PerformTextRecognition()
     {
         if (_currentImage == null)
         {
@@ -185,7 +185,7 @@ public partial class MainWindow : Window
         string text = string.Join(Environment.NewLine, recognizedTextLines);
 
         this.FileContent.Text = text;
-        return text;
+        return Task.FromResult(text);
     }
 
     private async Task SummarizeImageText(string text)

--- a/Samples/WindowsAIFoundry/cs-wpf/WindowsAISampleForWPF/MainWindow.xaml.cs
+++ b/Samples/WindowsAIFoundry/cs-wpf/WindowsAISampleForWPF/MainWindow.xaml.cs
@@ -81,7 +81,7 @@ public partial class MainWindow : Window
             this.Description.Text = this.FileContent.Text;
             await LoadAIModels();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             this.FileContent.Text = "An error has occured: Loading AI models...";
             this.Description.Text = this.FileContent.Text;
@@ -94,7 +94,7 @@ public partial class MainWindow : Window
             this.FileContent.Text = "Performing Text Recognition";
             textInImage = await PerformTextRecognition();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             this.FileContent.Text = "An error has occured: Performing Text Recognition...";
             return;
@@ -105,7 +105,7 @@ public partial class MainWindow : Window
             this.Description.Text = "Performing Text Description";
             await SummarizeImageText(textInImage);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             this.Description.Text = "An error has occured: Performing Text Description...";
             return;
@@ -172,7 +172,7 @@ public partial class MainWindow : Window
         }
     }
 
-    private async Task<string> PerformTextRecognition()
+    private Task<string> PerformTextRecognition()
     {
         if (_currentImage == null)
         {
@@ -185,7 +185,7 @@ public partial class MainWindow : Window
         string text = string.Join(Environment.NewLine, recognizedTextLines);
 
         this.FileContent.Text = text;
-        return text;
+        return Task.FromResult(text);
     }
 
     private async Task SummarizeImageText(string text)


### PR DESCRIPTION
There are lots of warnings while testing the samples. Here is an example [Aggregator build](https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=126059300&view=logs&j=5a7b29ea-1fa4-515d-c5a6-74125fabdc84&t=1acd5276-22e7-5320-550d-29393a1c0c80)

<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Please include a summary of the change and/or which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Target Release

Please specify which release this PR should align with. e.g., 1.0, 1.1, 1.1 Preview 1.

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
