### PR TITLE
Update Resnet C# sample to use correct registration API

### DIFF
--- a/Samples/WindowsML/cs/ResnetBuildDemoCS/ResnetBuildDemoCS/Program.cs
+++ b/Samples/WindowsML/cs/ResnetBuildDemoCS/ResnetBuildDemoCS/Program.cs
@@ -149,7 +149,7 @@ internal class Program
 
             // Use WinML to download and register Execution Providers
             var catalog = ExecutionProviderCatalog.GetDefault();
-            var registeredProviders = await catalog.EnsureAndRegisterAllAsync();
+            var registeredProviders = await catalog.EnsureAndRegisterCertifiedAsync();
 
             // Prepare paths
             string executableFolder = Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)!;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

The C# ResNet sample was using a previous version of the EP registration API, which will not resolve with current versions of Windows ML. This change switches over to using the correct API name. 

## Target Release

1.8.1

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
