### PR TITLE
Update README with retirement notice for Release/Experimental branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 </p>
 
 <h1 align="center">Windows App SDK samples</h1>
-
+<h1>This Release/Experimental branch that you are looking at is transitioning into retirement in the WinAppSDK 2.0 time frame. To experience experimental APIs, please refer to the Release/x.y-experimental branches. This Release/Experimental branch will no longer be actively maintained, in favor of the per-release experimental branches. </h1>
+<h1>BACKGROUND: Before WinAppSDK adopts SemVer in 2.0, 1.x versions of WinAppSDK maintained a high degree of backwards compatibility; therefore, sample apps generally do not need to be strongly versioned against a particular WinAppSDK version. That practice is no longer applicable for 2.0+, which does not guarantee backward compatibility with 1.x versions. Therefore, this no-clear-version-targetting branch Release/Experimental is no longer suitable for housing new WinAppSDK 2.0+ sample apps that contain experimental APIs.</h1>
 
 This repository hosts samples for the [Windows App SDK](https://github.com/microsoft/WindowsAppSDK). Samples for various features shipping in the Windows App SDK will be added to this repository. For more information about the Windows App SDK, visit the [Windows App SDK documentation](https://docs.microsoft.com/windows/apps/windows-app-sdk/). To learn more about the Windows App SDK design or to contribute to the project, make feature proposals, or start discussions, visit the [Windows App SDK GitHub page](https://github.com/microsoft/WindowsAppSDK).
 


### PR DESCRIPTION
Added notes about the retirement of the Release/Experimental branch and changes in versioning for WinAppSDK 2.0.

<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Please include a summary of the change and/or which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Target Release

Please specify which release this PR should align with. e.g., 1.0, 1.1, 1.1 Preview 1.

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
