### PR TITLE
Fix --ep_policy DISABLE: handle gracefully instead of crashing

### DIFF
--- a/Samples/WindowsML/Shared/cpp/ArgumentParser.cpp
+++ b/Samples/WindowsML/Shared/cpp/ArgumentParser.cpp
@@ -20,6 +20,8 @@ namespace Shared
             return false;
         }
 
+    bool disable_ep = false; // tracks --ep_policy DISABLE locally for validation
+
     for (size_t i = 1; i < arguments.size(); ++i)
     {
         if (arguments[i] == L"--compile")
@@ -67,11 +69,14 @@ namespace Shared
             }
             else if (policy_str == L"DISABLE")
             {
-                options.ep_policy = std::nullopt;
+                disable_ep = true;
+                options.ep_policy.reset();
             }
             else
             {
-                std::wcout << L"Unknown EP policy: " << policy_str << L", using default (DISABLE)\n";
+                std::wcout << L"Unknown EP policy: " << policy_str << L"\n";
+                PrintUsage();
+                return false;
             }
         }
         else if (arguments[i] == L"--perf_mode" && i + 1 < arguments.size())
@@ -117,8 +122,8 @@ namespace Shared
         return false;
     }
 
-    // Require one selection method
-    if (!options.ep_policy.has_value() && options.ep_name.empty())
+    // Require one selection method (unless disabled)
+    if (!disable_ep && !options.ep_policy.has_value() && options.ep_name.empty())
     {
         std::wcout << L"ERROR: You must specify one of --ep_policy or --ep_name.\n";
         PrintUsage();

--- a/Samples/WindowsML/Shared/cpp/InferenceEngine.cpp
+++ b/Samples/WindowsML/Shared/cpp/InferenceEngine.cpp
@@ -20,9 +20,9 @@ namespace Shared
             std::cout << "Using EP Selection Policy: " << ArgumentParser::ToString(options.ep_policy.value()) << std::endl;
             sessionOptions.SetEpSelectionPolicy(options.ep_policy.value());
         }
-        else
+        else if (!options.ep_name.empty())
         {
-            // Use explicit configuration
+            // Use explicit EP configuration
             std::cout << "Using explicit EP configuration" << std::endl;
             ExecutionProviderManager::ConfigureSelectedExecutionProvider(
                 sessionOptions,
@@ -30,6 +30,11 @@ namespace Shared
                 options.ep_name,
                 options.device_type,
                 options.perf_mode);
+        }
+        else
+        {
+            // DISABLE: no EP policy or explicit EP — use ONNX Runtime defaults (CPU + DML)
+            std::cout << "EP selection disabled, using ONNX Runtime defaults" << std::endl;
         }
 
         return sessionOptions;

--- a/Samples/WindowsML/Shared/cs/ArgumentParser.cs
+++ b/Samples/WindowsML/Shared/cs/ArgumentParser.cs
@@ -52,6 +52,7 @@ namespace WindowsML.Shared
         public static Options ParseOptions(string[] args)
         {
             Options options = new();
+            bool disableEp = false; // tracks --ep_policy DISABLE locally for validation
 
             for (int i = 0; i < args.Length; i++)
             {
@@ -76,12 +77,13 @@ namespace WindowsML.Shared
                                     options.EpPolicy = ExecutionProviderDevicePolicy.DEFAULT;
                                     break;
                                 case "DISABLE":
+                                    disableEp = true;
                                     options.EpPolicy = null;
                                     break;
                                 default:
-                                    Console.WriteLine($"Unknown EP policy: {policyStr}, using default (DISABLE)");
-                                    options.EpPolicy = null;
-                                    break;
+                                    Console.WriteLine($"Unknown EP policy: {policyStr}");
+                                    PrintHelp();
+                                    throw new ArgumentException($"Unknown EP policy: {policyStr}", "--ep_policy");
                             }
                         }
                         break;
@@ -173,11 +175,11 @@ namespace WindowsML.Shared
                 throw new Exception("Mutually exclusive EP options");
             }
 
-            if (!options.EpPolicy.HasValue && string.IsNullOrEmpty(options.EpName))
+            if (!disableEp && !options.EpPolicy.HasValue && string.IsNullOrEmpty(options.EpName))
             {
                 Console.WriteLine("ERROR: You must specify one of --ep_policy or --ep_name.");
                 PrintHelp();
-                throw new Exception("Missing EP selection");
+                throw new ArgumentException("Missing EP selection");
             }
 
             if (!string.IsNullOrEmpty(options.DeviceType))

--- a/Samples/WindowsML/Shared/cs/ModelManager.cs
+++ b/Samples/WindowsML/Shared/cs/ModelManager.cs
@@ -271,7 +271,8 @@ namespace WindowsML.Shared
             }
             else
             {
-                throw new Exception("Could not find an EP selection policy or an explicit execution provider.");
+                // DISABLE: no EP policy or explicit EP — use ONNX Runtime defaults (CPU + DML)
+                Console.WriteLine("EP selection disabled, using ONNX Runtime defaults");
             }
 
             return new InferenceSession(modelPath, sessionOptions);
@@ -344,10 +345,7 @@ namespace WindowsML.Shared
                             throw new Exception("Failed to configure selected execution provider");
                         }
                     }
-                    else
-                    {
-                        throw new Exception("Could not find an EP selection policy or an explicit execution provider.");
-                    }
+                    // else: DISABLE — compile with ONNX Runtime defaults
 
                     CompileModel(tempSessionOptions, modelPath, compiledModelPath);
 


### PR DESCRIPTION
## Summary

Fixes AB#61790993 — \\--ep_policy DISABLE\\ fails validation and crashes downstream code.

## Problem

\\DISABLE\\ means *do not call \\SetEpSelectionPolicy\\* — use ONNX Runtime built-in defaults (CPU + DML). Since \\OrtExecutionProviderDevicePolicy\\ has no \\DISABLE\\ enum value, the parser correctly leaves \\p_policy\\ unset. However, three layers then fail:

1. **ArgumentParser** validation requires \\p_policy\\ or \\p_name\\ to be set
2. **InferenceEngine.cpp** falls to else branch → calls \\ConfigureSelectedExecutionProvider\\ with empty ep_name → error
3. **ModelManager.cs** \\CreateSession\\ and \\ResolveActualModelPath\\ throw \\Exception\\ when neither is set

## Fix

- **ArgumentParser (C++/C#)**: Track DISABLE via a local flag, bypass the *must specify ep_policy or ep_name* validation
- **InferenceEngine.cpp**: Three-way branch — ep_policy → explicit EP → defaults (DISABLE)
- **ModelManager.cs**: \\CreateSession\\ and \\ResolveActualModelPath\\ gracefully fall through to ONNX Runtime defaults instead of throwing

## Semantics

\\DISABLE\\ ≠ \\DEFAULT\\:
- **DEFAULT**: actively calls \\SetEpSelectionPolicy(DEFAULT)\\ → ONNX Runtime automatic EP selection
- **DISABLE**: skips EP configuration entirely → falls back to built-in CPU + DML

## Testing

Verified with \\CSharpConsoleDesktop\\ sample:
- \\--ep_policy DISABLE\\ → runs inference successfully with ONNX Runtime defaults ✅
- \\--ep_policy DEFAULT\\ → uses EP selection policy as before ✅
- No args → validation error fires correctly ✅