### PR TITLE
Add wpf islands example

### DIFF
--- a/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIsland.sln
+++ b/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIsland.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36401.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleWpfXamlIslandApp", "SimpleWpfXamlIslandApp\SimpleWpfXamlIslandApp.csproj", "{4B331F0D-098B-D622-EBB0-61D14FA2C621}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinUILib", "WinUILib\WinUILib.csproj", "{6CEC863F-D767-463E-9E3E-D955E045CCF8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4B331F0D-098B-D622-EBB0-61D14FA2C621}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B331F0D-098B-D622-EBB0-61D14FA2C621}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B331F0D-098B-D622-EBB0-61D14FA2C621}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B331F0D-098B-D622-EBB0-61D14FA2C621}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CEC863F-D767-463E-9E3E-D955E045CCF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CEC863F-D767-463E-9E3E-D955E045CCF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CEC863F-D767-463E-9E3E-D955E045CCF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CEC863F-D767-463E-9E3E-D955E045CCF8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {613D332E-BCD6-44EA-A02D-11A32EE2469E}
+	EndGlobalSection
+EndGlobal

--- a/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/App.xaml
+++ b/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="WpfApp1.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:WpfApp1"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/App.xaml.cs
+++ b/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/App.xaml.cs
@@ -1,0 +1,14 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace WpfApp1
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+
+}

--- a/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/AssemblyInfo.cs
+++ b/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/MainWindow.xaml
+++ b/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/MainWindow.xaml
@@ -1,0 +1,27 @@
+﻿<Window x:Class="WpfApp1.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:WpfApp1"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Button Content="WPF button" 
+             Margin="10" 
+             HorizontalAlignment="Left" 
+             VerticalAlignment="Top"
+             Click="Button_Click"/>
+        <Border Name="ControlHostElement"
+Grid.Row="1"
+ HorizontalAlignment="Stretch"
+ VerticalAlignment="Stretch"
+ BorderBrush="LightGray"
+ BorderThickness="3"
+ DockPanel.Dock="Right"/>
+    </Grid>
+</Window>

--- a/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/MainWindow.xaml.cs
+++ b/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/MainWindow.xaml.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.UI.Dispatching;
+using SimpleWpfXamlIslandApp;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace WpfApp1
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        DispatcherQueueController _controller;
+        WinUIControlHost _winUIControl;
+
+        public MainWindow()
+        {
+            _controller = Microsoft.UI.Dispatching.DispatcherQueueController.CreateOnCurrentThread();
+
+            var xamlApp = new XamlApp();
+            InitializeComponent();
+            Loaded += MainWindow_Loaded;
+        }
+
+        void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            _winUIControl = new WinUIControlHost(ControlHostElement.ActualHeight, ControlHostElement.ActualWidth);
+            ControlHostElement.Child = _winUIControl;
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            MessageBox.Show("Hello from WPF!");
+        }
+    }
+}

--- a/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/SimpleWpfXamlIslandApp.csproj
+++ b/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/SimpleWpfXamlIslandApp.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+		<TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+
+		<Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+		<UseWinUI>true</UseWinUI>
+		<EnableDefaultXamlItems>false</EnableDefaultXamlItems>
+		<WindowsPackageType>None</WindowsPackageType>
+
+		<WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
+  </PropertyGroup>
+	
+	<PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net8.0'))">
+		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+		<UseRidGraph>true</UseRidGraph>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\WinUILib\WinUILib.csproj" />
+	</ItemGroup>
+</Project>

--- a/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/WinUIControlHost.cs
+++ b/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/WinUIControlHost.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.UI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Interop;
+using Windows.UI;
+using WinUILib;
+
+namespace SimpleWpfXamlIslandApp
+{
+    public class WinUIControlHost : HwndHost
+    {
+        int hostHeight, hostWidth;
+
+        Microsoft.UI.Xaml.Hosting.DesktopWindowXamlSource _xamlSource;
+
+
+        public WinUIControlHost(double height, double width)
+        {
+            hostHeight = (int)height;
+            hostWidth = (int)width;
+            _xamlSource = new Microsoft.UI.Xaml.Hosting.DesktopWindowXamlSource();
+        }
+
+        protected override HandleRef BuildWindowCore(HandleRef hwndParent)
+        {
+            var id = new Microsoft.UI.WindowId((ulong)hwndParent.Handle);
+            _xamlSource.Initialize(id);
+
+            InitIslandSampleCode();
+            //_xamlSource.SiteBridge.ResizePolicy = Microsoft.UI.Content.ContentSizePolicy.ResizeContentToParentWindow;
+            //_xamlSource.SiteBridge.Show();
+
+            return new HandleRef(null, (nint)_xamlSource.SiteBridge.WindowId.Value);
+        }
+
+        void InitIslandSampleCode()
+        {
+            var grid = new Microsoft.UI.Xaml.Controls.Grid();
+            grid.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Colors.LightGray);
+            grid.RowDefinitions.Add(new Microsoft.UI.Xaml.Controls.RowDefinition { Height = new Microsoft.UI.Xaml.GridLength(1, Microsoft.UI.Xaml.GridUnitType.Star) });
+            grid.RowDefinitions.Add(new Microsoft.UI.Xaml.Controls.RowDefinition { Height = new Microsoft.UI.Xaml.GridLength(1, Microsoft.UI.Xaml.GridUnitType.Star) });
+
+            var winUiButton = new MyCustomButton();
+            winUiButton.Click += (s, e) =>
+            {
+                System.Windows.MessageBox.Show("Hello from WinUI!");
+            };
+            grid.Children.Add(winUiButton);
+
+            var listView = new CustomListView {
+
+                ItemsSource = new List<string> { "Item 1", "Item 2", "Item 3" },
+            };
+
+            Microsoft.UI.Xaml.Controls.Grid.SetRow(listView, 1);
+            grid.Children.Add(listView);
+
+            _xamlSource.Content = grid;
+        }
+
+        protected override void DestroyWindowCore(HandleRef hwnd)
+        {
+
+        }
+    }
+}

--- a/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/XamlApp.cs
+++ b/Samples/Islands/SimpleWpfXamlIsland/SimpleWpfXamlIslandApp/XamlApp.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.UI.Xaml.Hosting;
+using Microsoft.UI.Xaml.Markup;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimpleWpfXamlIslandApp
+{
+    internal class XamlApp : Microsoft.UI.Xaml.Application, IXamlMetadataProvider
+    {
+        public XamlApp()
+        {
+            _xamlMetaDataProvider = new Microsoft.UI.Xaml.XamlTypeInfo.XamlControlsXamlMetaDataProvider();
+            _windowsXamlManager = WindowsXamlManager.InitializeForCurrentThread();
+        }
+
+        override protected void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+        {
+            this.Resources.MergedDictionaries.Add(new Microsoft.UI.Xaml.Controls.XamlControlsResources());
+            this.Resources.MergedDictionaries.Add(new Microsoft.UI.Xaml.ResourceDictionary {
+                Source = new Uri("ms-appx:///WinUILib/ListViewStyles.xbf")
+            });
+        }
+
+        IXamlType IXamlMetadataProvider.GetXamlType(string fullName)
+        {
+            var xamlType = _xamlMetaDataProvider.GetXamlType(fullName);
+            return xamlType;
+        }
+
+        IXamlType IXamlMetadataProvider.GetXamlType(System.Type type)
+        {
+            var xamlType = _xamlMetaDataProvider.GetXamlType(type);
+            return xamlType;
+        }
+
+        XmlnsDefinition[] IXamlMetadataProvider.GetXmlnsDefinitions()
+        {
+            return _xamlMetaDataProvider.GetXmlnsDefinitions();
+        }
+
+        WindowsXamlManager _windowsXamlManager;
+        IXamlMetadataProvider _xamlMetaDataProvider;
+    }
+}

--- a/Samples/Islands/SimpleWpfXamlIsland/WinUILib/CustomListView.cs
+++ b/Samples/Islands/SimpleWpfXamlIsland/WinUILib/CustomListView.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WinUILib
+{
+    public class CustomListView : ListView
+    {
+        public CustomListView()
+        {
+            ItemTemplate = Application.Current.Resources["ListViewItemTemplate"] as Microsoft.UI.Xaml.DataTemplate;
+        }
+    }
+}

--- a/Samples/Islands/SimpleWpfXamlIsland/WinUILib/ListViewStyles.xaml
+++ b/Samples/Islands/SimpleWpfXamlIsland/WinUILib/ListViewStyles.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+
+    xmlns:local="using:WinUILib">
+
+    <DataTemplate x:Key="ListViewItemTemplate">
+        <Grid>
+            <local:MyCustomButton Content="{Binding .}"/>
+        </Grid>
+    </DataTemplate>
+
+
+</ResourceDictionary>

--- a/Samples/Islands/SimpleWpfXamlIsland/WinUILib/MyCustomButton.cs
+++ b/Samples/Islands/SimpleWpfXamlIsland/WinUILib/MyCustomButton.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace WinUILib
+{
+    public partial class MyCustomButton : Microsoft.UI.Xaml.Controls.Button
+    {
+        public MyCustomButton()
+        {
+            Content = "Click Me WinUI";
+        }
+    }
+}

--- a/Samples/Islands/SimpleWpfXamlIsland/WinUILib/WinUILib.csproj
+++ b/Samples/Islands/SimpleWpfXamlIsland/WinUILib/WinUILib.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <RootNamespace>WinUILib</RootNamespace>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <UseWinUI>true</UseWinUI>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Description

This pull request introduces a new WPF sample application (`SimpleWpfXamlIslandApp`) that demonstrates how to host WinUI 3 controls inside a WPF application using XAML Islands. The solution includes both the WPF host app and a supporting WinUI library (`WinUILib`) with custom controls and styles. The most important changes are grouped below:

**WPF Host Application Setup:**

- Added a new WPF application project (`SimpleWpfXamlIslandApp`) with basic WPF setup files (`App.xaml`, `App.xaml.cs`, `MainWindow.xaml`, `MainWindow.xaml.cs`, `AssemblyInfo.cs`, and project file) to serve as the host for WinUI content. [[1]](diffhunk://#diff-c2679d604b2a8f15761c303457c1a039063082c1aa22809be584746668b52b9cR1-R9) [[2]](diffhunk://#diff-136f9f058844693b258056b15bd3472dae08ee7e1b61251ecfda822153fa832aR1-R14) [[3]](diffhunk://#diff-410d8259e217b66fed80d3378c5aef8d6619a602acf74f4084188be8fd7e8e3eR1-R27) [[4]](diffhunk://#diff-fb87b57257507a5cf572d8428e7cc1f20a15c693f0dd4cc0018adc5cd502792fR1-R44) [[5]](diffhunk://#diff-3715c15dc0081616dc1668a801621d881f76b41e84d4a06ce935653ec56ea1b5R1-R10) [[6]](diffhunk://#diff-1011d81d624d8376d6d94f49cc063d3be262c950dd01da7273c9a17961757e97R1-R30)
- Implemented `WinUIControlHost`, a custom `HwndHost` that embeds WinUI controls into the WPF window using `DesktopWindowXamlSource`.
- Added `XamlApp` class to initialize WinUI resources and styles for the embedded controls.

**WinUI Library and Custom Controls:**

- Added a new WinUI library project (`WinUILib`) with its own project file.
- Implemented `MyCustomButton`, a custom WinUI button, and `CustomListView`, a WinUI list view that uses a custom data template. [[1]](diffhunk://#diff-a2a5c6c271d7c0ea6b3445aac5f56dc075b64c64d3003c7375e321b8a8dce180R1-R19) [[2]](diffhunk://#diff-f3ea159c161c96c75087564bd618b806fb81cbec4c36ca6db76ba741bdd3f0e5R1-R18)
- Added `ListViewStyles.xaml`, defining a data template for the custom list view, which includes the custom button.

**Solution Structure:**

- Added a new Visual Studio solution file (`SimpleWpfXamlIsland.sln`) to group the WPF app and WinUI library projects.

## Target Release

Please specify which release this PR should align with. e.g., 1.0, 1.1, 1.1 Preview 1.

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
