### PR TITLE
Windows ML: Fix warnings in cs-winui project

### DIFF
--- a/Samples/WindowsML/cs-winui/WindowsMLSample.csproj
+++ b/Samples/WindowsML/cs-winui/WindowsMLSample.csproj
@@ -3,7 +3,6 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>WindowsMLSample</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <PublishProfile Condition="Exists('$(MSBuildProjectDirectory)\Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

There are some warnings-as-errors generated in the cs-winui project when building via the script, e.g., `build.cmd x64 Release WindowsML` (see below). Broadly speaking, they are related to publishing / deployment aspects of the project. This change resolves the warnings by conditioning the PublishProfile property (the sample is more oriented around local F5 on a developer device), and by enabling signing only if the developer has explicitly provided signing-related pieces. I re-built locally and verified that these no longer show up in the script output and further verified that the sample continues to function as expected. 

```
"D:\source\WindowsAppSDK-Samples\samples\WindowsML\WindowsML-Samples.sln" (default target) (1) ->
"D:\source\WindowsAppSDK-Samples\samples\WindowsML\cs-winui\WindowsMLSample.csproj" (default target) (6) ->
(PrepareForPublish target) ->
C:\Program Files\dotnet\sdk\9.0.305\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(217,5): error
NETSDK1198: A publish profile with the name 'win-x64.pubxml' was not found in the project. Set the PublishProfile
property to a valid file name. [D:\source\WindowsAppSDK-Samples\samples\WindowsML\cs-winui\WindowsMLSample.cspro
j]

"D:\source\WindowsAppSDK-Samples\samples\WindowsML\WindowsML-Samples.sln" (default target) (1) ->
"D:\source\WindowsAppSDK-Samples\samples\WindowsML\cs-winui\WindowsMLSample.csproj" (default target) (6) ->
(_ValidateSigningCertificate target) ->
D:\source\WindowsAppSDK-Samples\packages\microsoft.windows.sdk.buildtools.msix\1.7.20250829.1\build\Microsoft.W
indows.SDK.BuildTools.MSIX.Packaging.targets(783,5): error : SigningCertificateNoCertSpecified [D:\source\Windows
AppSDK-Samples\samples\WindowsML\cs-winui\WindowsMLSample.csproj]
```

## Target Release

1.8.2

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
