### PR TITLE
Revert "Update model management APIs in WinML sample"

### DIFF
--- a/Samples/WindowsML/Resources/SqueezeNetModelCatalog.json
+++ b/Samples/WindowsML/Resources/SqueezeNetModelCatalog.json
@@ -2,15 +2,13 @@
   "base": "https://learn.microsoft.com/azure/ai-foundry/foundry-local/reference/reference-catalog-api",
   "models": [
     {
-      "id": "squeezenet",
+      "alias": "squeezenet",
       "name": "squeezenet",
       "version": "1",
+      "modelType": "ONNX",
       "publisher": "microsoft",
-      "executionProviders": [
-        {
-          "name": "CPUExecutionProvider"
-        }
-      ],
+      "executionProvider": "CPUExecutionProvider",
+      "description": "",
       "modelSizeBytes": 1250000,
       "license": "BSD",
       "licenseUri": "https://github.com/microsoft/WindowsAppSDK-Samples/raw/refs/heads/release/experimental/Samples/WindowsML/cpp/CppConsoleDesktop/CppConsoleDesktop/SqueezeNet.LICENSE.txt",
@@ -35,15 +33,13 @@
       ]
     },
     {
-      "id": "squeezenet-fp32",
+      "alias": "squeezenet-fp32",
       "name": "squeezenet-fp32",
       "version": "1.1-7",
+      "modelType": "ONNX",
       "publisher": "microsoft",
-      "executionProviders": [
-        {
-          "name": "NvTensorRTRTXExecutionProvider"
-        }
-      ],
+      "executionProvider": "NvTensorRTRTXExecutionProvider",
+      "description": "",
       "modelSizeBytes": 4730000,
       "license": "BSD",
       "licenseUri": "https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/Samples/WindowsML/Resources/SqueezeNet.LICENSE.txt",

--- a/Samples/WindowsML/Shared/cs/ModelManager.cs
+++ b/Samples/WindowsML/Shared/cs/ModelManager.cs
@@ -126,10 +126,10 @@ namespace WindowsML.Shared
                 // Build source
                 string sampleCatalogJsonPath = Path.Combine(executableFolder, "SqueezeNetModelCatalog.json");
                 var uri = new System.Uri(sampleCatalogJsonPath);
-                var sampleCatalogSource = await ModelCatalogSource.CreateFromUriAsync(uri);
-
-                ModelCatalog modelCatalog = new ModelCatalog(new[] { sampleCatalogSource });
-
+                var sampleCatalogSource = await CatalogModelSource.CreateFromUri(uri);
+                
+                WinMLModelCatalog modelCatalog = new WinMLModelCatalog(new[] { sampleCatalogSource });
+                
                 // Use intelligent model variant selection based on execution provider and device capabilities
                 ModelVariant actualVariant = DetermineModelVariant(options, ortEnv);
                 
@@ -137,12 +137,12 @@ namespace WindowsML.Shared
                 
                 string modelVariantName = (actualVariant == ModelVariant.FP32) ? "squeezenet-fp32" : "squeezenet";
                 
-                modelFromCatalog = await modelCatalog.FindModelAsync(modelVariantName);
+                modelFromCatalog = await modelCatalog.FindModel(modelVariantName);
                 
                 if (modelFromCatalog != null)
                 {
                     var additionalHeaders = new Dictionary<string, string>();
-                    var catalogModelInstanceOp = modelFromCatalog.GetInstanceAsync(additionalHeaders);
+                    var catalogModelInstanceOp = modelFromCatalog.GetInstance(additionalHeaders);
                     
                     catalogModelInstanceOp.Progress += (operation, progress) => {
                         Console.Write($"Model download progress: {progress}%\r");
@@ -150,9 +150,9 @@ namespace WindowsML.Shared
                     
                     var catalogModelInstanceResult = await catalogModelInstanceOp;
                     
-                    if (catalogModelInstanceResult.Status == CatalogModelInstanceStatus.Available)
+                    if (catalogModelInstanceResult.Status == CatalogModelStatus.Available)
                     {
-                        using var catalogModelInstance = catalogModelInstanceResult.GetInstance();
+                        var catalogModelInstance = catalogModelInstanceResult.Instance;
                         var modelPaths = catalogModelInstance.ModelPaths;
                         
                         string modelFolderPath = modelPaths[0];

--- a/Samples/WindowsML/cpp/CppConsoleDesktop/CppConsoleDesktop.cpp
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop/CppConsoleDesktop.cpp
@@ -41,9 +41,9 @@ IAsyncAction RunInferenceAsync(const CommandLineOptions& options)
 
             auto sampleCatalogJsonPath = executableFolder / L"SqueezeNetModelCatalog.json";
             auto uri = winrt::Windows::Foundation::Uri(sampleCatalogJsonPath.c_str());
-            auto sampleCatalogSource = winrt::Microsoft::Windows::AI::MachineLearning::ModelCatalogSource::CreateFromUriAsync(uri).get();
+            auto sampleCatalogSource = winrt::Microsoft::Windows::AI::MachineLearning::CatalogModelSource::CreateFromUri(uri).get();
 
-            winrt::Microsoft::Windows::AI::MachineLearning::ModelCatalog modelCatalog({sampleCatalogSource});
+            winrt::Microsoft::Windows::AI::MachineLearning::WinMLModelCatalog modelCatalog({sampleCatalogSource});
 
             // Use intelligent model variant selection based on execution provider and device capabilities
             ModelVariant actualVariant = ModelManager::DetermineModelVariant(options, env);
@@ -52,11 +52,11 @@ IAsyncAction RunInferenceAsync(const CommandLineOptions& options)
 
             std::wstring modelVariantName = (actualVariant == ModelVariant::FP32) ? L"squeezenet-fp32" : L"squeezenet";
 
-            modelFromCatalog = modelCatalog.FindModelAsync(modelVariantName.c_str()).get();
+            modelFromCatalog = modelCatalog.FindModel(modelVariantName.c_str()).get();
 
             if (modelFromCatalog != nullptr)
             {
-                auto catalogModelInstanceOp = modelFromCatalog.GetInstanceAsync({});
+                auto catalogModelInstanceOp = modelFromCatalog.GetInstance({});
 
                 catalogModelInstanceOp.Progress([](auto const& /*operation*/, double progress) {
                     std::wcout << L"Model download progress: " << progress << L"%\r";
@@ -64,9 +64,9 @@ IAsyncAction RunInferenceAsync(const CommandLineOptions& options)
 
                 auto catalogModelInstanceResult = co_await catalogModelInstanceOp;
 
-                if (catalogModelInstanceResult.Status() == winrt::Microsoft::Windows::AI::MachineLearning::CatalogModelInstanceStatus::Available)
+                if (catalogModelInstanceResult.Status() == winrt::Microsoft::Windows::AI::MachineLearning::CatalogModelStatus::Available)
                 {
-                    auto catalogModelInstance = catalogModelInstanceResult.GetInstance();
+                    auto catalogModelInstance = catalogModelInstanceResult.Instance();
                     auto modelPaths = catalogModelInstance.ModelPaths();
 
                     auto modelFolderPath = std::filesystem::path(modelPaths.GetAt(0).c_str());


### PR DESCRIPTION
Reverts microsoft/WindowsAppSDK-Samples#564

Because there are few errors when we test the sample after this PR merged

```
##[error]WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(129,49): Error CS0103: The name 'ModelCatalogSource' does not exist in the current context
C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(129,49): error CS0103: The name 'ModelCatalogSource' does not exist in the current context [C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\cs\CSharpConsoleDesktop\CSharpConsoleDesktop\CSharpConsoleDesktop.csproj]
##[error]WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(131,17): Error CS0246: The type or namespace name 'ModelCatalog' could not be found (are you missing a using directive or an assembly reference?)
C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(131,17): error CS0246: The type or namespace name 'ModelCatalog' could not be found (are you missing a using directive or an assembly reference?) [C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\cs\CSharpConsoleDesktop\CSharpConsoleDesktop\CSharpConsoleDesktop.csproj]
##[error]WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(131,49): Error CS0246: The type or namespace name 'ModelCatalog' could not be found (are you missing a using directive or an assembly reference?)
C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(131,49): error CS0246: The type or namespace name 'ModelCatalog' could not be found (are you missing a using directive or an assembly reference?) [C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\cs\CSharpConsoleDesktop\CSharpConsoleDesktop\CSharpConsoleDesktop.csproj]
##[warning]WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(136,17): Warning CS8305: 'Microsoft.Windows.AI.MachineLearning.CatalogModelInfo' is for evaluation purposes only and is subject to change or removal in future updates.
C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(136,17): warning CS8305: 'Microsoft.Windows.AI.MachineLearning.CatalogModelInfo' is for evaluation purposes only and is subject to change or removal in future updates. [C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\cs\CSharpConsoleDesktop\CSharpConsoleDesktop\CSharpConsoleDesktop.csproj]
##[error]WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(145,67): Error CS1061: 'CatalogModelInfo' does not contain a definition for 'GetInstanceAsync' and no accessible extension method 'GetInstanceAsync' accepting a first argument of type 'CatalogModelInfo' could be found (are you missing a using directive or an assembly reference?)
C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(145,67): error CS1061: 'CatalogModelInfo' does not contain a definition for 'GetInstanceAsync' and no accessible extension method 'GetInstanceAsync' accepting a first argument of type 'CatalogModelInfo' could be found (are you missing a using directive or an assembly reference?) [C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\cs\CSharpConsoleDesktop\CSharpConsoleDesktop\CSharpConsoleDesktop.csproj]
##[error]WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(153,62): Error CS0103: The name 'CatalogModelInstanceStatus' does not exist in the current context
C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\Shared\cs\ModelManager.cs(153,62): error CS0103: The name 'CatalogModelInstanceStatus' does not exist in the current context [C:\__w\1\s\WindowsAppSDK-Samples\Samples\WindowsML\cs\CSharpConsoleDesktop\CSharpConsoleDesktop\CSharpConsoleDesktop.csproj]


```