### PR TITLE
samples: sync NotesApp with latest ACI API changes

### DIFF
--- a/Samples/AppContentSearch/README.md
+++ b/Samples/AppContentSearch/README.md
@@ -16,9 +16,17 @@ extendedZipContent:
 
 # AppContentSearch Sample Application
 
-This sample demonstrates how to use App Content Search's **AppContentIndex APIs** in a **WinUI3** notes application. It shows how to create, manage, and semantically search through the index that includes both text content and images. It also shows how to use use the search results to enable retrieval augmented genaration (RAG) scenarios with language models.
+This sample demonstrates how to use App Content Search's
+**AppContentIndex APIs** in a **WinUI3** notes application.
+It shows how to create, manage, and semantically search
+through the index that includes both text content and images.
+It also shows how to use the search results to enable
+retrieval augmented generation (RAG) scenarios with language
+models.
 
-> **Note**: This sample is targeted and tested for **Windows App SDK 2.0 Experimental2** and **Visual Studio 2022**. The AppContentSearch APIs are experimental and available in Windows App SDK 2.0 experimental2.
+> **Note**: This sample is targeted and tested for
+> **Windows App SDK 2.0 Preview1** and
+> **Visual Studio 2022**.
 
 
 ## Features
@@ -42,7 +50,7 @@ This sample demonstrates:
 
 ## Building and Running the Sample
 
-* Open the solution file (`AppContentSearch.sln`) in Visual Studio.
+* Open the solution file (`NotesApp.sln`) in Visual Studio.
 * Press Ctrl+Shift+B, or select **Build** \> **Build Solution**.
 * Run the application to see the Notes app with integrated search functionality.
 

--- a/Samples/AppContentSearch/README.md
+++ b/Samples/AppContentSearch/README.md
@@ -22,7 +22,7 @@ It shows how to create, manage, and semantically search
 through the index that includes both text content and images.
 It also shows how to use the search results to enable
 retrieval augmented generation (RAG) scenarios with language
-models.
+models. 
 
 > **Note**: This sample is targeted and tested for
 > **Windows App SDK 2.0 Preview1** and

--- a/Samples/AppContentSearch/cs-winui/AI/Provider/FoundryAIProvider.cs
+++ b/Samples/AppContentSearch/cs-winui/AI/Provider/FoundryAIProvider.cs
@@ -176,9 +176,7 @@ public class FoundryAIProvider : ILanguageModelProvider
     {
         try
         {
-#pragma warning disable CA2000 // Dispose objects before losing scope
-            var foundryManager = new FoundryLocalManager();
-#pragma warning restore CA2000 // Dispose objects before losing scope
+            using var foundryManager = new FoundryLocalManager();
             var cached = foundryManager.ListCachedModelsAsync().GetAwaiter().GetResult();
             return cached.Count > 0;
         }
@@ -199,9 +197,7 @@ public class FoundryAIProvider : ILanguageModelProvider
         {
             try
             {
-#pragma warning disable CA2000 // Dispose objects before losing scope
-                var foundryManager = new FoundryLocalManager();
-#pragma warning restore CA2000 // Dispose objects before losing scope
+                using var foundryManager = new FoundryLocalManager();
 
                 var cached = await foundryManager.ListCachedModelsAsync();
                 if (cached.Count != 0)

--- a/Samples/AppContentSearch/cs-winui/AI/Provider/FoundryAIProvider.cs
+++ b/Samples/AppContentSearch/cs-winui/AI/Provider/FoundryAIProvider.cs
@@ -1,10 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-using Microsoft.AI.Foundry.Local;
-using Microsoft.Extensions.AI;
-using Notes.ViewModels;
-using OpenAI;
-using OpenAI.Chat;
 using System;
 using System.ClientModel;
 using System.Collections.Generic;
@@ -13,6 +8,11 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AI.Foundry.Local;
+using Microsoft.Extensions.AI;
+using Notes.ViewModels;
+using OpenAI;
+using OpenAI.Chat;
 using Windows.Storage;
 using AppChatRole = Notes.ViewModels.ChatRole;
 using ExtChatRole = Microsoft.Extensions.AI.ChatRole;
@@ -143,7 +143,8 @@ public class FoundryAIProvider : ILanguageModelProvider
                     break;
                 }
 
-                if (!hasNext) break;
+                if (!hasNext)
+                    break;
 
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -175,7 +176,9 @@ public class FoundryAIProvider : ILanguageModelProvider
     {
         try
         {
+#pragma warning disable CA2000 // Dispose objects before losing scope
             var foundryManager = new FoundryLocalManager();
+#pragma warning restore CA2000 // Dispose objects before losing scope
             var cached = foundryManager.ListCachedModelsAsync().GetAwaiter().GetResult();
             return cached.Count > 0;
         }
@@ -187,7 +190,8 @@ public class FoundryAIProvider : ILanguageModelProvider
 
     private async Task EnsureFoundryClientAsync(CancellationToken ct)
     {
-        if (_foundryClient != null && _foundryChatClient != null) return;
+        if (_foundryClient != null && _foundryChatClient != null)
+            return;
 
         var settings = ApplicationData.Current.LocalSettings;
         string alias = (settings.Values[FoundryModelKey] as string)?.Trim() ?? "";
@@ -195,7 +199,9 @@ public class FoundryAIProvider : ILanguageModelProvider
         {
             try
             {
+#pragma warning disable CA2000 // Dispose objects before losing scope
                 var foundryManager = new FoundryLocalManager();
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
                 var cached = await foundryManager.ListCachedModelsAsync();
                 if (cached.Count != 0)

--- a/Samples/AppContentSearch/cs-winui/Controls/AttachmentView.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/Controls/AttachmentView.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using Notes.Models;
 using Notes.ViewModels;
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Storage;
@@ -58,8 +59,26 @@ namespace Notes.Controls
             _boundingBox = boundingBox;
 
             AttachmentVM = attachment;
+
+            string? filename = attachment.Attachment.Filename;
+            if (string.IsNullOrWhiteSpace(filename))
+            {
+                Debug.WriteLine($"AttachmentView: attachment id={attachment.Attachment.Id} has no filename; skipping.");
+                AttachmentImage.Source = null;
+                return;
+            }
+
             StorageFolder attachmentsFolder = await Utils.GetAttachmentsFolderAsync();
-            StorageFile attachmentFile = await attachmentsFolder.GetFileAsync(attachment.Attachment.Filename);
+
+            // Use TryGetItemAsync so a missing/stale file (e.g. deleted on disk but still in the
+            // search index) does not throw FileNotFoundException and crash the app.
+            StorageFile? attachmentFile = await attachmentsFolder.TryGetItemAsync(filename) as StorageFile;
+            if (attachmentFile == null)
+            {
+                Debug.WriteLine($"AttachmentView: file '{filename}' not found in attachments folder; skipping.");
+                AttachmentImage.Source = null;
+                return;
+            }
 
             switch (AttachmentVM.Attachment.Type)
             {

--- a/Samples/AppContentSearch/cs-winui/Controls/SearchView.xaml
+++ b/Samples/AppContentSearch/cs-winui/Controls/SearchView.xaml
@@ -100,6 +100,20 @@
                             </ItemsView.Layout>
                         </ItemsView>
                     </StackPanel>
+
+                    <!-- OCR Text Results List -->
+                    <StackPanel Visibility="{x:Bind ViewModel.ShowOcrResults, Mode=OneWay}">
+                        <TextBlock x:Name="OcrResultsTextBlock"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="4,12">OCR Text Results</TextBlock>
+
+                        <ItemsView x:Name="resultsOcrItemsView"
+                                   ItemsSource="{x:Bind ViewModel.OcrResults}"
+                                   ItemInvoked="ResultsItemsView_ItemInvoked"
+                                   IsItemInvokedEnabled="True"
+                                   SelectionMode="None"
+                                   ItemTemplate="{StaticResource TextSearchResultDataTemplate}">
+                        </ItemsView>
+                    </StackPanel>
                     
 
                     <!-- Text Results List -->
@@ -127,7 +141,8 @@
                     Height="32"
                     Width="400"
                     PlaceholderText="Search for anything..."
-                    QuerySubmitted="SearchBox_QuerySubmitted">
+                    QuerySubmitted="SearchBox_QuerySubmitted"
+                    TextChanged="SearchBox_TextChanged">
                     <AutoSuggestBox.QueryIcon>
                         <FontIcon
                             x:Name="SearchBoxQueryIcon"

--- a/Samples/AppContentSearch/cs-winui/Controls/SearchView.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/Controls/SearchView.xaml.cs
@@ -22,6 +22,7 @@ namespace Notes.Controls
         public SearchView()
         {
             this.InitializeComponent();
+            this.Unloaded += (_, _) => ViewModel.Dispose();
         }
 
         private void HideResultsPanel()

--- a/Samples/AppContentSearch/cs-winui/Controls/SearchView.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/Controls/SearchView.xaml.cs
@@ -32,7 +32,6 @@ namespace Notes.Controls
 
         private async void ResultsItemsView_ItemInvoked(ItemsView sender, ItemsViewItemInvokedEventArgs e)
         {
-            var context = await AppDataContext.GetCurrentAsync();
             var item = e.InvokedItem as SearchResult;
 
             if (MainWindow.Instance != null && item != null)
@@ -43,10 +42,22 @@ namespace Notes.Controls
                 }
                 else if (item.ContentType == ContentType.OcrText)
                 {
-                    await MainWindow.Instance.SelectNoteById(item.SourceId);
+                    if (item.AttachmentId is int attachmentId)
+                    {
+                        await MainWindow.Instance.SelectNoteById(
+                            item.SourceId,
+                            attachmentId,
+                            item.MostRelevantSentence,
+                            item.BoundingBox);
+                    }
+                    else
+                    {
+                        await MainWindow.Instance.SelectNoteById(item.SourceId);
+                    }
                 }
                 else
                 {
+                    var context = await AppDataContext.GetCurrentAsync();
                     var attachment = context.Attachments.Where(a => a.Id == item.SourceId).FirstOrDefault();
 
                     if (attachment != null)

--- a/Samples/AppContentSearch/cs-winui/Controls/SearchView.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/Controls/SearchView.xaml.cs
@@ -40,6 +40,10 @@ namespace Notes.Controls
                 {
                     await MainWindow.Instance.SelectNoteById(item.SourceId);
                 }
+                else if (item.ContentType == ContentType.OcrText)
+                {
+                    await MainWindow.Instance.SelectNoteById(item.SourceId);
+                }
                 else
                 {
                     var attachment = context.Attachments.Where(a => a.Id == item.SourceId).FirstOrDefault();
@@ -136,6 +140,23 @@ namespace Notes.Controls
         private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
         {
             ViewModel.HandleQuerySubmitted(sender.Text);
+        }
+
+        private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            // Only react to user input, not programmatic changes
+            if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+            {
+                ViewModel.HandleTextChanged(sender.Text);
+            }
+        }
+
+        public void InitializeQuerySessions()
+        {
+            if (MainWindow.AppContentIndexer != null)
+            {
+                ViewModel.InitializeQuerySessions(MainWindow.AppContentIndexer, DispatcherQueue);
+            }
         }
 
         private void ItemContainer_BringIntoViewRequested(UIElement sender, BringIntoViewRequestedEventArgs args)

--- a/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
@@ -50,6 +50,12 @@ namespace Notes
 
             VM.Notes.CollectionChanged += Notes_CollectionChanged;
 
+            this.Closed += (_, _) =>
+            {
+                _appContentIndexer?.Dispose();
+                _appContentIndexer = null;
+            };
+
             _initializeAppContentIndexerTask = InitializeAppContentIndexerAsync();
 
             DispatcherQueue.TryEnqueue(async () =>

--- a/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Windows.Foundation.Collections;
 
 namespace Notes
 {
@@ -20,11 +21,13 @@ namespace Notes
         private static SearchView? _searchView;
         private static MainWindow? _instance;
         private static AppContentIndexer? _appContentIndexer;
+        private static IndexCapabilitiesOfCurrentSystem? _systemCapabilities;
 
         public static ChatSessionView? ChatSessionView => _chatSessionView;
         public static SearchView? SearchView => _searchView;
         public static MainWindow? Instance => _instance;
         public static AppContentIndexer? AppContentIndexer => _appContentIndexer;
+        public static IndexCapabilitiesOfCurrentSystem? SystemCapabilities => _systemCapabilities;
 
         public ViewModel VM;
 
@@ -93,11 +96,119 @@ namespace Notes
             }
         }
 
+        private static void CheckSystemCapabilities()
+        {
+            _systemCapabilities = AppContentIndexer.GetIndexCapabilitiesOfCurrentSystem();
+
+            var capabilities = new[]
+            {
+                IndexCapability.TextLexical,
+                IndexCapability.TextSemantic,
+                IndexCapability.ImageOcr,
+                IndexCapability.ImageSemantic
+            };
+
+            foreach (var capability in capabilities)
+            {
+                var status = _systemCapabilities.GetIndexCapabilityStatus(capability);
+                Debug.WriteLine($"System capability {capability}: {status}");
+
+                if (status == IndexCapabilityOfCurrentSystemStatus.DisabledByPolicy)
+                {
+                    Debug.WriteLine($"Warning: {capability} is disabled by policy.");
+                }
+                else if (status == IndexCapabilityOfCurrentSystemStatus.NotSupported)
+                {
+                    Debug.WriteLine($"Warning: {capability} is not supported on this system.");
+                }
+            }
+        }
+
+        private void SubscribeToIndexerListener()
+        {
+            if (_appContentIndexer is null)
+            {
+                return;
+            }
+
+            var listener = _appContentIndexer.Listener;
+
+            listener.IndexCapabilitiesChanged += (sender, capabilities) =>
+            {
+                if (capabilities.HasCapabilitiesWithErrors)
+                {
+                    var errors = capabilities.GetCapabilitiesWithErrors();
+                    foreach (var cap in errors)
+                    {
+                        var state = capabilities.GetCapabilityState(cap);
+                        Debug.WriteLine($"Index capability error — {cap}: {state.InitializationStatus}, {state.ErrorMessage}");
+                    }
+                }
+                else
+                {
+                    Debug.WriteLine("All index capabilities are healthy.");
+                }
+            };
+
+            listener.IndexStatisticsChanged += (sender, stats) =>
+            {
+                Debug.WriteLine($"Index statistics changed — Items: {stats.ItemCount}, " +
+                    $"Completed: {stats.CompletedCount}, InProgress: {stats.InProgressCount}, " +
+                    $"NotStarted: {stats.NotStartedCount}, Errors: {stats.ErrorsCount}, " +
+                    $"PendingDeletion: {stats.PendingDeletionCount}, " +
+                    $"RequiringReindexing: {stats.RequiringReindexingCount}");
+
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    if (stats.IndexingInProgress)
+                    {
+                        int total = stats.ItemCount;
+                        int completed = stats.CompletedCount;
+                        if (total > 0)
+                        {
+                            double percent = (double)completed / total * 100;
+                            _searchView?.SetIndexProgressBar(percent);
+                        }
+                    }
+                    else
+                    {
+                        _searchView?.SetSearchBoxIndexingCompleted();
+                    }
+                });
+            };
+
+            listener.ContentItemStatusChanged += (sender, statusMap) =>
+            {
+                foreach (var kvp in statusMap)
+                {
+                    Debug.WriteLine($"Content item '{kvp.Key}' status: {kvp.Value.Status}, Error: {kvp.Value.ErrorDetail}");
+                }
+            };
+        }
+
+        private static void LogIndexStatistics()
+        {
+            if (_appContentIndexer is null)
+            {
+                return;
+            }
+
+            var stats = _appContentIndexer.GetIndexStatistics();
+            Debug.WriteLine($"Index statistics — Items: {stats.ItemCount}, " +
+                $"Completed: {stats.CompletedCount}, InProgress: {stats.InProgressCount}, " +
+                $"NotStarted: {stats.NotStartedCount}, Errors: {stats.ErrorsCount}, " +
+                $"PendingDeletion: {stats.PendingDeletionCount}, " +
+                $"RequiringReindexing: {stats.RequiringReindexingCount}");
+        }
+
         private async Task InitializeAppContentIndexerAsync()
         {
             GetOrCreateIndexResult? getOrCreateResult = null;
             await Task.Run(() =>
             {
+                // Pre-flight: check system-level ACI capabilities before creating an index.
+                CheckSystemCapabilities();
+
                 getOrCreateResult = AppContentIndexer.GetOrCreateIndex("NotesIndex");
                 if (getOrCreateResult == null)
                 {
@@ -109,12 +220,20 @@ namespace Notes
                 }
 
                 _appContentIndexer = getOrCreateResult.Indexer;
+
+                LogIndexStatistics();
             });
+
+            // Subscribe to live status updates from the indexer.
+            SubscribeToIndexerListener();
 
             DispatcherQueue.TryEnqueue(() =>
             {
                 ChatPaneToggleButton.IsEnabled = true;
                 AppSearchView.SetSearchBoxInitializingCompleted();
+
+                // Initialize query sessions for search-as-you-type.
+                AppSearchView.InitializeQuerySessions();
 
                 var status = getOrCreateResult?.Status;
 

--- a/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using Notes.Controls;
 using Notes.Pages;
 using Notes.ViewModels;
@@ -98,10 +98,10 @@ namespace Notes
             GetOrCreateIndexResult? getOrCreateResult = null;
             await Task.Run(() =>
             {
-                getOrCreateResult = Microsoft.Windows.AI.Search.Experimental.AppContentIndex.AppContentIndexer.GetOrCreateIndex("NotesIndex");
+                getOrCreateResult = AppContentIndexer.GetOrCreateIndex("NotesIndex");
                 if (getOrCreateResult == null)
                 {
-                    throw new Exception("GetOrCreateIndexResult is null");
+                    throw new InvalidOperationException("GetOrCreateIndexResult is null");
                 }
                 if (!getOrCreateResult.Succeeded)
                 {

--- a/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
@@ -324,8 +324,18 @@ namespace Notes
 
         public async void OpenAttachmentView(AttachmentViewModel attachment, string? attachmentText = null, Windows.Foundation.Rect? boundingBox = null)
         {
-            await AttachmentView.UpdateAttachment(attachment, attachmentText, boundingBox);
-            AttachmentView.Show();
+            // OpenAttachmentView is async void: any exception that escapes here is unhandled
+            // and will crash the app (no DispatcherUnhandledException handler is registered).
+            // Guard against missing/stale files or other update failures.
+            try
+            {
+                await AttachmentView.UpdateAttachment(attachment, attachmentText, boundingBox);
+                AttachmentView.Show();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"OpenAttachmentView failed for attachment id={attachment?.Attachment?.Id}: {ex.Message}");
+            }
         }
 
         private async Task IndexAllAsync()

--- a/Samples/AppContentSearch/cs-winui/Notes.csproj
+++ b/Samples/AppContentSearch/cs-winui/Notes.csproj
@@ -29,21 +29,12 @@
 		<Content Remove="Assets\mockText.txt" />
 	</ItemGroup>
 
-	<!-- <ItemGroup>
-		<ProjectReference Include="..\..\product\APIs\Projection\Microsoft.Windows.AI.Search.Projection\Microsoft.Windows.AI.Search.Projection.csproj" />
-		<ProjectReference Include="..\..\product\APIs\Projection\Microsoft.Windows.AI.Text.Projection\Microsoft.Windows.AI.Text.Projection.csproj" />
-	</ItemGroup> -->
-
 	<ItemGroup>
 		<None Remove="Assets\Notes.ico" />
 		<None Remove="Controls\AttachmentView.xaml" />
 		<None Remove="Controls\ChatSessionView.xaml" />
 		<None Remove="Controls\SearchView.xaml" />
 	</ItemGroup>
-
-	<!-- <ItemGroup>
-		<AdditionalFiles Include="NativeMethods.txt" />
-	</ItemGroup> -->
 
 	<ItemGroup>
 		<Content Include="Assets\SplashScreen.scale-200.png" />
@@ -76,7 +67,7 @@
 		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.3.0-preview.1.25114.11" />
 		<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4948" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental3" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-preview1" />
 		<PackageReference Include="OpenAI" Version="2.2.0-beta.2" />
 	</ItemGroup>
 	<ItemGroup>
@@ -119,30 +110,6 @@
 			<Generator>MSBuild:Compile</Generator>
 		</Page>
 	</ItemGroup>
-	<!-- <ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Compile Remove="C:\.tools\.nuget\packages\microsoft.windowsappsdk.packages\1.8.250515001-experimental2\buildTransitive\..\include\WindowsAppSDK-VersionInfo.cs" />
-	</ItemGroup> -->
 	<ItemGroup>
 	  <PRIResource Remove="Assets\Icon\**" />
 	</ItemGroup>

--- a/Samples/AppContentSearch/cs-winui/Notes.csproj
+++ b/Samples/AppContentSearch/cs-winui/Notes.csproj
@@ -61,7 +61,6 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
-		<PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.250402" />
 		<PackageReference Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
 		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.3.0-preview.1.25114.11" />

--- a/Samples/AppContentSearch/cs-winui/Package.appxmanifest
+++ b/Samples/AppContentSearch/cs-winui/Package.appxmanifest
@@ -5,19 +5,17 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
-  IgnorableNamespaces="uap rescap systemai">
-
+  IgnorableNamespaces="uap rescap systemai"
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10">
+  
   <Identity
-    Name="8e8c755b-914d-4f6c-89b6-95af1fc4fbaa"
-    Publisher="CN=nikol"
-    Version="1.0.1.0" />
-
-  <mp:PhoneIdentity PhoneProductId="8e8c755b-914d-4f6c-89b6-95af1fc4fbaa" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
+    Name="ai-powered-notes-winui3-sample"
+    Publisher="CN=AppContentSearchSample"
+    Version="1.0.0.0" />
 
   <Properties>
     <DisplayName>Notes</DisplayName>
-    <PublisherDisplayName>nikol</PublisherDisplayName>
+    <PublisherDisplayName>AppContentSearchSample</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
 

--- a/Samples/AppContentSearch/cs-winui/Pages/SettingsPage.xaml
+++ b/Samples/AppContentSearch/cs-winui/Pages/SettingsPage.xaml
@@ -2,8 +2,7 @@
     x:Class="Notes.Pages.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Notes.Pages"
-    xmlns:toolkit="using:CommunityToolkit.WinUI.Controls">
+    xmlns:local="using:Notes.Pages">
 
     <Page.Resources>
         <x:Double x:Key="SettingsCardSpacing">4</x:Double>
@@ -29,27 +28,35 @@
 
                     <!-- Language Model Settings Expander -->
                     <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Language Models" />
-                    <toolkit:SettingsExpander x:Name="ModelSourceExpander" Header="ModelSource">
-                        <ComboBox SelectionChanged="ModelSource_SelectionChanged">
-                            <ComboBoxItem x:Name="PhiSilicaComboBoxItem" Content="Windows AI APIs LanguageModel (Phi Silica)" IsSelected="True"/>
-                            <ComboBoxItem x:Name="AzureComboBoxItem" Content="Azure OpenAI"/>
-                            <ComboBoxItem x:Name="FoundryComboBoxItem" Content="Foundry Local"/>
-                        </ComboBox>
+                    <Expander x:Name="ModelSourceExpander" Header="Model Source">
+                        <StackPanel Padding="12,8,12,12" Spacing="12">
+                            <ComboBox SelectionChanged="ModelSource_SelectionChanged">
+                                <ComboBoxItem x:Name="PhiSilicaComboBoxItem" Content="Windows AI APIs LanguageModel (Phi Silica)" IsSelected="True"/>
+                                <ComboBoxItem x:Name="AzureComboBoxItem" Content="Azure OpenAI"/>
+                                <ComboBoxItem x:Name="FoundryComboBoxItem" Content="Foundry Local"/>
+                            </ComboBox>
 
-                        <toolkit:SettingsExpander.Items>
                             <!-- Azure Settings Card -->
-                            <toolkit:SettingsCard x:Name="AzureSettingsCard" Header="AzureSettings" Visibility="Collapsed" HorizontalContentAlignment="Left" ContentAlignment="Left">
-                                <StackPanel Margin="-42,-24,0,12" Spacing="8">
+                            <Border x:Name="AzureSettingsCard"
+                                    Padding="16"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Visibility="Collapsed">
+                                <StackPanel Spacing="8">
                                     <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Azure Settings" />
                                     <PasswordBox x:Name="AzureApiKeyPasswordBox" Header="API Key" PlaceholderText="Enter your API key" />
                                     <TextBox x:Name="AzureEndpointUriTextBox" Header="Endpoint URI" PlaceholderText="https://YOUR_RESOURCE_NAME.openai.azure.com/" />
                                     <TextBox x:Name="AzureDeploymentNameTextBox" Header="Model Deployment Name:" PlaceholderText="e.g. gpt-4o" />
                                 </StackPanel>
-                            </toolkit:SettingsCard>
+                            </Border>
 
                             <!-- Foundry Settings Card -->
-                            <toolkit:SettingsCard x:Name="FoundrySettingsCard" Visibility="Collapsed" HorizontalContentAlignment="Left" ContentAlignment="Left">
-                                <StackPanel Margin="-42,-24,0,12" Spacing="8">
+                            <Border x:Name="FoundrySettingsCard"
+                                    Padding="16"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Visibility="Collapsed">
+                                <StackPanel Spacing="8">
                                     <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Foundry Settings" />
                                     <ComboBox x:Name="FoundryModelComboBox" Header="AI Foundry Model" PlaceholderText="Select a model" Width="260"/>
 
@@ -84,20 +91,24 @@
                                         </ListView.ItemTemplate>
                                     </ListView>
                                 </StackPanel>
-                            </toolkit:SettingsCard>
-                        </toolkit:SettingsExpander.Items>
-                    </toolkit:SettingsExpander>
+                            </Border>
+                        </StackPanel>
+                    </Expander>
 
                     <!-- Image / Bounding Box Settings Expander -->
                     <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Image Overlays" />
-                    <toolkit:SettingsCard Header="Image Result Overlays" Description="Show bounding boxes on image search results">
-                        <StackPanel Padding="0" Spacing="12">
+                    <Border Padding="16"
+                            BorderThickness="1"
+                            CornerRadius="8">
+                        <StackPanel Spacing="12">
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Image Result Overlays" />
+                            <TextBlock Text="Show bounding boxes on image search results" TextWrapping="WrapWholeWords" />
                             <ToggleSwitch
                                  x:Name="ShowBoundingBoxesToggleSwitch"
                                  OffContent="Off"
-                                 OnContent="On"/>
+                                  OnContent="On"/>
                         </StackPanel>
-                    </toolkit:SettingsCard>
+                    </Border>
 
                     <Button x:Name="SaveButton" Content="Save" Margin="0,16,0,0" Click="SaveButton_Click" Width="120" Style="{StaticResource AccentButtonStyle}" HorizontalAlignment="Left" IsEnabled="False"/>
                 </StackPanel>

--- a/Samples/AppContentSearch/cs-winui/Pages/SettingsPage.xaml
+++ b/Samples/AppContentSearch/cs-winui/Pages/SettingsPage.xaml
@@ -27,10 +27,14 @@
                     <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="Settings" Margin="12,0,0,0"/>
 
                     <!-- Language Model Settings Expander -->
-                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Language Models" />
-                    <Expander x:Name="ModelSourceExpander" Header="Model Source">
+                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
+                               Text="Language Models"
+                               AutomationProperties.HeadingLevel="Level2" />
+                    <Expander x:Name="ModelSourceExpander" Header="Model Source"
+                              AutomationProperties.Name="Model Source">
                         <StackPanel Padding="12,8,12,12" Spacing="12">
-                            <ComboBox SelectionChanged="ModelSource_SelectionChanged">
+                            <ComboBox SelectionChanged="ModelSource_SelectionChanged"
+                                      AutomationProperties.Name="Model Source">
                                 <ComboBoxItem x:Name="PhiSilicaComboBoxItem" Content="Windows AI APIs LanguageModel (Phi Silica)" IsSelected="True"/>
                                 <ComboBoxItem x:Name="AzureComboBoxItem" Content="Azure OpenAI"/>
                                 <ComboBoxItem x:Name="FoundryComboBoxItem" Content="Foundry Local"/>
@@ -41,9 +45,12 @@
                                     Padding="16"
                                     BorderThickness="1"
                                     CornerRadius="8"
-                                    Visibility="Collapsed">
+                                    Visibility="Collapsed"
+                                    AutomationProperties.Name="Azure Settings">
                                 <StackPanel Spacing="8">
-                                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Azure Settings" />
+                                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
+                                               Text="Azure Settings"
+                                               AutomationProperties.HeadingLevel="Level3" />
                                     <PasswordBox x:Name="AzureApiKeyPasswordBox" Header="API Key" PlaceholderText="Enter your API key" />
                                     <TextBox x:Name="AzureEndpointUriTextBox" Header="Endpoint URI" PlaceholderText="https://YOUR_RESOURCE_NAME.openai.azure.com/" />
                                     <TextBox x:Name="AzureDeploymentNameTextBox" Header="Model Deployment Name:" PlaceholderText="e.g. gpt-4o" />
@@ -55,15 +62,19 @@
                                     Padding="16"
                                     BorderThickness="1"
                                     CornerRadius="8"
-                                    Visibility="Collapsed">
+                                    Visibility="Collapsed"
+                                    AutomationProperties.Name="Foundry Settings">
                                 <StackPanel Spacing="8">
-                                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Foundry Settings" />
+                                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
+                                               Text="Foundry Settings"
+                                               AutomationProperties.HeadingLevel="Level3" />
                                     <ComboBox x:Name="FoundryModelComboBox" Header="AI Foundry Model" PlaceholderText="Select a model" Width="260"/>
 
                                     <!-- Model Download Section -->
-                                    <TextBlock Text="Download Models:" Margin="0,16,0,0" />
+                                    <TextBlock Text="Download Models:" Margin="0,16,0,0" AutomationProperties.HeadingLevel="Level4" />
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <ComboBox x:Name="AvailableModelsComboBox" PlaceholderText="Select model to download" Width="260"/>
+                                        <ComboBox x:Name="AvailableModelsComboBox" PlaceholderText="Select model to download" Width="260"
+                                                  AutomationProperties.Name="Model to download" />
                                         <Button x:Name="DownloadModelButton" Content="Download" Click="DownloadModel_Click" IsEnabled="False"/>
                                         <Button x:Name="RefreshModelsButton" Content="Refresh" Click="RefreshModels_Click"/>
                                     </StackPanel>
@@ -75,8 +86,9 @@
                                     </StackPanel>
 
                                     <!-- Downloaded Models List -->
-                                    <TextBlock Text="Downloaded Models" Margin="0,16,0,0" />
-                                    <ListView x:Name="DownloadedModelsListView" MaxHeight="150" SelectionMode="None" HorizontalAlignment="Stretch">
+                                    <TextBlock Text="Downloaded Models" Margin="0,16,0,0" AutomationProperties.HeadingLevel="Level4" />
+                                    <ListView x:Name="DownloadedModelsListView" MaxHeight="150" SelectionMode="None" HorizontalAlignment="Stretch"
+                                              AutomationProperties.Name="Downloaded Models">
                                         <ListView.ItemTemplate>
                                             <DataTemplate>
                                                 <Grid>
@@ -96,15 +108,21 @@
                     </Expander>
 
                     <!-- Image / Bounding Box Settings Expander -->
-                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Image Overlays" />
+                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
+                               Text="Image Overlays"
+                               AutomationProperties.HeadingLevel="Level2" />
                     <Border Padding="16"
                             BorderThickness="1"
-                            CornerRadius="8">
+                            CornerRadius="8"
+                            AutomationProperties.Name="Image Result Overlays">
                         <StackPanel Spacing="12">
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Image Result Overlays" />
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}"
+                                       Text="Image Result Overlays"
+                                       AutomationProperties.HeadingLevel="Level3" />
                             <TextBlock Text="Show bounding boxes on image search results" TextWrapping="WrapWholeWords" />
                             <ToggleSwitch
                                  x:Name="ShowBoundingBoxesToggleSwitch"
+                                 AutomationProperties.Name="Show bounding boxes on image search results"
                                  OffContent="Off"
                                   OnContent="On"/>
                         </StackPanel>

--- a/Samples/AppContentSearch/cs-winui/Utils/AttachmentProcessor.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/AttachmentProcessor.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
-using Notes.Models;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Windows.Search.AppContentIndex;
+using Notes.Models;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.Storage.Streams;
@@ -14,7 +14,7 @@ namespace Notes
 {
     public static class AttachmentProcessor
     {
-        public static EventHandler<AttachmentProcessedEventArgs>? AttachmentProcessed;
+        internal static EventHandler<AttachmentProcessedEventArgs>? AttachmentProcessed;
 
         private readonly static List<Attachment> _toBeProcessed = new();
         private static bool _isProcessing = false;
@@ -46,7 +46,7 @@ namespace Notes
             {
                 await Task.Run(() =>
                 {
-                    MainWindow.AppContentIndexer.Remove(attachment.Id.ToString());
+                    MainWindow.AppContentIndexer.RemoveContentItem(attachment.Id.ToString());
                 });
                 Debug.WriteLine($"Deleted image from index: {attachment.Filename}");
             }

--- a/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
@@ -57,19 +57,15 @@ namespace Notes
 
         public static async Task<List<SearchResult>> SearchAsync(AppContentIndexer appContentIndexer, string searchText, int top = 5, CancellationToken cancellationToken = default)
         {
-            var results = new List<SearchResult>();
-
             if (string.IsNullOrWhiteSpace(searchText) || appContentIndexer == null)
             {
-                return results;
+                return new List<SearchResult>();
             }
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var context = await AppDataContext.GetCurrentAsync();
-
-            IEnumerable<AppIndexQueryMatch>? textMatches = null;
-            IEnumerable<AppIndexQueryMatch>? imageMatches = null;
+            IEnumerable<TextQueryMatch>? textMatches = null;
+            IEnumerable<ImageQueryMatch>? imageMatches = null;
             await Task.Run(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -79,6 +75,14 @@ namespace Notes
                 imageMatches = imageQuery.GetNextMatches(top);
             }, cancellationToken);
 
+            return await SearchMatchesAsync(textMatches, imageMatches, cancellationToken);
+        }
+
+        public static async Task<List<SearchResult>> SearchMatchesAsync(IEnumerable<TextQueryMatch>? textMatches, IEnumerable<ImageQueryMatch>? imageMatches, CancellationToken cancellationToken = default)
+        {
+            var results = new List<SearchResult>();
+            var context = await AppDataContext.GetCurrentAsync();
+
             cancellationToken.ThrowIfCancellationRequested();
 
             if (textMatches != null)
@@ -87,56 +91,10 @@ namespace Notes
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    if (match is AppManagedOcrTextQueryMatch ocrMatch)
+                    SearchResult? ocrResult = await TryCreateOcrSearchResultAsync(match, context, cancellationToken);
+                    if (ocrResult != null)
                     {
-                        if (!int.TryParse(match.ContentId, out int attachmentId))
-                        {
-                            Debug.WriteLine($"Skipping OCR match with non-integer content ID: {match.ContentId}");
-                            continue;
-                        }
-
-                        var attachment = await context.Attachments.FindAsync(attachmentId);
-                        if (attachment == null)
-                        {
-                            Debug.WriteLine($"Skipping OCR match; attachment not found for content ID: {attachmentId}");
-                            continue;
-                        }
-
-                        var note = await context.Notes.FindAsync(attachment.NoteId);
-                        if (note == null)
-                        {
-                            Debug.WriteLine($"Skipping OCR match; note not found for attachment ID: {attachmentId}");
-                            continue;
-                        }
-
-                        // OCR matches come from text extracted from indexed images via OCR.
-                        Debug.WriteLine($"OCR text match: contentId={ocrMatch.ContentId}, fragment='{ocrMatch.Fragment}', Subregion={ocrMatch.Subregion}");
-
-                        var attachmentsFolder = await GetAttachmentsFolderAsync();
-                        var searchResult = new SearchResult
-                        {
-                            Content = ocrMatch.Fragment,
-                            ContentType = ContentType.OcrText,
-                            ContentSubType = ContentSubType.None,
-                            SourceId = note.Id,
-                            Title = note.Title + " (OCR)",
-                            MostRelevantSentence = ocrMatch.Fragment,
-                            Path = attachmentsFolder.Path + "\\" + attachment.RelativePath
-                        };
-
-                        try
-                        {
-                            if (ocrMatch.Subregion != null)
-                            {
-                                searchResult.BoundingBox = ocrMatch.Subregion.Value;
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Debug.WriteLine("Failed to read OCR Subregion: " + ex.Message);
-                        }
-
-                        results.Add(searchResult);
+                        results.Add(ocrResult);
                         continue;
                     }
 
@@ -271,7 +229,70 @@ namespace Notes
             {
                 Debug.WriteLine("ImageMatches is null");
             }
+
             return results;
+        }
+
+        private static async Task<SearchResult?> TryCreateOcrSearchResultAsync(TextQueryMatch match, AppDataContext context, CancellationToken cancellationToken)
+        {
+            if (!string.Equals(match.GetType().Name, "AppManagedOcrTextQueryMatch", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!int.TryParse(match.ContentId, out int attachmentId))
+            {
+                Debug.WriteLine($"Skipping OCR match with non-integer content ID: {match.ContentId}");
+                return null;
+            }
+
+            var attachment = await context.Attachments.FindAsync(attachmentId);
+            if (attachment == null)
+            {
+                Debug.WriteLine($"Skipping OCR match; attachment not found for content ID: {attachmentId}");
+                return null;
+            }
+
+            var note = await context.Notes.FindAsync(attachment.NoteId);
+            if (note == null)
+            {
+                Debug.WriteLine($"Skipping OCR match; note not found for attachment ID: {attachmentId}");
+                return null;
+            }
+
+            string fragment = match.GetType().GetProperty("Fragment")?.GetValue(match) as string ?? string.Empty;
+            Rect? subregion = GetMatchSubregion(match);
+            Debug.WriteLine($"OCR text match: contentId={match.ContentId}, fragment='{fragment}', Subregion={subregion}");
+
+            var attachmentsFolder = await GetAttachmentsFolderAsync();
+            return new SearchResult
+            {
+                Content = fragment,
+                ContentType = ContentType.OcrText,
+                ContentSubType = ContentSubType.None,
+                SourceId = note.Id,
+                AttachmentId = attachment.Id,
+                Title = note.Title + " (OCR)",
+                MostRelevantSentence = fragment,
+                Path = attachmentsFolder.Path + "\\" + attachment.RelativePath,
+                BoundingBox = subregion
+            };
+        }
+
+        private static Rect? GetMatchSubregion(TextQueryMatch match)
+        {
+            try
+            {
+                object? subregion = match.GetType().GetProperty("Subregion")?.GetValue(match);
+                return subregion is Rect rect ? rect : null;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("Failed to read OCR Subregion: " + ex.Message);
+                return null;
+            }
         }
     }
 
@@ -283,6 +304,7 @@ namespace Notes
         public string? MostRelevantSentence { get; set; }
         public string? Path { get; set; }
         public int SourceId { get; set; }
+        public int? AttachmentId { get; set; }
         public ContentType ContentType { get; set; }
         public ContentSubType ContentSubType { get; set; }
         public Rect? BoundingBox { get; set; }

--- a/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
@@ -201,7 +201,12 @@ namespace Notes
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    int matchContentId = int.Parse(match.ContentId);
+                    if (!int.TryParse(match.ContentId, out int matchContentId))
+                    {
+                        Debug.WriteLine($"Skipping image match with non-integer content ID: {match.ContentId}");
+                        continue;
+                    }
+
                     var image = await context.Attachments.FindAsync(matchContentId);
 
                     if (image != null)

--- a/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
@@ -1,12 +1,12 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
-using Notes.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Windows.Search.AppContentIndex;
+using Notes.ViewModels;
 using Windows.Foundation;
 using Windows.Storage;
 
@@ -149,7 +149,7 @@ namespace Notes
                         AppManagedImageQueryMatch? imageMatch = match as AppManagedImageQueryMatch;
                         if (imageMatch != null)
                         {
-                            Debug.WriteLine($"Image match: {imageMatch.ContentId}, Subregion: {imageMatch.Subregion}");
+                            Debug.WriteLine($"Image match: {imageMatch.ContentId}, Region of interest: {imageMatch.RegionOfInterest}");
                             var searchResult = new SearchResult
                             {
                                 ContentType = ContentType.Image,
@@ -184,18 +184,18 @@ namespace Notes
                             var attachmentsFolder = await GetAttachmentsFolderAsync();
                             searchResult.Path = attachmentsFolder.Path + "\\" + image.RelativePath;
 
-                            // Capture bounding box if present (Subregion is IReference<Rect>)
+                            // Capture bounding box if present (Region of interest is IReference<Rect>)
                             try
                             {
-                                if (imageMatch.Subregion != null)
+                                if (imageMatch.RegionOfInterest != null)
                                 {
-                                    var rect = imageMatch.Subregion.Value;
+                                    var rect = imageMatch.RegionOfInterest.Value;
                                     searchResult.BoundingBox = rect;
                                 }
                             }
                             catch (Exception ex)
                             {
-                                Debug.WriteLine("Failed to read image Subregion: " + ex.Message);
+                                Debug.WriteLine("Failed to read image Region of interest: " + ex.Message);
                             }
                             results.Add(searchResult);
                         }

--- a/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Windows.Search.AppContentIndex;
@@ -94,8 +95,43 @@ namespace Notes
                         Debug.WriteLine($"Text match: {note.Filename}");
 
                         AppManagedTextQueryMatch? textMatch = match as AppManagedTextQueryMatch;
+                        AppManagedOcrTextQueryMatch? ocrMatch = match as AppManagedOcrTextQueryMatch;
 
-                        if (textMatch != null)
+                        if (ocrMatch != null)
+                        {
+                            // OCR matches come from text extracted from indexed images via OCR.
+                            Debug.WriteLine($"OCR text match: fragment='{ocrMatch.Fragment}', Subregion={ocrMatch.Subregion}");
+
+                            var attachmentsFolder = await GetAttachmentsFolderAsync();
+
+                            // Find the attachment whose image produced the OCR match
+                            var attachment = context.Attachments.Where(a => a.NoteId == note.Id).FirstOrDefault();
+                            var searchResult = new SearchResult
+                            {
+                                Content = ocrMatch.Fragment,
+                                ContentType = ContentType.OcrText,
+                                ContentSubType = ContentSubType.None,
+                                SourceId = note.Id,
+                                Title = note.Title + " (OCR)",
+                                MostRelevantSentence = ocrMatch.Fragment,
+                                Path = attachmentsFolder.Path + "\\" + (attachment?.RelativePath ?? note.Filename)
+                            };
+
+                            try
+                            {
+                                if (ocrMatch.Subregion != null)
+                                {
+                                    searchResult.BoundingBox = ocrMatch.Subregion.Value;
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.WriteLine("Failed to read OCR Subregion: " + ex.Message);
+                            }
+
+                            results.Add(searchResult);
+                        }
+                        else if (textMatch != null)
                         {
                             string matchingData = await NoteViewModel.LoadTextContentByIdAsync(note.Filename);
 
@@ -231,6 +267,7 @@ namespace Notes
                 ContentType.Audio => "🎙️",
                 ContentType.Video => "🎞️",
                 ContentType.Document => "📄",
+                ContentType.OcrText => "🔍",
                 _ => throw new NotImplementedException()
             };
         }
@@ -256,6 +293,7 @@ namespace Notes
         Video = 2,
         Document = 3,
         Note = 4,
+        OcrText = 5,
     }
 
     public enum ContentSubType

--- a/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
@@ -262,6 +262,13 @@ namespace Notes
                 return null;
             }
 
+            // TODO: Replace these reflection-based accesses with direct property access
+            // (e.g. `(match as AppManagedOcrTextQueryMatch).Fragment`) once the
+            // AppManagedOcrTextQueryMatch type and its Fragment / Subregion properties are
+            // projected by the Microsoft.Windows.Search.AppContentIndex SDK. Reflection is
+            // used here only as a temporary workaround for the current preview SDK and is
+            // NOT a recommended pattern for production code: if the API renames either
+            // property in a future preview this would silently return null/empty.
             string fragment = match.GetType().GetProperty("Fragment")?.GetValue(match) as string ?? string.Empty;
             Rect? subregion = GetMatchSubregion(match);
             Debug.WriteLine($"OCR text match: contentId={match.ContentId}, fragment='{fragment}', Subregion={subregion}");
@@ -285,6 +292,9 @@ namespace Notes
         {
             try
             {
+                // TODO: Same temporary workaround as the `Fragment` access above —
+                // replace with direct property access once `Subregion` is projected
+                // by the SDK.
                 object? subregion = match.GetType().GetProperty("Subregion")?.GetValue(match);
                 return subregion is Rect rect ? rect : null;
             }

--- a/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
@@ -87,81 +87,105 @@ namespace Notes
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    int matchcontentId = int.Parse(match.ContentId);
-                    var note = await context.Notes.FindAsync(matchcontentId);
-
-                    if (note != null && note.Filename != null)
+                    if (match is AppManagedOcrTextQueryMatch ocrMatch)
                     {
+                        if (!int.TryParse(match.ContentId, out int attachmentId))
+                        {
+                            Debug.WriteLine($"Skipping OCR match with non-integer content ID: {match.ContentId}");
+                            continue;
+                        }
+
+                        var attachment = await context.Attachments.FindAsync(attachmentId);
+                        if (attachment == null)
+                        {
+                            Debug.WriteLine($"Skipping OCR match; attachment not found for content ID: {attachmentId}");
+                            continue;
+                        }
+
+                        var note = await context.Notes.FindAsync(attachment.NoteId);
+                        if (note == null)
+                        {
+                            Debug.WriteLine($"Skipping OCR match; note not found for attachment ID: {attachmentId}");
+                            continue;
+                        }
+
+                        // OCR matches come from text extracted from indexed images via OCR.
+                        Debug.WriteLine($"OCR text match: contentId={ocrMatch.ContentId}, fragment='{ocrMatch.Fragment}', Subregion={ocrMatch.Subregion}");
+
+                        var attachmentsFolder = await GetAttachmentsFolderAsync();
+                        var searchResult = new SearchResult
+                        {
+                            Content = ocrMatch.Fragment,
+                            ContentType = ContentType.OcrText,
+                            ContentSubType = ContentSubType.None,
+                            SourceId = note.Id,
+                            Title = note.Title + " (OCR)",
+                            MostRelevantSentence = ocrMatch.Fragment,
+                            Path = attachmentsFolder.Path + "\\" + attachment.RelativePath
+                        };
+
+                        try
+                        {
+                            if (ocrMatch.Subregion != null)
+                            {
+                                searchResult.BoundingBox = ocrMatch.Subregion.Value;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.WriteLine("Failed to read OCR Subregion: " + ex.Message);
+                        }
+
+                        results.Add(searchResult);
+                        continue;
+                    }
+
+                    if (match is AppManagedTextQueryMatch textMatch)
+                    {
+                        if (!int.TryParse(match.ContentId, out int noteId))
+                        {
+                            Debug.WriteLine($"Skipping text match with non-integer content ID: {match.ContentId}");
+                            continue;
+                        }
+
+                        var note = await context.Notes.FindAsync(noteId);
+                        if (note == null || note.Filename == null)
+                        {
+                            continue;
+                        }
+
                         Debug.WriteLine($"Text match: {note.Filename}");
 
-                        AppManagedTextQueryMatch? textMatch = match as AppManagedTextQueryMatch;
-                        AppManagedOcrTextQueryMatch? ocrMatch = match as AppManagedOcrTextQueryMatch;
+                        string matchingData = await NoteViewModel.LoadTextContentByIdAsync(note.Filename);
 
-                        if (ocrMatch != null)
+                        int textOffset = Math.Max(0, Math.Min(textMatch.TextOffset, matchingData.Length));
+                        int remainingLength = matchingData.Length - textOffset;
+
+                        if (remainingLength <= 0)
                         {
-                            // OCR matches come from text extracted from indexed images via OCR.
-                            Debug.WriteLine($"OCR text match: fragment='{ocrMatch.Fragment}', Subregion={ocrMatch.Subregion}");
-
-                            var attachmentsFolder = await GetAttachmentsFolderAsync();
-
-                            // Find the attachment whose image produced the OCR match
-                            var attachment = context.Attachments.Where(a => a.NoteId == note.Id).FirstOrDefault();
-                            var searchResult = new SearchResult
-                            {
-                                Content = ocrMatch.Fragment,
-                                ContentType = ContentType.OcrText,
-                                ContentSubType = ContentSubType.None,
-                                SourceId = note.Id,
-                                Title = note.Title + " (OCR)",
-                                MostRelevantSentence = ocrMatch.Fragment,
-                                Path = attachmentsFolder.Path + "\\" + (attachment?.RelativePath ?? note.Filename)
-                            };
-
-                            try
-                            {
-                                if (ocrMatch.Subregion != null)
-                                {
-                                    searchResult.BoundingBox = ocrMatch.Subregion.Value;
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                Debug.WriteLine("Failed to read OCR Subregion: " + ex.Message);
-                            }
-
-                            results.Add(searchResult);
+                            Debug.WriteLine($"Skipping match with invalid TextOffset: {textMatch.TextOffset} for content length: {matchingData.Length}");
+                            continue;
                         }
-                        else if (textMatch != null)
+
+                        int substringLength = Math.Min(500, remainingLength);
+                        string matchingString = matchingData.Substring(textOffset, substringLength);
+                        var notesFolder = await GetLocalFolderAsync();
+                        var textResult = new SearchResult
                         {
-                            string matchingData = await NoteViewModel.LoadTextContentByIdAsync(note.Filename);
+                            Content = matchingString,
+                            ContentType = ContentType.Note,
+                            ContentSubType = ContentSubType.None,
+                            SourceId = note.Id,
+                            Title = note.Title,
+                            MostRelevantSentence = matchingString,
+                            Path = notesFolder.Path + "\\" + note.Filename
+                        };
 
-                            int textOffset = Math.Max(0, Math.Min(textMatch.TextOffset, matchingData.Length));
-                            int remainingLength = matchingData.Length - textOffset;
-
-                            if (remainingLength > 0)
-                            {
-                                int substringLength = Math.Min(500, remainingLength);
-                                string matchingString = matchingData.Substring(textOffset, substringLength);
-                                var attachmentsFolder = await GetAttachmentsFolderAsync();
-                                var searchResult = new SearchResult
-                                {
-                                    Content = matchingString,
-                                    ContentType = ContentType.Note,
-                                    ContentSubType = ContentSubType.None,
-                                    SourceId = note.Id,
-                                    Title = note.Title,
-                                    MostRelevantSentence = matchingString,
-                                    Path = attachmentsFolder.Path + "\\" + note.Filename
-                                };
-
-                                results.Add(searchResult);
-                            }
-                            else
-                            {
-                                Debug.WriteLine($"Skipping match with invalid TextOffset: {textMatch.TextOffset} for content length: {matchingData.Length}");
-                            }
-                        }
+                        results.Add(textResult);
+                        continue;
                     }
+
+                    Debug.WriteLine($"Skipping unsupported text match type: {match.GetType().Name}");
                 }
             }
             else

--- a/Samples/AppContentSearch/cs-winui/ViewModels/NoteViewModel.cs
+++ b/Samples/AppContentSearch/cs-winui/ViewModels/NoteViewModel.cs
@@ -1,15 +1,15 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
-using CommunityToolkit.Mvvm.ComponentModel;
-using Microsoft.UI.Dispatching;
-using Microsoft.UI.Xaml;
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
-using Notes.Models;
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.Windows.Search.AppContentIndex;
+using Notes.Models;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
 
@@ -220,7 +220,7 @@ namespace Notes.ViewModels
             {
                 await Task.Run(() =>
                 {
-                    MainWindow.AppContentIndexer.Remove(Note.Id.ToString());
+                    MainWindow.AppContentIndexer.RemoveContentItem(Note.Id.ToString());
                 });
                 Debug.WriteLine($"Deleted note from index: {Note.Filename}");
             }
@@ -247,7 +247,7 @@ namespace Notes.ViewModels
             {
                 await Task.Run(() =>
                 {
-                    MainWindow.AppContentIndexer.RemoveAll();
+                    MainWindow.AppContentIndexer.RemoveAllContentItems();
                 });
                 Debug.WriteLine($"Deleted Index");
             }
@@ -327,7 +327,7 @@ namespace Notes.ViewModels
 
                 await Task.Run(() =>
                 {
-                    MainWindow.AppContentIndexer.Remove(Note.Id.ToString());
+                    MainWindow.AppContentIndexer.RemoveContentItem(Note.Id.ToString());
                 });
                 Debug.WriteLine($"Deleted note {Note.Title}");
 

--- a/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
+++ b/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -13,6 +15,8 @@ namespace Notes.ViewModels
 {
     public partial class SearchViewModel : ObservableObject, IDisposable
     {
+        private const int MaxVisibleMatches = 5;
+
         [ObservableProperty]
         public bool showResults = false;
 
@@ -34,27 +38,50 @@ namespace Notes.ViewModels
 
         private string _searchText = string.Empty;
         private CancellationTokenSource? _currentSearchCancellation;
+        private AppIndexTextQuerySession? _textQuerySession;
+        private AppIndexImageQuerySession? _imageQuerySession;
+        private DispatcherQueue? _dispatcherQueue;
+        private bool _isDisposed;
 
         public SearchViewModel()
         {
         }
-        public async void HandleQuerySubmitted(string text)
+
+        public void HandleQuerySubmitted(string text)
         {
             _searchText = text;
-            await Search();
+            StartSearch();
         }
 
-        public async void HandleTextChanged(string text)
+        public void HandleTextChanged(string text)
         {
             _searchText = text;
-            await Search();
+            StartSearch();
         }
 
         public void InitializeQuerySessions(AppContentIndexer appContentIndexer, DispatcherQueue dispatcherQueue)
         {
-            // Search-as-you-type currently uses cancellation-based one-shot queries.
-            _ = appContentIndexer;
-            _ = dispatcherQueue;
+            if (_isDisposed || _textQuerySession != null || _imageQuerySession != null)
+            {
+                return;
+            }
+
+            _dispatcherQueue = dispatcherQueue;
+
+            _textQuerySession = appContentIndexer.CreateTextQuerySession();
+            _textQuerySession.DesiredMatchesPerResult = MaxVisibleMatches;
+            _textQuerySession.ResultChanged += TextQuerySession_ResultChanged;
+            _textQuerySession.Start();
+
+            _imageQuerySession = appContentIndexer.CreateImageQuerySession();
+            _imageQuerySession.DesiredMatchesPerResult = MaxVisibleMatches;
+            _imageQuerySession.ResultChanged += ImageQuerySession_ResultChanged;
+            _imageQuerySession.Start();
+
+            if (!string.IsNullOrWhiteSpace(_searchText))
+            {
+                UpdateQuerySessions(_searchText);
+            }
         }
 
         public void Reset()
@@ -69,22 +96,60 @@ namespace Notes.ViewModels
             ShowOcrResults = false;
         }
 
-        private async Task Search()
+        private void StartSearch()
         {
-            Debug.WriteLine("searching");
+            if (_isDisposed)
+            {
+                return;
+            }
 
-            // Cancel any existing search
+            if (_textQuerySession != null && _imageQuerySession != null)
+            {
+                UpdateQuerySessions(_searchText);
+                return;
+            }
+
+            _ = SearchAsync();
+        }
+
+        private void UpdateQuerySessions(string text)
+        {
+            CancelCurrentSearch();
+            Reset();
+
+            if (_textQuerySession is null || _imageQuerySession is null)
+            {
+                return;
+            }
+
+            _textQuerySession.UpdateQueryPhrase(text ?? string.Empty);
+            _imageQuerySession.UpdateQueryPhrase(text ?? string.Empty);
+        }
+
+        private CancellationToken BeginCurrentSearch()
+        {
+            CancelCurrentSearch();
+            _currentSearchCancellation = new CancellationTokenSource();
+            return _currentSearchCancellation.Token;
+        }
+
+        private void CancelCurrentSearch()
+        {
             _currentSearchCancellation?.Cancel();
             _currentSearchCancellation?.Dispose();
+            _currentSearchCancellation = null;
+        }
 
-            // Create new cancellation token for this search
-            _currentSearchCancellation = new CancellationTokenSource();
-            var cancellationToken = _currentSearchCancellation.Token;
+        private async Task SearchAsync()
+        {
+            Debug.WriteLine("searching");
+            string searchText = _searchText;
+            CancellationToken cancellationToken = BeginCurrentSearch();
 
             try
             {
                 Reset();
-                if (string.IsNullOrWhiteSpace(_searchText))
+                if (string.IsNullOrWhiteSpace(searchText))
                 {
                     return;
                 }
@@ -95,52 +160,21 @@ namespace Notes.ViewModels
                     return;
                 }
 
-                var results = await Utils.SearchAsync(MainWindow.AppContentIndexer, _searchText, cancellationToken: cancellationToken);
+                var results = await Utils.SearchAsync(
+                    MainWindow.AppContentIndexer,
+                    searchText,
+                    top: MaxVisibleMatches,
+                    cancellationToken: cancellationToken);
 
                 // Check if we were cancelled before updating UI
-                if (cancellationToken.IsCancellationRequested)
+                if (cancellationToken.IsCancellationRequested ||
+                    !string.Equals(searchText, _searchText, StringComparison.Ordinal))
                 {
                     Debug.WriteLine("Search was cancelled, not updating results");
                     return;
                 }
 
-                foreach (var result in results)
-                {
-                    if (result.ContentType == ContentType.Image)
-                    {
-                        ImageResults.Add(result);
-                    }
-                    else if (result.ContentType == ContentType.Note)
-                    {
-                        TextResults.Add(result);
-                    }
-                    else if (result.ContentType == ContentType.OcrText)
-                    {
-                        OcrResults.Add(result);
-                    }
-                }
-
-                if (ImageResults.Count > 0)
-                {
-                    ShowImageResults = true;
-                }
-
-                if (TextResults.Count > 0)
-                {
-                    ShowTextResults = true;
-                }
-
-                if (OcrResults.Count > 0)
-                {
-                    ShowOcrResults = true;
-                }
-
-                if (!ShowImageResults && !ShowTextResults && !ShowOcrResults)
-                {
-                    ShowNoResults = true;
-                }
-
-                ShowResults = true;
+                ApplySearchResults(results, showNoResultsWhenEmpty: true);
             }
             catch (OperationCanceledException)
             {
@@ -154,11 +188,144 @@ namespace Notes.ViewModels
             }
         }
 
+        private void TextQuerySession_ResultChanged(AppIndexTextQuerySession sender, object args)
+        {
+            _ = RefreshQuerySessionResultsAsync();
+        }
+
+        private void ImageQuerySession_ResultChanged(AppIndexImageQuerySession sender, object args)
+        {
+            _ = RefreshQuerySessionResultsAsync();
+        }
+
+        private async Task RefreshQuerySessionResultsAsync()
+        {
+            if (_isDisposed || _dispatcherQueue is null || _textQuerySession is null || _imageQuerySession is null)
+            {
+                return;
+            }
+
+            string searchText = _searchText;
+            if (string.IsNullOrWhiteSpace(searchText))
+            {
+                return;
+            }
+
+            try
+            {
+                List<TextQueryMatch>? textMatches = null;
+                List<ImageQueryMatch>? imageMatches = null;
+
+                TextQuerySessionResult textResult = _textQuerySession.GetResult();
+                bool hasValidTextResult =
+                    textResult.IsValid &&
+                    string.Equals(textResult.QueryPhrase, searchText, StringComparison.Ordinal);
+                if (hasValidTextResult)
+                {
+                    textMatches = textResult.Matches.Take(MaxVisibleMatches).ToList();
+                }
+
+                ImageQuerySessionResult imageResult = _imageQuerySession.GetResult();
+                bool hasValidImageResult =
+                    imageResult.IsValid &&
+                    string.Equals(imageResult.QueryPhrase, searchText, StringComparison.Ordinal);
+                if (hasValidImageResult)
+                {
+                    imageMatches = imageResult.Matches.Take(MaxVisibleMatches).ToList();
+                }
+
+                if (!hasValidTextResult && !hasValidImageResult)
+                {
+                    return;
+                }
+
+                CancellationToken cancellationToken = BeginCurrentSearch();
+                var results = await Utils.SearchMatchesAsync(textMatches, imageMatches, cancellationToken);
+
+                if (_isDisposed ||
+                    cancellationToken.IsCancellationRequested ||
+                    !string.Equals(searchText, _searchText, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                bool showNoResultsWhenEmpty = hasValidTextResult && hasValidImageResult;
+                _dispatcherQueue.TryEnqueue(() =>
+                {
+                    if (_isDisposed ||
+                        cancellationToken.IsCancellationRequested ||
+                        !string.Equals(searchText, _searchText, StringComparison.Ordinal))
+                    {
+                        return;
+                    }
+
+                    ApplySearchResults(results, showNoResultsWhenEmpty);
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                Debug.WriteLine("Interactive search update was cancelled");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Interactive search failed: {ex.Message}");
+            }
+        }
+
+        private void ApplySearchResults(IEnumerable<SearchResult> results, bool showNoResultsWhenEmpty)
+        {
+            Reset();
+
+            foreach (var result in results)
+            {
+                if (result.ContentType == ContentType.Image)
+                {
+                    ImageResults.Add(result);
+                }
+                else if (result.ContentType == ContentType.Note)
+                {
+                    TextResults.Add(result);
+                }
+                else if (result.ContentType == ContentType.OcrText)
+                {
+                    OcrResults.Add(result);
+                }
+            }
+
+            ShowImageResults = ImageResults.Count > 0;
+            ShowTextResults = TextResults.Count > 0;
+            ShowOcrResults = OcrResults.Count > 0;
+
+            bool hasResults = ShowImageResults || ShowTextResults || ShowOcrResults;
+            ShowNoResults = !hasResults && showNoResultsWhenEmpty;
+            ShowResults = hasResults || ShowNoResults;
+        }
+
         public void Dispose()
         {
-            _currentSearchCancellation?.Cancel();
-            _currentSearchCancellation?.Dispose();
-            _currentSearchCancellation = null;
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            CancelCurrentSearch();
+
+            if (_textQuerySession != null)
+            {
+                _textQuerySession.ResultChanged -= TextQuerySession_ResultChanged;
+                _textQuerySession.Dispose();
+                _textQuerySession = null;
+            }
+
+            if (_imageQuerySession != null)
+            {
+                _imageQuerySession.ResultChanged -= ImageQuerySession_ResultChanged;
+                _imageQuerySession.Dispose();
+                _imageQuerySession = null;
+            }
+
+            _dispatcherQueue = null;
         }
     }
 }

--- a/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
+++ b/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
@@ -1,16 +1,15 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
-using CommunityToolkit.Mvvm.ComponentModel;
-using Microsoft.UI.Xaml;
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Notes.ViewModels
 {
-    public partial class SearchViewModel : ObservableObject
+    public partial class SearchViewModel : ObservableObject, IDisposable
     {
         [ObservableProperty]
         public bool showResults = false;
@@ -27,7 +26,7 @@ namespace Notes.ViewModels
         public ObservableCollection<SearchResult> ImageResults { get; set; } = new();
 
         private string _searchText = string.Empty;
-        private CancellationTokenSource? _currentSearchCancellation;
+        private CancellationTokenSource? currentSearchCancellation;
 
         public SearchViewModel()
         {
@@ -51,15 +50,15 @@ namespace Notes.ViewModels
         private async Task Search()
         {
             Debug.WriteLine("searching");
-            
+
             // Cancel any existing search
-            _currentSearchCancellation?.Cancel();
-            _currentSearchCancellation?.Dispose();
-            
+            currentSearchCancellation?.Cancel();
+            currentSearchCancellation?.Dispose();
+
             // Create new cancellation token for this search
-            _currentSearchCancellation = new CancellationTokenSource();
-            var cancellationToken = _currentSearchCancellation.Token;
-            
+            currentSearchCancellation = new CancellationTokenSource();
+            var cancellationToken = currentSearchCancellation.Token;
+
             try
             {
                 Reset();
@@ -122,6 +121,13 @@ namespace Notes.ViewModels
                 Debug.WriteLine($"Search failed: {ex.Message}");
                 // Handle other exceptions as needed
             }
+        }
+
+        public void Dispose()
+        {
+            currentSearchCancellation?.Cancel();
+            currentSearchCancellation?.Dispose();
+            currentSearchCancellation = null;
         }
     }
 }

--- a/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
+++ b/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
@@ -190,12 +190,29 @@ namespace Notes.ViewModels
 
         private void TextQuerySession_ResultChanged(AppIndexTextQuerySession sender, object args)
         {
-            _ = RefreshQuerySessionResultsAsync();
+            _ = SafeRefreshQuerySessionResultsAsync();
         }
 
         private void ImageQuerySession_ResultChanged(AppIndexImageQuerySession sender, object args)
         {
-            _ = RefreshQuerySessionResultsAsync();
+            _ = SafeRefreshQuerySessionResultsAsync();
+        }
+
+        // Observes both synchronous and asynchronous failures from
+        // RefreshQuerySessionResultsAsync. The ResultChanged event handlers can't await the
+        // refresh, and a bare `_ = RefreshQuerySessionResultsAsync()` would swallow any
+        // exception thrown by the query session (e.g. after disposal or on an unsupported
+        // system), causing search to silently stop working.
+        private async Task SafeRefreshQuerySessionResultsAsync()
+        {
+            try
+            {
+                await RefreshQuerySessionResultsAsync();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Query session refresh failed: {ex.Message}");
+            }
         }
 
         private async Task RefreshQuerySessionResultsAsync()

--- a/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
+++ b/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
@@ -33,7 +33,7 @@ namespace Notes.ViewModels
         public ObservableCollection<SearchResult> OcrResults { get; set; } = new();
 
         private string _searchText = string.Empty;
-        private CancellationTokenSource? currentSearchCancellation;
+        private CancellationTokenSource? _currentSearchCancellation;
 
         public SearchViewModel()
         {
@@ -74,12 +74,12 @@ namespace Notes.ViewModels
             Debug.WriteLine("searching");
 
             // Cancel any existing search
-            currentSearchCancellation?.Cancel();
-            currentSearchCancellation?.Dispose();
+            _currentSearchCancellation?.Cancel();
+            _currentSearchCancellation?.Dispose();
 
             // Create new cancellation token for this search
-            currentSearchCancellation = new CancellationTokenSource();
-            var cancellationToken = currentSearchCancellation.Token;
+            _currentSearchCancellation = new CancellationTokenSource();
+            var cancellationToken = _currentSearchCancellation.Token;
 
             try
             {
@@ -156,9 +156,9 @@ namespace Notes.ViewModels
 
         public void Dispose()
         {
-            currentSearchCancellation?.Cancel();
-            currentSearchCancellation?.Dispose();
-            currentSearchCancellation = null;
+            _currentSearchCancellation?.Cancel();
+            _currentSearchCancellation?.Dispose();
+            _currentSearchCancellation = null;
         }
     }
 }

--- a/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
+++ b/Samples/AppContentSearch/cs-winui/ViewModels/SearchViewModel.cs
@@ -6,6 +6,8 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.UI.Dispatching;
+using Microsoft.Windows.Search.AppContentIndex;
 
 namespace Notes.ViewModels
 {
@@ -22,8 +24,13 @@ namespace Notes.ViewModels
 
         [ObservableProperty]
         public bool showTextResults = false;
+
+        [ObservableProperty]
+        public bool showOcrResults = false;
+
         public ObservableCollection<SearchResult> TextResults { get; set; } = new();
         public ObservableCollection<SearchResult> ImageResults { get; set; } = new();
+        public ObservableCollection<SearchResult> OcrResults { get; set; } = new();
 
         private string _searchText = string.Empty;
         private CancellationTokenSource? currentSearchCancellation;
@@ -37,14 +44,29 @@ namespace Notes.ViewModels
             await Search();
         }
 
+        public async void HandleTextChanged(string text)
+        {
+            _searchText = text;
+            await Search();
+        }
+
+        public void InitializeQuerySessions(AppContentIndexer appContentIndexer, DispatcherQueue dispatcherQueue)
+        {
+            // Search-as-you-type currently uses cancellation-based one-shot queries.
+            _ = appContentIndexer;
+            _ = dispatcherQueue;
+        }
+
         public void Reset()
         {
             TextResults.Clear();
             ImageResults.Clear();
+            OcrResults.Clear();
             ShowResults = false;
             ShowNoResults = false;
             ShowImageResults = false;
             ShowTextResults = false;
+            ShowOcrResults = false;
         }
 
         private async Task Search()
@@ -92,6 +114,10 @@ namespace Notes.ViewModels
                     {
                         TextResults.Add(result);
                     }
+                    else if (result.ContentType == ContentType.OcrText)
+                    {
+                        OcrResults.Add(result);
+                    }
                 }
 
                 if (ImageResults.Count > 0)
@@ -104,7 +130,12 @@ namespace Notes.ViewModels
                     ShowTextResults = true;
                 }
 
-                if (!ShowImageResults && !ShowTextResults)
+                if (OcrResults.Count > 0)
+                {
+                    ShowOcrResults = true;
+                }
+
+                if (!ShowImageResults && !ShowTextResults && !ShowOcrResults)
                 {
                     ShowNoResults = true;
                 }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->


 ## Summary

## Update NotesApp sample to WinAppSDK 2.0.0-preview1 ACI API surface

   ### Namespace & API renames
 - Update namespace from `Microsoft.Windows.AI.Search.Experimental.AppContentIndex` to `Microsoft.Windows.Search.AppContentIndex`
 - Rename `Remove` → `RemoveContentItem`, `RemoveAll` → `RemoveAllContentItems`
 - Use `RegionOfInterest` (on `AppManagedImageQueryMatch`) instead of `Subregion` (which remains on `AppManagedOcrTextQueryMatch` for OCR matches)
 
 ### New API usage
 - Add pre-flight system capability checks via `GetIndexCapabilitiesOfCurrentSystem()` before creating an index
 - Subscribe to `AppContentIndexListener` events (`IndexCapabilitiesChanged`, `IndexStatisticsChanged`, `ContentItemStatusChanged`) for live index monitoring
 - Drive search UI progress bar from `IndexStatisticsChanged` events
 - Log index statistics via `GetIndexStatistics()` on startup
 
 ### Resource management & robustness
 - Dispose `AppContentIndexer` in `MainWindow.Closed` handler
 - Add `IDisposable` to `SearchViewModel`; call `Dispose()` via `SearchView.Unloaded` to release `CancellationTokenSource`
 - Replace `int.Parse` with `int.TryParse` for image match `ContentId` to avoid `FormatException`
 - Replace `throw new Exception` with `throw new InvalidOperationException`
 
 ### Cleanup
 - Update WinAppSDK from 2.0.0-experimental3 to 2.0.0-preview1
 - Remove stale commented-out internal project references from csproj
 - Fix README: correct solution filename, update SDK version reference
 - Clean up `Package.appxmanifest` identity for public sample

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
