### PR TITLE
Update samples to use .net 8 (At least)

### DIFF
--- a/Samples/AppLifecycle/Activation/cs/cs-console-unpackaged/CsConsoleActivation/CsConsoleActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs/cs-console-unpackaged/CsConsoleActivation/CsConsoleActivation.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <ApplicationIcon>C.ico</ApplicationIcon>
   </PropertyGroup>
 
@@ -17,6 +17,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Activation/cs/cs-winforms-unpackaged/CsWinFormsActivation/CsWinFormsActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs/cs-winforms-unpackaged/CsWinFormsActivation/CsWinFormsActivation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
@@ -29,5 +29,6 @@
   </ItemGroup>
 
 </Project>
+
 
 

--- a/Samples/AppLifecycle/Activation/cs/cs-winforms-unpackaged/CsWinFormsActivation/CsWinFormsActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs/cs-winforms-unpackaged/CsWinFormsActivation/CsWinFormsActivation.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <ApplicationIcon>D.ico</ApplicationIcon>
   </PropertyGroup>
 
@@ -29,6 +29,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Activation/cs/cs-wpf-unpackaged/CsWpfActivation/CsWpfActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs/cs-wpf-unpackaged/CsWpfActivation/CsWpfActivation.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <StartupObject>CsWpfActivation.Program</StartupObject>
     <ApplicationIcon>E.ico</ApplicationIcon>
   </PropertyGroup>
@@ -19,6 +19,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Activation/cs/cs-wpf-unpackaged/CsWpfActivation/CsWpfActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs/cs-wpf-unpackaged/CsWpfActivation/CsWpfActivation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
@@ -19,6 +19,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Activation/cs1/cs-wpf-packaged/CsWpfActivation/CsWpfActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs1/cs-wpf-packaged/CsWpfActivation/CsWpfActivation.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <StartupObject>CsWpfActivation.Program</StartupObject>
   </PropertyGroup>
 
@@ -18,6 +18,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Activation/cs1/cs-wpf-packaged/CsWpfActivation/CsWpfActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs1/cs-wpf-packaged/CsWpfActivation/CsWpfActivation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
@@ -18,6 +18,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Activation/cs1/cs-wpf-packaged/CsWpfActivation/CsWpfActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs1/cs-wpf-packaged/CsWpfActivation/CsWpfActivation.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <StartupObject>CsWpfActivation.Program</StartupObject>
   </PropertyGroup>
 

--- a/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/CsWinUiDesktopActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/CsWinUiDesktopActivation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsWinUiDesktopActivation</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -15,6 +15,7 @@
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/CsWinUiDesktopActivation.csproj
+++ b/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/CsWinUiDesktopActivation.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>CsWinUiDesktopActivation</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
 
@@ -15,6 +15,7 @@
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/Activation/cs2/cs-winui-packaged/CsWinUiDesktopActivation/CsWinUiDesktopActivation/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/EnvironmentVariables/cs-winforms-unpackaged/CsWinFormsEnv/CsWinFormsEnv.csproj
+++ b/Samples/AppLifecycle/EnvironmentVariables/cs-winforms-unpackaged/CsWinFormsEnv/CsWinFormsEnv.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
 	<WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
 
@@ -14,6 +14,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/EnvironmentVariables/cs-winforms-unpackaged/CsWinFormsEnv/CsWinFormsEnv.csproj
+++ b/Samples/AppLifecycle/EnvironmentVariables/cs-winforms-unpackaged/CsWinFormsEnv/CsWinFormsEnv.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86</RuntimeIdentifiers>
@@ -14,5 +14,6 @@
   </ItemGroup>
 
 </Project>
+
 
 

--- a/Samples/AppLifecycle/Instancing/cs/cs-console-unpackaged/CsConsoleInstancing/CsConsoleInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs/cs-console-unpackaged/CsConsoleInstancing/CsConsoleInstancing.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <ApplicationIcon>H.ico</ApplicationIcon>
   </PropertyGroup>
 
@@ -13,6 +13,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Instancing/cs/cs-console-unpackaged/CsConsoleInstancing/CsConsoleInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs/cs-console-unpackaged/CsConsoleInstancing/CsConsoleInstancing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
     <ApplicationIcon>H.ico</ApplicationIcon>
@@ -13,6 +13,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Instancing/cs/cs-winforms-unpackaged/CsWinFormsInstancing/CsWinFormsInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs/cs-winforms-unpackaged/CsWinFormsInstancing/CsWinFormsInstancing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
@@ -14,5 +14,6 @@
   </ItemGroup>
 
 </Project>
+
 
 

--- a/Samples/AppLifecycle/Instancing/cs/cs-winforms-unpackaged/CsWinFormsInstancing/CsWinFormsInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs/cs-winforms-unpackaged/CsWinFormsInstancing/CsWinFormsInstancing.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <ApplicationIcon>J.ico</ApplicationIcon>
   </PropertyGroup>
 
@@ -14,6 +14,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Instancing/cs/cs-wpf-unpackaged/CsWpfInstancing/CsWpfInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs/cs-wpf-unpackaged/CsWpfInstancing/CsWpfInstancing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
@@ -19,6 +19,7 @@
   </ItemGroup>
   
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Instancing/cs/cs-wpf-unpackaged/CsWpfInstancing/CsWpfInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs/cs-wpf-unpackaged/CsWpfInstancing/CsWpfInstancing.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <StartupObject>CsWpfInstancing.Program</StartupObject>
     <ApplicationIcon>K.ico</ApplicationIcon>
   </PropertyGroup>
@@ -19,6 +19,7 @@
   </ItemGroup>
   
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Instancing/cs1/cs-wpf-packaged/CsWpfInstancing/CsWpfInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs1/cs-wpf-packaged/CsWpfInstancing/CsWpfInstancing.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <StartupObject>CsWpfInstancing.Program</StartupObject>
   </PropertyGroup>
 

--- a/Samples/AppLifecycle/Instancing/cs1/cs-wpf-packaged/CsWpfInstancing/CsWpfInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs1/cs-wpf-packaged/CsWpfInstancing/CsWpfInstancing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
@@ -18,6 +18,7 @@
   </ItemGroup>
   
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Instancing/cs1/cs-wpf-packaged/CsWpfInstancing/CsWpfInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs1/cs-wpf-packaged/CsWpfInstancing/CsWpfInstancing.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <StartupObject>CsWpfInstancing.Program</StartupObject>
   </PropertyGroup>
 
@@ -18,6 +18,7 @@
   </ItemGroup>
   
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsWinUiDesktopInstancing</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -33,6 +33,7 @@
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing.csproj
+++ b/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>CsWinUiDesktopInstancing</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -33,6 +33,7 @@
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/Instancing/cs2/cs-winui-packaged/CsWinUiDesktopInstancing/CsWinUiDesktopInstancing/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/cs-winui-packaged.csproj
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/cs-winui-packaged.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>cs_winui_packaged</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -34,6 +34,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/cs-winui-packaged.csproj
+++ b/Samples/AppLifecycle/Restart/cs-winui-packaged/cs-winui-packaged/cs-winui-packaged.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>cs_winui_packaged</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
@@ -34,6 +34,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/cs-winui-packaged.csproj
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/cs-winui-packaged.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>cs_winui_packaged</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -45,6 +45,7 @@
     </Page>
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/cs-winui-packaged.csproj
+++ b/Samples/AppLifecycle/RestartRegistration/cs-winui-packaged/cs-winui-packaged.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>cs_winui_packaged</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -45,6 +45,7 @@
     </Page>
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp.csproj
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>WinUI_CS_ShareTargetSampleApp</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -53,6 +53,7 @@
     <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
   </PropertyGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp.csproj
+++ b/Samples/AppLifecycle/ShareTarget/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp/WinUI-CS-ShareTargetSampleApp.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>WinUI_CS_ShareTargetSampleApp</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
@@ -53,6 +53,7 @@
     <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
   </PropertyGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs/cs-console-unpackaged/CsConsoleState/CsConsoleState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs/cs-console-unpackaged/CsConsoleState/CsConsoleState.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
@@ -12,6 +12,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs/cs-console-unpackaged/CsConsoleState/CsConsoleState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs/cs-console-unpackaged/CsConsoleState/CsConsoleState.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +12,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs/cs-winforms-unpackaged/CsWinFormsState/CsWinFormsState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs/cs-winforms-unpackaged/CsWinFormsState/CsWinFormsState.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
@@ -13,5 +13,6 @@
   </ItemGroup>
 
 </Project>
+
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs/cs-winforms-unpackaged/CsWinFormsState/CsWinFormsState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs/cs-winforms-unpackaged/CsWinFormsState/CsWinFormsState.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +13,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs/cs-wpf-unpackaged/CsWpfState/CsWpfState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs/cs-wpf-unpackaged/CsWpfState/CsWpfState.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
@@ -18,6 +18,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs/cs-wpf-unpackaged/CsWpfState/CsWpfState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs/cs-wpf-unpackaged/CsWpfState/CsWpfState.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <StartupObject>CsWpfState.Program</StartupObject>
   </PropertyGroup>
 
@@ -18,6 +18,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs1/cs-wpf-packaged/CsWpfState/CsWpfState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs1/cs-wpf-packaged/CsWpfState/CsWpfState.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <StartupObject>CsWpfState.Program</StartupObject>
   </PropertyGroup>
 
@@ -18,6 +18,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs1/cs-wpf-packaged/CsWpfState/CsWpfState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs1/cs-wpf-packaged/CsWpfState/CsWpfState.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <StartupObject>CsWpfState.Program</StartupObject>
   </PropertyGroup>
 

--- a/Samples/AppLifecycle/StateNotifications/cs1/cs-wpf-packaged/CsWpfState/CsWpfState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs1/cs-wpf-packaged/CsWpfState/CsWpfState.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64;win-x86;win-x64;win-arm64</RuntimeIdentifiers>
@@ -18,6 +18,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/CsWinUiDesktopState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/CsWinUiDesktopState.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>CsWinUiDesktopState</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
 
@@ -15,6 +15,7 @@
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/CsWinUiDesktopState.csproj
+++ b/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/CsWinUiDesktopState.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsWinUiDesktopState</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -15,6 +15,7 @@
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/AppLifecycle/StateNotifications/cs2/cs-winui-packaged/CsWinUiDesktopState/CsWinUiDesktopState/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/CameraCaptureUI/cswinui/cswinui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/CameraCaptureUI/cswinui/cswinui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/CameraCaptureUI/cswinui/cswinui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/CameraCaptureUI/cswinui/cswinui/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/CameraCaptureUI/cswinui/cswinui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/CameraCaptureUI/cswinui/cswinui/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/CameraCaptureUI/cswinui/cswinui/cswinui.csproj
+++ b/Samples/CameraCaptureUI/cswinui/cswinui/cswinui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>cswinui</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -37,6 +37,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/CameraCaptureUI/cswinui/cswinui/cswinui.csproj
+++ b/Samples/CameraCaptureUI/cswinui/cswinui/cswinui.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>cswinui</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -37,6 +37,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/CustomControls/CsApp/CsApp.csproj
+++ b/Samples/CustomControls/CsApp/CsApp.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>CsApp</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -41,6 +41,7 @@
     <ProjectReference Include="..\WinUIComponentCs\WinUIComponentCs.csproj" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/CustomControls/CsApp/CsApp.csproj
+++ b/Samples/CustomControls/CsApp/CsApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsApp</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -41,6 +41,7 @@
     <ProjectReference Include="..\WinUIComponentCs\WinUIComponentCs.csproj" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/CustomControls/CsApp/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/CustomControls/CsApp/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/CustomControls/CsApp/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/CustomControls/CsApp/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/CustomControls/CsApp/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/CustomControls/CsApp/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/CustomControls/WinUIComponentCs/WinUIComponentCs.csproj
+++ b/Samples/CustomControls/WinUIComponentCs/WinUIComponentCs.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>WinUIComponentCs</RootNamespace>
 		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
@@ -21,6 +21,7 @@
 	</ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/CustomControls/WinUIComponentCs/WinUIComponentCs.csproj
+++ b/Samples/CustomControls/WinUIComponentCs/WinUIComponentCs.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>WinUIComponentCs</RootNamespace>
-		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
 		<UseWinUI>true</UseWinUI>
 		<CsWinRTComponent>true</CsWinRTComponent>
 		<Platforms>x64;x86;ARM64</Platforms>
@@ -21,6 +21,7 @@
 	</ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/DeploymentManager/cs-winui/DeploymentManagerSample.csproj
+++ b/Samples/DeploymentManager/cs-winui/DeploymentManagerSample.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>DeploymentManagerSample</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -37,6 +37,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/DeploymentManager/cs-winui/DeploymentManagerSample.csproj
+++ b/Samples/DeploymentManager/cs-winui/DeploymentManagerSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>DeploymentManagerSample</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -37,6 +37,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/DeploymentManager/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Input/cs-winui/Input.csproj
+++ b/Samples/Input/cs-winui/Input.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Input</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -57,6 +57,7 @@
     </Page>
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/Input/cs-winui/Input.csproj
+++ b/Samples/Input/cs-winui/Input.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Input</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -57,6 +57,7 @@
     </Page>
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/Input/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Input/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Input/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications.csproj
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>CsUnpackagedAppNotifications</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -43,6 +43,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications.csproj
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsUnpackagedAppNotifications</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -43,6 +43,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Notifications/App/CsUnpackagedAppNotifications/CsUnpackagedAppNotifications/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Notifications/Badge/cswinui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Notifications/Badge/cswinui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Notifications/Badge/cswinui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Notifications/Badge/cswinui/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Notifications/Badge/cswinui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Notifications/Badge/cswinui/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Notifications/Badge/cswinui/cswinui.csproj
+++ b/Samples/Notifications/Badge/cswinui/cswinui.csproj
@@ -6,7 +6,7 @@
 		<RootNamespace>cswinui</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<Platforms>x86;x64;arm64</Platforms>
-		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
 		<UseWinUI>true</UseWinUI>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 		<PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -39,6 +39,7 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250916003" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/Notifications/Badge/cswinui/cswinui.csproj
+++ b/Samples/Notifications/Badge/cswinui/cswinui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>cswinui</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
@@ -39,6 +39,7 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250916003" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -7,7 +7,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
     <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-arm64.pubxml
@@ -6,8 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-x64.pubxml
+++ b/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -7,7 +7,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
     <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-x64.pubxml
+++ b/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-x64.pubxml
@@ -6,8 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-x86.pubxml
+++ b/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -7,7 +7,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
     <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-x86.pubxml
+++ b/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/Properties/PublishProfiles/win-x86.pubxml
@@ -6,8 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/TestOAuthCSharp.csproj
+++ b/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/TestOAuthCSharp.csproj
@@ -7,7 +7,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
@@ -47,5 +47,6 @@
     <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
   </PropertyGroup>
 </Project>
+
 
 

--- a/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/TestOAuthCSharp.csproj
+++ b/Samples/OAuth2Manager/cs-winui/TestOAuthCSharp/TestOAuthCSharp.csproj
@@ -6,8 +6,7 @@
     <RootNamespace>TestOAuthCSharp</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/Samples/PhotoEditor/cs-winui/PhotoEditor.csproj
+++ b/Samples/PhotoEditor/cs-winui/PhotoEditor.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>PhotoEditor</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
@@ -35,6 +35,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/PhotoEditor/cs-winui/PhotoEditor.csproj
+++ b/Samples/PhotoEditor/cs-winui/PhotoEditor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>PhotoEditor</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -35,6 +35,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/PhotoEditor/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ResourceManagement/cs/cs-winforms-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/ResourceManagement/cs/cs-winforms-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ResourceManagement/cs/cs-winforms-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/ResourceManagement/cs/cs-winforms-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ResourceManagement/cs/cs-winforms-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/ResourceManagement/cs/cs-winforms-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ResourceManagement/cs/cs-winforms-unpackaged/winforms_unpackaged_app.csproj
+++ b/Samples/ResourceManagement/cs/cs-winforms-unpackaged/winforms_unpackaged_app.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <WindowsPackageType>None</WindowsPackageType>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,6 +30,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/ResourceManagement/cs/cs-winforms-unpackaged/winforms_unpackaged_app.csproj
+++ b/Samples/ResourceManagement/cs/cs-winforms-unpackaged/winforms_unpackaged_app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWindowsForms>true</UseWindowsForms>
     <WindowsPackageType>None</WindowsPackageType>
@@ -30,5 +30,6 @@
   </ItemGroup>
 
 </Project>
+
 
 

--- a/Samples/ResourceManagement/cs/cs-winui/ClassLibrary/ClassLibrary.csproj
+++ b/Samples/ResourceManagement/cs/cs-winui/ClassLibrary/ClassLibrary.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>ClassLibrary</RootNamespace>
     <Platforms>x86;x64;ARM64</Platforms>
@@ -17,6 +17,7 @@
     <PRIResource Include="ClassLibraryResources.resw" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/ResourceManagement/cs/cs-winui/ClassLibrary/ClassLibrary.csproj
+++ b/Samples/ResourceManagement/cs/cs-winui/ClassLibrary/ClassLibrary.csproj
@@ -4,7 +4,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>ClassLibrary</RootNamespace>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="ClassLibraryResources.resw" />
@@ -17,6 +17,7 @@
     <PRIResource Include="ClassLibraryResources.resw" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/ResourceManagement/cs/cs-winui/winui_desktop_packaged_app/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/ResourceManagement/cs/cs-winui/winui_desktop_packaged_app/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ResourceManagement/cs/cs-winui/winui_desktop_packaged_app/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/ResourceManagement/cs/cs-winui/winui_desktop_packaged_app/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ResourceManagement/cs/cs-winui/winui_desktop_packaged_app/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/ResourceManagement/cs/cs-winui/winui_desktop_packaged_app/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ResourceManagement/cs/cs-winui/winui_desktop_packaged_app/winui_desktop_packaged_app.csproj
+++ b/Samples/ResourceManagement/cs/cs-winui/winui_desktop_packaged_app/winui_desktop_packaged_app.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>winui_desktop_packaged_app</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -65,6 +65,7 @@
   </PropertyGroup>
 
 </Project>
+
 
 
 

--- a/Samples/ResourceManagement/cs/cs-winui/winui_desktop_packaged_app/winui_desktop_packaged_app.csproj
+++ b/Samples/ResourceManagement/cs/cs-winui/winui_desktop_packaged_app/winui_desktop_packaged_app.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>winui_desktop_packaged_app</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -65,6 +65,7 @@
   </PropertyGroup>
 
 </Project>
+
 
 
 

--- a/Samples/ResourceManagement/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/ResourceManagement/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ResourceManagement/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/ResourceManagement/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ResourceManagement/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/ResourceManagement/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ResourceManagement/cs1/cs-wpf/wpf_packaged_app/wpf_packaged_app.csproj
+++ b/Samples/ResourceManagement/cs1/cs-wpf/wpf_packaged_app/wpf_packaged_app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
@@ -33,6 +33,7 @@
     </EmbeddedResource>
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs/cs-console-unpackaged/SelfContainedDeployment.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
 	<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -24,6 +24,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/SelfContainedDeployment.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 	<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Nullable>enable</Nullable>
 	<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
@@ -26,6 +26,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs/cs-wpf-unpackaged/SelfContainedDeployment.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 	<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Nullable>enable</Nullable>
-	<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+	<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWPF>true</UseWPF>
     <Platforms>x64;x86;ARM64</Platforms>
 	<PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -26,6 +26,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/SelfContainedDeployment.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>SelfContainedDeployment</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -61,6 +61,7 @@
 	  </ItemGroup>
   </Target>
 </Project>
+
 
 
 

--- a/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs1/cs-winui-packaged-wap/SelfContainedDeployment/SelfContainedDeployment.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SelfContainedDeployment</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
   </PropertyGroup>
@@ -61,6 +61,7 @@
 	  </ItemGroup>
   </Target>
 </Project>
+
 
 
 

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/SelfContainedDeployment.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SelfContainedDeployment</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -44,6 +44,7 @@
 	  </ItemGroup>
   </Target>
 </Project>
+
 
 
 

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-packaged/SelfContainedDeployment.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>SelfContainedDeployment</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -44,6 +44,7 @@
 	  </ItemGroup>
   </Target>
 </Project>
+
 
 
 

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/Properties/PublishProfiles/win10-x86.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/SelfContainedDeployment.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SelfContainedDeployment</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -39,6 +39,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/SelfContainedDeployment.csproj
+++ b/Samples/SelfContainedDeployment/cs2/cs-winui-unpackaged/SelfContainedDeployment.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>SelfContainedDeployment</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -39,6 +39,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/Unpackaged/cs-console-unpackaged/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Samples/Unpackaged/cs-console-unpackaged/Properties/PublishProfiles/FolderProfile.pubxml
@@ -7,7 +7,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>False</PublishReadyToRun>

--- a/Samples/Unpackaged/cs-console-unpackaged/Unpackaged.csproj
+++ b/Samples/Unpackaged/cs-console-unpackaged/Unpackaged.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <!-- Set WindowsPackageType=None to auto-intialize access to the WinAppSDK framework -->
@@ -17,6 +17,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/Unpackaged/cs-console-unpackaged/Unpackaged.csproj
+++ b/Samples/Unpackaged/cs-console-unpackaged/Unpackaged.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <!-- Set WindowsPackageType=None to auto-intialize access to the WinAppSDK framework -->
     <!-- Remove this property to control bootstrapper initialization -->
     <WindowsPackageType>None</WindowsPackageType>
@@ -17,6 +17,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/CsConsoleWidgetProvider.csproj
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/CsConsoleWidgetProvider.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows10.0.18362.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.18362.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsConsoleWidgetProvider</RootNamespace>
     <Platforms>x86;x64;ARM64</Platforms>
@@ -46,5 +46,6 @@
 
   <Import Project="..\WidgetHelper\WidgetHelper.projitems" Label="Shared" />
 </Project>
+
 
 

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/CsConsoleWidgetProvider.csproj
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/CsConsoleWidgetProvider.csproj
@@ -5,7 +5,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CsConsoleWidgetProvider</RootNamespace>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>false</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>
@@ -46,6 +46,7 @@
 
   <Import Project="..\WidgetHelper\WidgetHelper.projitems" Label="Shared" />
 </Project>
+
 
 
 

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-arm64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Widgets/cs-console-packaged/CsConsoleWidgetProvider/Properties/PublishProfiles/win10-x86.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Windowing/cs/cs-winforms-unpackaged/winforms_unpackaged_app.csproj
+++ b/Samples/Windowing/cs/cs-winforms-unpackaged/winforms_unpackaged_app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x86;x64;ARM64</Platforms>
@@ -15,5 +15,6 @@
   </ItemGroup>
 
 </Project>
+
 
 

--- a/Samples/Windowing/cs/cs-winforms-unpackaged/winforms_unpackaged_app.csproj
+++ b/Samples/Windowing/cs/cs-winforms-unpackaged/winforms_unpackaged_app.csproj
@@ -6,7 +6,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
 
@@ -15,6 +15,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/Windowing/cs/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Windowing/cs/cs-winui/Properties/PublishProfiles/win10-arm64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Windowing/cs/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Windowing/cs/cs-winui/Properties/PublishProfiles/win10-x64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+  <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Windowing/cs/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Windowing/cs/cs-winui/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Windowing/cs/cs-winui/Windowing.csproj
+++ b/Samples/Windowing/cs/cs-winui/Windowing.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Windowing</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
@@ -45,6 +45,7 @@
     </Page>
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/Windowing/cs/cs-winui/Windowing.csproj
+++ b/Samples/Windowing/cs/cs-winui/Windowing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Windowing</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -45,6 +45,7 @@
     </Page>
   </ItemGroup>
 </Project>
+
 
 
 

--- a/Samples/Windowing/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Samples/Windowing/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Windowing/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Samples/Windowing/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Windowing/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Samples/Windowing/cs1/cs-wpf/wpf_packaged_app/Properties/PublishProfiles/win10-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/Windowing/cs1/cs-wpf/wpf_packaged_app/wpf_packaged_app.csproj
+++ b/Samples/Windowing/cs1/cs-wpf/wpf_packaged_app/wpf_packaged_app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
@@ -26,6 +26,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/Samples/WindowsAIFoundry/cs-winui/Properties/PublishProfiles/win-x86.pubxml
+++ b/Samples/WindowsAIFoundry/cs-winui/Properties/PublishProfiles/win-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/nuget.config
+++ b/Samples/nuget.config
@@ -9,6 +9,10 @@
     </packageRestore>
     <packageSources>
         <clear />
+        <!-- default nuget.org source, we don't use it in pipeline, but kept here for local development
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+        -->
+
         <!-- publicly accessible NuGet feed -->
         <add key="WinAppSDK-SampleDeps" value="https://pkgs.dev.azure.com/shine-oss/WinAppSDK-Samples/_packaging/WinAppSDK-SampleDeps/nuget/v3/index.json" />
 

--- a/Templates/VSIX/Project Templates/cs-winui-template/Package.appxmanifest
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Package.appxmanifest
@@ -4,7 +4,8 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
+  IgnorableNamespaces="uap rescap systemai">
 
   <Identity
     Name="$guid9$"
@@ -18,8 +19,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
   </Dependencies>
 
   <Resources>
@@ -44,5 +45,6 @@
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <systemai:Capability Name="systemAIModels"/>
   </Capabilities>
 </Package>

--- a/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-arm64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x64.pubxml
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x86.pubxml
+++ b/Templates/VSIX/Project Templates/cs-winui-template/Properties/PublishProfiles/win10-x86.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description
Given .net 6 already EOL, at least we should update all project to .net 8.

This pull request updates multiple C# sample projects to modernize their .NET framework versions and standardize runtime identifiers. The changes improve compatibility with newer .NET features and align runtime naming conventions across all samples.

.NET Framework and Runtime Modernization:

* Updated the `TargetFramework` for all sample `.csproj` files from `net6.0-windows10.0.19041.0` to `net8.0-windows10.0.19041.0`, ensuring support for the latest .NET features and APIs. [[1]](diffhunk://#diff-68440e5ce8248b149503ce5405466c3c36488f5ab2fde292c636741eea8e61f7L5-R7) [[2]](diffhunk://#diff-26b2792faa207ae769e7ca61820f14d2bf8b0b77b67604495a7d1c497aba26eeL5-R8) [[3]](diffhunk://#diff-f3c5347b7aee3b3690953e97cbe40fbf063038f8eb2cd0d4f67a6f0dcac9094fL5-R8) [[4]](diffhunk://#diff-0a3c6ff7d088af0cd062f1548defe812324557bcc6514c1134b42a159117bb29L5-R8) [[5]](diffhunk://#diff-a9bda1da4f146ddf0b7c87d2b88073089d060e4cd6b3b45f6ec397b60ffe90f5L4-R9) [[6]](diffhunk://#diff-2a52cbb93554a77beaf249083c760c65acf357c8a6732fc3381b290d5774aa9bL5-R8) [[7]](diffhunk://#diff-a6909715e744463b4ccb6c96b4caa15c98d052c055f3ec121cf7dba6ce7b9841L5-R7) [[8]](diffhunk://#diff-f510f64489204f503432cbe42bd5889e9cef0213164de8c1b612ec70c07f8a6fL5-R8) [[9]](diffhunk://#diff-47bbb1f5a3d1bda7226c1c332e86b59d74cd1c3ff3f57f7144ff57a4233c3f1cL5-R8) [[10]](diffhunk://#diff-820e2267f842ecb6f146d17f3c54b14087076aed729dd12c8e07b58436a81007L5-R8) [[11]](diffhunk://#diff-e47cc5ff4c468f2e64b2517ae2550ac25073873dd5ad696f07c89dafef846fa1L4-R9) [[12]](diffhunk://#diff-d1902fcac82fce053c557f1657a482c8ddc29df8a1d3df58754ffc61184d7c37L4-R9) [[13]](diffhunk://#diff-539503ee66055708dc1f38c28325a2a39fe978fb3fedf7ac15318baf9556ba8dL4-R9) [[14]](diffhunk://#diff-d5765e9be4992064b8c09177458af176fd4c48d9df5e869d65423e20602db216L4-R9) [[15]](diffhunk://#diff-eda8b4b1eca916b480b38430cd4f11def6e670d5cfec8ca2b3387a16aeb01800L5-R7) [[16]](diffhunk://#diff-ef653efc10115f25b428a2c0b70ef1095ae2ff7ca82c71dc424c345784ae98e0L5-R8) [[17]](diffhunk://#diff-fa170396bf299c068ede972ba8cab9fa5ed0b6281dbd6756d314f6a95890181bL5-R8)
* Standardized `RuntimeIdentifiers` by replacing `win10-*` identifiers with `win-*` (e.g., `win10-x64` → `win-x64`) across all projects for consistency and future-proofing. [[1]](diffhunk://#diff-68440e5ce8248b149503ce5405466c3c36488f5ab2fde292c636741eea8e61f7L5-R7) [[2]](diffhunk://#diff-26b2792faa207ae769e7ca61820f14d2bf8b0b77b67604495a7d1c497aba26eeL5-R8) [[3]](diffhunk://#diff-f3c5347b7aee3b3690953e97cbe40fbf063038f8eb2cd0d4f67a6f0dcac9094fL5-R8) [[4]](diffhunk://#diff-0a3c6ff7d088af0cd062f1548defe812324557bcc6514c1134b42a159117bb29L5-R8) [[5]](diffhunk://#diff-a9bda1da4f146ddf0b7c87d2b88073089d060e4cd6b3b45f6ec397b60ffe90f5L4-R9) [[6]](diffhunk://#diff-2a52cbb93554a77beaf249083c760c65acf357c8a6732fc3381b290d5774aa9bL5-R8) [[7]](diffhunk://#diff-a6909715e744463b4ccb6c96b4caa15c98d052c055f3ec121cf7dba6ce7b9841L5-R7) [[8]](diffhunk://#diff-f510f64489204f503432cbe42bd5889e9cef0213164de8c1b612ec70c07f8a6fL5-R8) [[9]](diffhunk://#diff-47bbb1f5a3d1bda7226c1c332e86b59d74cd1c3ff3f57f7144ff57a4233c3f1cL5-R8) [[10]](diffhunk://#diff-820e2267f842ecb6f146d17f3c54b14087076aed729dd12c8e07b58436a81007L5-R8) [[11]](diffhunk://#diff-e47cc5ff4c468f2e64b2517ae2550ac25073873dd5ad696f07c89dafef846fa1L4-R9) [[12]](diffhunk://#diff-d1902fcac82fce053c557f1657a482c8ddc29df8a1d3df58754ffc61184d7c37L4-R9) [[13]](diffhunk://#diff-539503ee66055708dc1f38c28325a2a39fe978fb3fedf7ac15318baf9556ba8dL4-R9) [[14]](diffhunk://#diff-d5765e9be4992064b8c09177458af176fd4c48d9df5e869d65423e20602db216L4-R9) [[15]](diffhunk://#diff-eda8b4b1eca916b480b38430cd4f11def6e670d5cfec8ca2b3387a16aeb01800L5-R7) [[16]](diffhunk://#diff-ef653efc10115f25b428a2c0b70ef1095ae2ff7ca82c71dc424c345784ae98e0L5-R8) [[17]](diffhunk://#diff-fa170396bf299c068ede972ba8cab9fa5ed0b6281dbd6756d314f6a95890181bL5-R8)

These updates help keep the sample projects current and compatible with the latest development tools.

## Target Release

Please specify which release this PR should align with 1.8

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
