### PR TITLE
Update TargetPlatformVersion where 22000 was used

### DIFF
--- a/Samples/AppLifecycle/Activation/cpp/cpp-win32-unpackaged/CppWinMainActivation/CppWinMainActivation.vcxproj
+++ b/Samples/AppLifecycle/Activation/cpp/cpp-win32-unpackaged/CppWinMainActivation/CppWinMainActivation.vcxproj
@@ -48,7 +48,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{11400d28-21eb-4f92-ae9e-0ee652c98400}</ProjectGuid>
     <RootNamespace>CppWinMainActivation</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>CppWinMainActivation</ProjectName>
     <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>

--- a/Samples/AppLifecycle/Instancing/cpp/cpp-console-unpackaged/CppWinRtConsoleInstancing/CppWinRtConsoleInstancing.vcxproj
+++ b/Samples/AppLifecycle/Instancing/cpp/cpp-console-unpackaged/CppWinRtConsoleInstancing/CppWinRtConsoleInstancing.vcxproj
@@ -26,7 +26,7 @@
     <ProjectGuid>{a55ae73a-73fc-430a-8755-4df2e6f774b0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>CppWinRtConsoleInstancing</RootNamespace>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>

--- a/Samples/Notifications/Push/cpp-console-packaged/cpp-console-package/cpp-console-package.wapproj
+++ b/Samples/Notifications/Push/cpp-console-packaged/cpp-console-package/cpp-console-package.wapproj
@@ -45,7 +45,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>21ac7584-8c7c-43d5-b879-f8f58581bbc1</ProjectGuid>
-    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment (Package)/SelfContainedDeployment (Package).wapproj
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment (Package)/SelfContainedDeployment (Package).wapproj
@@ -36,7 +36,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>a8f28d10-4c02-4a5a-80f1-8938c03b5c4f</ProjectGuid>
-    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <AssetTargetFallback>net6.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/Samples/Widgets/cpp-win32-packaged/SampleWidgetProviderAppPackage/SampleWidgetProviderAppPackage.wapproj
+++ b/Samples/Widgets/cpp-win32-packaged/SampleWidgetProviderAppPackage/SampleWidgetProviderAppPackage.wapproj
@@ -35,7 +35,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>7C9DBD64-9DC7-4706-8FDA-8Df2A43184FE</ProjectGuid>
-    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <AssetTargetFallback>net6.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Please include a summary of the change and/or which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Target Release

Please specify which release this PR should align with. e.g., 1.0, 1.1, 1.1 Preview 1.

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
