### PR TITLE
Modify Resnet solution to include explicit platforms for x64 and ARM64

### DIFF
--- a/Samples/WindowsML/cs/ResnetBuildDemoCS/ResnetBuildDemoCS.sln
+++ b/Samples/WindowsML/cs/ResnetBuildDemoCS/ResnetBuildDemoCS.sln
@@ -1,20 +1,26 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.36105.23 d17.13
+VisualStudioVersion = 17.13.36105.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResnetBuildDemoCS", "ResnetBuildDemoCS\ResnetBuildDemoCS.csproj", "{54DBD6E2-D447-4F70-879B-D42F13AA4699}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Debug|ARM64.Build.0 = Debug|ARM64
+		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Debug|x64.ActiveCfg = Debug|x64
+		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Debug|x64.Build.0 = Debug|x64
+		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Release|ARM64.ActiveCfg = Release|ARM64
+		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Release|ARM64.Build.0 = Release|ARM64
+		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Release|x64.ActiveCfg = Release|x64
+		{54DBD6E2-D447-4F70-879B-D42F13AA4699}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Samples/WindowsML/cs/ResnetBuildDemoCS/ResnetBuildDemoCS/ResnetBuildDemoCS.csproj
+++ b/Samples/WindowsML/cs/ResnetBuildDemoCS/ResnetBuildDemoCS/ResnetBuildDemoCS.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WindowsPackageType>None</WindowsPackageType>
+    <Platforms>ARM64;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

The sample build pipeline explicitly tries to compile each sample solution for specific platforms (e.g., ARM64, x64), which did not work for the Resnet solution since it was targeting only AnyCPU. This change modifies the solution to explicitly include those platforms so that it can be eventually included in the testing pipeline.

## Target Release

These samples are currently experimental (initially included as part of 1.8 experimental 4). 

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
