### PR TITLE
Windows ML: Increase version of GenAI package

### DIFF
--- a/Samples/WindowsML/Directory.Packages.props
+++ b/Samples/WindowsML/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- WindowsAppSDK packages -->
-    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.WinML" Version="0.10.0" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.WinML" Version="0.10.1" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.250930001-experimental1" />
     <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="1.8.38" />
     <PackageVersion Include="Microsoft.WindowsAppSDK.Base" Version="1.8.250831001" />


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

To align with the experimental WASDK release train, we need to shift the "Hello, Phi" sample to take a dependency on the newest GenAI package (version 0.10.1) https://www.nuget.org/packages/Microsoft.ML.OnnxRuntimeGenAI.WinML/0.10.1

This will also assist with experimental pipeline build automation, as the 0.10.0 package has a closed-interval dependency on the stable WASDK release and therefore causes a version conflict. 

## Target Release

2.0 experimental 2

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
