### PR TITLE
Fix one of the sparse app (WPF) according to public doc

### DIFF
--- a/Samples/WindowsAIFoundry/cs-wpf-sparse/WindowsAISampleForWPF/AppxManifest.xml
+++ b/Samples/WindowsAIFoundry/cs-wpf-sparse/WindowsAISampleForWPF/AppxManifest.xml
@@ -7,7 +7,8 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
-  IgnorableNamespaces="uap uap2 uap3 rescap desktop uap10">
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
+  IgnorableNamespaces="uap uap2 uap3 rescap desktop uap10 systemai">
   <Identity
     Name="WindowsAISampleForWPFSparse"
     Publisher="CN=Fabrikam Corporation, O=Fabrikam Corporation, L=Redmond, S=Washington, C=US"
@@ -24,7 +25,7 @@
     <Resource Language="en-us" />
   </Resources>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19000.0" MaxVersionTested="10.0.19000.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19000.0" MaxVersionTested="10.0.26226.0" />
       <PackageDependency
           Name="Microsoft.WindowsAppRuntime.1.8-experimental2"
           Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
@@ -32,6 +33,7 @@
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <systemai:Capability Name="systemAIModels"/>
     <rescap:Capability Name="unvirtualizedResources"/>
   </Capabilities>
   <Applications>

--- a/Samples/WindowsAIFoundry/cs-wpf-sparse/WindowsAISampleForWPF/WindowsAISampleForWPFSparse.csproj
+++ b/Samples/WindowsAIFoundry/cs-wpf-sparse/WindowsAISampleForWPF/WindowsAISampleForWPFSparse.csproj
@@ -7,6 +7,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <Platforms>x64;ARM64</Platforms>
+		<AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
+		<AppxOSMaxVersionTestedReplaceManifestVersion>false</AppxOSMaxVersionTestedReplaceManifestVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

According to https://learn.microsoft.com/en-us/windows/ai/apis/get-started?tabs=winget%2Cwinui%2Cwinui2, there are multiple changes before the AI API can be used.
This pull request updates the Windows AI Foundry WPF sample to support new system AI model capabilities and aligns the app manifest with the latest Windows versions. The most important changes are grouped below:

**Manifest and Capability Updates:**

* Added the `systemai` namespace and set it as ignorable in `AppxManifest.xml`, enabling the use of new system AI capabilities.
* Added the `systemAIModels` capability under the new `systemai` namespace, allowing the app to access system-provided AI models.

**Platform and Compatibility Updates:**

* Increased the `MaxVersionTested` for the `Windows.Desktop` target device family to `10.0.26226.0` in `AppxManifest.xml`, ensuring compatibility with the latest Windows Insider builds.
* Updated the project file (`WindowsAISampleForWPFSparse.csproj`) to prevent automatic replacement of manifest OS min/max versions, giving developers more control over versioning.

## Target Release
1.8