### PR TITLE
Windows ML: Add runtime ID to C# console sample

### DIFF
--- a/Samples/WindowsML/cs/CSharpConsoleDesktop/CSharpConsoleDesktop/CSharpConsoleDesktop.csproj
+++ b/Samples/WindowsML/cs/CSharpConsoleDesktop/CSharpConsoleDesktop/CSharpConsoleDesktop.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <WindowsPackageType>None</WindowsPackageType>
     <SelfContained>True</SelfContained>
+    <RuntimeIdentifier Condition="'$(Platform)' == 'x64'">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

#556 introduced some changes to make the C# console desktop application self-contained. I saw build breaks in the pipeline though due to mismatches between the platform and the runtime (self-contained requires a strict alignment between the two):

`C:__t\dotnet\sdk\8.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(288,5): error NETSDK1032: The RuntimeIdentifier platform 'win-x64' and the PlatformTarget 'arm64' must be compatible. [C:__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\cs\CSharpConsoleDesktop\CSharpConsoleDesktop\CSharpConsoleDesktop.csproj]`

This change addresses the problem by specifying the runtime identifier based on the supplied platform. I tested this via `dotnet build` and supplying the corresponding versions, which seemed to work, and I'll further validate in the pipeline itself. 

## Target Release

1.8.3

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
