### PR TITLE
Disable VS sideloading telemetry DLLs to fix BinSkim BA2022

### DIFF
--- a/Samples/Directory.Build.props
+++ b/Samples/Directory.Build.props
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Prevent VS from binplacing telemetry DLLs that fail BinSkim BA2022 (SignSecurely) -->
+  <PropertyGroup>
+    <AppxLogTelemetryFromSideloadingScript>false</AppxLogTelemetryFromSideloadingScript>
+  </PropertyGroup>
+
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>%(AdditionalOptions) /Qspectre</AdditionalOptions>


### PR DESCRIPTION
Setting `AppxLogTelemetryFromSideloadingScript` to `false` prevents VS's MSBuild AppxPackage targets (`_AddWindowsInstallScriptToTestLayout`) from copying SHA-1 signed telemetry DLLs (`Microsoft.Diagnostics.Tracing.EventSource.dll`, `Microsoft.VisualStudio.Telemetry.dll`, etc.) into sample app packages. These DLLs fail BinSkim BA2022 (SignSecurely).

The telemetry DLLs are only used for VS sideloading telemetry collection and are not needed for sample app functionality.

Fix identified and verified by Scott Jones.

Fixes: https://dev.azure.com/microsoft/OS/_workitems/edit/57941542

How built:
- Redirected the Agg Nightly pipeline to point at this private branch on the Samples repo. The [private pipeline run](https://dev.azure.com/microsoft/ProjectReunion/_build/results?buildId=143090596&view=sariftools.scans.build-tab) passed.

How tested:
- In the private pipeline run linked above, no Binskim BA2022 error was found under the Scans tab.