### PR TITLE
Fix OpenVINO issue in the WinML CppConsoleDesktop Sample

### DIFF
--- a/Samples/WindowsML/cpp/CppConsoleDesktop/CppConsoleDesktop/CppConsoleDesktop.cpp
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop/CppConsoleDesktop/CppConsoleDesktop.cpp
@@ -202,8 +202,7 @@ void ConfigureExecutionProviders(Ort::SessionOptions& session_options, Ort::Env&
         }
         else if (ep_name == "OpenVINOExecutionProvider")
         {
-            // Configure threading for OpenVINO EP, pick the first device found.
-            ep_options.Add("num_of_threads", "4");
+            // Configure OpenVINO EP - pick the first device found.
             session_options.AppendExecutionProvider_V2(env, {devices.front()}, ep_options);
             std::cout << "Successfully added " << ep_name << " EP (first device only)" << std::endl;
         }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Removed the specification of the number of threads for OpenVINO in the WinML CppConsoleDesktop sample. This fix was suggested by the IHV.

## Target Release

Next release that picks up release/experimental branch

## Checklist

Note that /azp run currently isn't working for this repo.

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
