### PR TITLE
Fix build issues and update core package versions

### DIFF
--- a/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
@@ -254,7 +254,7 @@ namespace Notes
         }
     }
 
-    internal class MenuItemTemplateSelector : DataTemplateSelector
+    internal partial class MenuItemTemplateSelector : DataTemplateSelector
     {
         public DataTemplate? NoteTemplate { get; set; }
         public DataTemplate? DefaultTemplate { get; set; }

--- a/Samples/AppContentSearch/cs-winui/Notes.csproj
+++ b/Samples/AppContentSearch/cs-winui/Notes.csproj
@@ -75,6 +75,7 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
 		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.3.0-preview.1.25114.11" />
 		<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+		<PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4948" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental3" />
 		<PackageReference Include="OpenAI" Version="2.2.0-beta.2" />

--- a/Samples/AppContentSearch/cs-winui/NotesApp.sln
+++ b/Samples/AppContentSearch/cs-winui/NotesApp.sln
@@ -7,15 +7,23 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
 		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Debug|ARM64.ActiveCfg = Debug|ARM64
 		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Debug|ARM64.Build.0 = Debug|ARM64
 		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Debug|x64.ActiveCfg = Debug|x64
+		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Debug|x64.Build.0 = Debug|x64
+		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Debug|x64.Deploy.0 = Debug|x64
 		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Release|ARM64.ActiveCfg = Release|ARM64
 		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Release|ARM64.Build.0 = Release|ARM64
 		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Release|ARM64.Deploy.0 = Release|ARM64
+		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Release|x64.ActiveCfg = Release|x64
+		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Release|x64.Build.0 = Release|x64
+		{DB0EC506-054D-44C7-50E7-440A96C593E2}.Release|x64.Deploy.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Samples/AppContentSearch/cs-winui/Pages/NotesPage.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/Pages/NotesPage.xaml.cs
@@ -15,7 +15,7 @@ using Windows.Storage;
 
 namespace Notes.Pages
 {
-    public class RelativePathConverter : IValueConverter
+    public partial class RelativePathConverter : IValueConverter
     {
         public object? Convert(object value, Type targetType, object parameter, string language)
         {

--- a/Samples/BackgroundTask/InProc BackgroundTask/cpp-winui/BackgroundTaskBuilder/BackgroundTask.cpp
+++ b/Samples/BackgroundTask/InProc BackgroundTask/cpp-winui/BackgroundTaskBuilder/BackgroundTask.cpp
@@ -30,7 +30,7 @@ namespace winrt::BackgroundTaskBuilder
         m_mainWindow = window.as<winrt::BackgroundTaskBuilder::IMainWindow>();
 
         Windows::Foundation::TimeSpan period{ std::chrono::seconds{2} };
-        m_periodicTimer = Windows::System::Threading::ThreadPoolTimer::CreatePeriodicTimer([this, lifetime = get_strong()](Windows::System::Threading::ThreadPoolTimer timer)
+        m_periodicTimer = Windows::System::Threading::ThreadPoolTimer::CreatePeriodicTimer([this, lifetime = get_strong()](Windows::System::Threading::ThreadPoolTimer /* timer */)
             {
                 if (!m_cancelRequested && m_progress < 100)
                 {

--- a/Samples/Directory.Packages.props
+++ b/Samples/Directory.Packages.props
@@ -7,14 +7,14 @@
     <!-- Core -->
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.250916003" />
     <PackageVersion Include="Microsoft.WindowsAppSDK.Foundation" Version="1.8.250906002" />
-    <PackageVersion Include="Microsoft.Windows.CppWinRT" Version="2.0.221104.6" />
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Windows.CppWinRT" Version="2.0.240111.5" />
+    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
 
     <!-- Build tooling -->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.20250829.1" />
-    <PackageVersion Include="Microsoft.Windows.ImplementationLibrary" Version="1.0.220914.1" />
+    <PackageVersion Include="Microsoft.Windows.ImplementationLibrary" Version="1.0.240803.1" />
 
     <!-- Controls/web -->
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3179.45" />
@@ -27,12 +27,12 @@
     <!-- Optional feature packs (only if you really use them) -->
     <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="1.8.38" />
     <PackageVersion Include="Microsoft.WindowsAppSDK.ML" Version="1.8.2091" />
-    
+
     <!-- Other libraries -->
     <PackageVersion Include="System.Numerics.Tensors" Version="9.0.0" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.WinML" Version="0.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
     <PackageVersion Include="Microsoft.DXSDK.D3DX" Version="9.29.952.8" />
-    <PackageVersion Include="Microsoft.VCRTForwarders.140" version = "1.1.0"/>
+    <PackageVersion Include="Microsoft.VCRTForwarders.140" Version="1.1.0"/>
   </ItemGroup>
 </Project>

--- a/Samples/DynamicDependenciesSample/DynamicDependencies/DirectX/D3D9ExSample.cpp
+++ b/Samples/DynamicDependenciesSample/DynamicDependencies/DirectX/D3D9ExSample.cpp
@@ -103,8 +103,8 @@ const UINT32 majorMinorVersion{ 0x00010000 };
 PCWSTR versionTag{ L"" };
 
 int APIENTRY wWinMain( HINSTANCE hInstance,
-                       HINSTANCE hPrevInstance,
-                       LPWSTR    lpCmdLine,
+                       HINSTANCE /* hPrevInstance */,
+                       LPWSTR    /* lpCmdLine */,
                        int       nCmdShow )
 {
     // Use Dynamic Dependencies API to use DirectX framework package
@@ -745,7 +745,7 @@ void Render( IDirect3DDevice9Ex* pDev )
     g_liLastTimerUpdate.QuadPart = liCurrentTime.QuadPart;
 }
 
-void RenderText( IDirect3DDevice9Ex* pDev )
+void RenderText( IDirect3DDevice9Ex* /* pDev */ )
 {
     // The helper object simply helps keep track of text position, and color
     // and then it calls pFont->DrawText( m_pSprite, strMsg, -1, &rc, DT_NOCLIP, m_clr );

--- a/Samples/DynamicDependenciesSample/DynamicDependencies/DirectX/D3D9ExSample.vcxproj
+++ b/Samples/DynamicDependenciesSample/DynamicDependencies/DirectX/D3D9ExSample.vcxproj
@@ -151,6 +151,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -171,6 +172,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>

--- a/Samples/WindowsAIFoundry/cs-wpf-dotnet/WindowsAISampleForWPF/WindowsAISampleForWPF.csproj
+++ b/Samples/WindowsAIFoundry/cs-wpf-dotnet/WindowsAISampleForWPF/WindowsAISampleForWPF.csproj
@@ -82,7 +82,8 @@
     <Exec Command="$(_SignMsixCommand)"  Condition="'$(RepoTestCertificatePassword)' != ''"/>
     <Copy SourceFiles="@(BinplaceItem)"
       DestinationFiles="@(BinplaceItem->'$(AppxPackageDir)$(AppxPackageName)_Test\%(Filename)%(Extension)')"
-      SkipUnchangedFiles="true">
+      SkipUnchangedFiles="true"
+      Condition="Exists('$(RepoTestCertificateCer)')">
         <Output TaskParameter="CopiedFiles" ItemName="BinplaceItemCopied" />
     </Copy>
   </Target>


### PR DESCRIPTION
  - Upgrade `Microsoft.Windows.CppWinRT` (2.0.221104.6 → 2.0.240111.5), `Microsoft.Windows.CsWinRT` (2.1.1 → 2.2.0), and `Microsoft.Windows.ImplementationLibrary` (1.0.220914.1 → 1.0.240803.1) in the root `Directory.Packages.props`
  - **AppContentSearch**: add explicit `Microsoft.Windows.CsWinRT 2.2.0` reference to fix CS1705 (`CommunityToolkit.WinUI.Controls.SettingsControls 8.2.x` requires `WinRT.Runtime 2.2.0`); mark `MenuItemTemplateSelector` and `RelativePathConverter` as `partial` to satisfy CsWinRT1028; add x64 platform configuration to `NotesApp.sln`
  - **BackgroundTask**, **DynamicDependencies**: fix unused parameter warnings (C4100); add C++17 language standard to
  `D3D9ExSample.vcxproj`
  - **WindowsAIFoundry (WPF)**: skip certificate copy in `SignMSIX` target when `.cer` file is absent

  ## Test plan

  - [ ] Verify AppContentSearch builds on x64 without CS1705 or CsWinRT1028 errors
  - [ ] Verify pipeline passes for affected samples