### PR TITLE
Add 'PackageSourceMapping' entries to Nuget.config, since multiple sources are used

### DIFF
--- a/Samples/nuget.config
+++ b/Samples/nuget.config
@@ -16,5 +16,16 @@
         <add key="localpackages" value="localpackages" />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
+
+    <packageSourceMapping>
+        <packageSource key="WinAppSDK-SampleDeps">
+            <package pattern="Microsoft.WindowsAppSDK.*" />
+        </packageSource>
+        <packageSource key="nuget.org">
+            <package pattern="System.*" />
+            <package pattern="Microsoft.*" />
+        </packageSource>
+    </packageSourceMapping>
+
     <disabledPackageSources />
 </configuration>


### PR DESCRIPTION
## Description

When building the WindowsML samples through the command-line with:

```powershell
.\build.cmd x64 Debug WindowsML
```

I see errors, along the lines of:

```
S:\source\github\microsoft\WindowsAppSDK-Samples\samples\WindowsML\cs\CSharpConsoleDesktop\CSharpConsoleDesktop\CSharpConsoleDesktop.csproj : error
 NU1507: There are 2 package sources defined in your configuration. When using central package management, please map your package sources with pac
kage source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: nuget.org,
 WinAppSDK-SampleDeps
```

The error is complaining because there's a `:/Samples/nuget.config` file with multiple `packageSource` elements, but no `packageSourceMapping`. So this PR adds `packageSourceMapping` for the `packageSource` elements.

Note: The samples are still not building cleanly, there's more errors behind this one.

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
