### PR TITLE
samples: NotesApp ACS API updates

### DIFF
--- a/Samples/AppContentSearch/cs-winui/AI/Provider/FoundryAIProvider.cs
+++ b/Samples/AppContentSearch/cs-winui/AI/Provider/FoundryAIProvider.cs
@@ -1,10 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-using Microsoft.AI.Foundry.Local;
-using Microsoft.Extensions.AI;
-using Notes.ViewModels;
-using OpenAI;
-using OpenAI.Chat;
 using System;
 using System.ClientModel;
 using System.Collections.Generic;
@@ -13,6 +8,11 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AI.Foundry.Local;
+using Microsoft.Extensions.AI;
+using Notes.ViewModels;
+using OpenAI;
+using OpenAI.Chat;
 using Windows.Storage;
 using AppChatRole = Notes.ViewModels.ChatRole;
 using ExtChatRole = Microsoft.Extensions.AI.ChatRole;
@@ -143,7 +143,8 @@ public class FoundryAIProvider : ILanguageModelProvider
                     break;
                 }
 
-                if (!hasNext) break;
+                if (!hasNext)
+                    break;
 
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -175,7 +176,9 @@ public class FoundryAIProvider : ILanguageModelProvider
     {
         try
         {
+#pragma warning disable CA2000 // Dispose objects before losing scope
             var foundryManager = new FoundryLocalManager();
+#pragma warning restore CA2000 // Dispose objects before losing scope
             var cached = foundryManager.ListCachedModelsAsync().GetAwaiter().GetResult();
             return cached.Count > 0;
         }
@@ -187,7 +190,8 @@ public class FoundryAIProvider : ILanguageModelProvider
 
     private async Task EnsureFoundryClientAsync(CancellationToken ct)
     {
-        if (_foundryClient != null && _foundryChatClient != null) return;
+        if (_foundryClient != null && _foundryChatClient != null)
+            return;
 
         var settings = ApplicationData.Current.LocalSettings;
         string alias = (settings.Values[FoundryModelKey] as string)?.Trim() ?? "";
@@ -195,7 +199,9 @@ public class FoundryAIProvider : ILanguageModelProvider
         {
             try
             {
+#pragma warning disable CA2000 // Dispose objects before losing scope
                 var foundryManager = new FoundryLocalManager();
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
                 var cached = await foundryManager.ListCachedModelsAsync();
                 if (cached.Count != 0)

--- a/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using Notes.Controls;
 using Notes.Pages;
 using Notes.ViewModels;
@@ -98,10 +98,10 @@ namespace Notes
             GetOrCreateIndexResult? getOrCreateResult = null;
             await Task.Run(() =>
             {
-                getOrCreateResult = Microsoft.Windows.AI.Search.Experimental.AppContentIndex.AppContentIndexer.GetOrCreateIndex("NotesIndex");
+                getOrCreateResult = AppContentIndexer.GetOrCreateIndex("NotesIndex");
                 if (getOrCreateResult == null)
                 {
-                    throw new Exception("GetOrCreateIndexResult is null");
+                    throw new InvalidOperationException("GetOrCreateIndexResult is null");
                 }
                 if (!getOrCreateResult.Succeeded)
                 {

--- a/Samples/AppContentSearch/cs-winui/Notes.csproj
+++ b/Samples/AppContentSearch/cs-winui/Notes.csproj
@@ -29,21 +29,12 @@
 		<Content Remove="Assets\mockText.txt" />
 	</ItemGroup>
 
-	<!-- <ItemGroup>
-		<ProjectReference Include="..\..\product\APIs\Projection\Microsoft.Windows.AI.Search.Projection\Microsoft.Windows.AI.Search.Projection.csproj" />
-		<ProjectReference Include="..\..\product\APIs\Projection\Microsoft.Windows.AI.Text.Projection\Microsoft.Windows.AI.Text.Projection.csproj" />
-	</ItemGroup> -->
-
 	<ItemGroup>
 		<None Remove="Assets\Notes.ico" />
 		<None Remove="Controls\AttachmentView.xaml" />
 		<None Remove="Controls\ChatSessionView.xaml" />
 		<None Remove="Controls\SearchView.xaml" />
 	</ItemGroup>
-
-	<!-- <ItemGroup>
-		<AdditionalFiles Include="NativeMethods.txt" />
-	</ItemGroup> -->
 
 	<ItemGroup>
 		<Content Include="Assets\SplashScreen.scale-200.png" />
@@ -76,7 +67,7 @@
 		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.3.0-preview.1.25114.11" />
 		<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4948" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental3" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-preview1" />
 		<PackageReference Include="OpenAI" Version="2.2.0-beta.2" />
 	</ItemGroup>
 	<ItemGroup>
@@ -119,30 +110,6 @@
 			<Generator>MSBuild:Compile</Generator>
 		</Page>
 	</ItemGroup>
-	<!-- <ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup> -->
 	<ItemGroup>
 	  <PRIResource Remove="Assets\Icon\**" />
 	</ItemGroup>

--- a/Samples/AppContentSearch/cs-winui/Package.appxmanifest
+++ b/Samples/AppContentSearch/cs-winui/Package.appxmanifest
@@ -5,19 +5,17 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
-  IgnorableNamespaces="uap rescap systemai">
-
+  IgnorableNamespaces="uap rescap systemai"
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10">
+  
   <Identity
-    Name="8e8c755b-914d-4f6c-89b6-95af1fc4fbaa"
-    Publisher="CN=nikol"
-    Version="1.0.1.0" />
-
-  <mp:PhoneIdentity PhoneProductId="8e8c755b-914d-4f6c-89b6-95af1fc4fbaa" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
+    Name="ai-powered-notes-winui3-sample"
+    Publisher="CN=AIFabricTest"
+    Version="1.0.0.0" />
 
   <Properties>
     <DisplayName>Notes</DisplayName>
-    <PublisherDisplayName>nikol</PublisherDisplayName>
+    <PublisherDisplayName>AIFabricTest</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
 

--- a/Samples/AppContentSearch/cs-winui/Utils/AttachmentProcessor.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/AttachmentProcessor.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Extensions.AI;
+using Microsoft.Windows.Search.AppContentIndex;
 using Notes.Models;
 using System;
 using System.Collections.Generic;
@@ -14,7 +15,7 @@ namespace Notes
 {
     public static class AttachmentProcessor
     {
-        public static EventHandler<AttachmentProcessedEventArgs>? AttachmentProcessed;
+        internal static EventHandler<AttachmentProcessedEventArgs>? AttachmentProcessed;
 
         private readonly static List<Attachment> _toBeProcessed = new();
         private static bool _isProcessing = false;

--- a/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
@@ -1,12 +1,12 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
-using Notes.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Windows.Search.AppContentIndex;
+using Notes.ViewModels;
 using Windows.Foundation;
 using Windows.Storage;
 

--- a/Samples/AppContentSearch/cs-winui/ViewModels/NoteViewModel.cs
+++ b/Samples/AppContentSearch/cs-winui/ViewModels/NoteViewModel.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using Notes.Models;
 using System;
 using System.Collections.ObjectModel;

--- a/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
+++ b/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
@@ -1,16 +1,15 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
-using CommunityToolkit.Mvvm.ComponentModel;
-using Microsoft.UI.Xaml;
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Notes.ViewModels
 {
-    public partial class SearchViewModel : ObservableObject
+    public partial class SearchViewModel : ObservableObject, IDisposable
     {
         [ObservableProperty]
         public bool showResults = false;
@@ -27,7 +26,7 @@ namespace Notes.ViewModels
         public ObservableCollection<SearchResult> ImageResults { get; set; } = new();
 
         private string _searchText = string.Empty;
-        private CancellationTokenSource? _currentSearchCancellation;
+        private CancellationTokenSource? currentSearchCancellation;
 
         public SearchViewModel()
         {
@@ -51,15 +50,15 @@ namespace Notes.ViewModels
         private async Task Search()
         {
             Debug.WriteLine("searching");
-            
+
             // Cancel any existing search
-            _currentSearchCancellation?.Cancel();
-            _currentSearchCancellation?.Dispose();
-            
+            currentSearchCancellation?.Cancel();
+            currentSearchCancellation?.Dispose();
+
             // Create new cancellation token for this search
-            _currentSearchCancellation = new CancellationTokenSource();
-            var cancellationToken = _currentSearchCancellation.Token;
-            
+            currentSearchCancellation = new CancellationTokenSource();
+            var cancellationToken = currentSearchCancellation.Token;
+
             try
             {
                 Reset();
@@ -122,6 +121,13 @@ namespace Notes.ViewModels
                 Debug.WriteLine($"Search failed: {ex.Message}");
                 // Handle other exceptions as needed
             }
+        }
+
+        public void Dispose()
+        {
+            currentSearchCancellation?.Cancel();
+            currentSearchCancellation?.Dispose();
+            currentSearchCancellation = null;
         }
     }
 }


### PR DESCRIPTION
Auto-generated NotesApp updates for AI Fabric ACS feature changes.

Using Microsoft.WindowsAppSDK 2.0.0-preview1.

## Changes
- Updated NuGet from 2.0.0-experimental4 to 2.0.0-preview1
- Removed internal NuGet feed references and commented-out project references
- Synced from aifabric test/NotesApp (feature/ACISamples)

Reference: https://github.com/microsoft/WindowsAppSDK-Samples/pull/566