### PR TITLE
[Cherry-Pick] Adding compile / link switches for native WindowsML samples (#577)

### DIFF
--- a/Samples/WindowsML/cpp/Directory.Build.props
+++ b/Samples/WindowsML/cpp/Directory.Build.props
@@ -1,4 +1,23 @@
 <Project>
+  <!-- Security settings for Control Flow Guard (CFG) and other mitigations -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) /Qspectre</AdditionalOptions>
+      <!-- /GS Enable Control Flow Guard -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <!-- Setting this to be compatible with CFG -->
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <!-- dynamicbase is required for enabling CFG -->
+      <AdditionalOptions>%(AdditionalOptions) /dynamicbase</AdditionalOptions>
+      <!-- /GS Enable Control Flow Guard -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
+    </Link>
+  </ItemDefinitionGroup>
+
   <PropertyGroup>
     <!-- C++ specific settings only -->
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

The compiler and linker switches from the Directory.Build.props at the root of the repository need to be reflected into the private one used by the Windows ML samples to ensure that we pick up those configurations when building those binaries. The absence of these switches is generating BinSkim errors in the pipeline builds.

## Target Release

2.0

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
