### PR TITLE
Auto-load model and run inference on WinUI app launch

### DIFF
--- a/Samples/WindowsML/cs-winui/MainWindow.xaml.cs
+++ b/Samples/WindowsML/cs-winui/MainWindow.xaml.cs
@@ -78,8 +78,24 @@ namespace WindowsMLSample
                 EpCombo.SelectionChanged += EpCombo_SelectionChanged;
 
                 providerInfo.AppendLine("========================================");
-                providerInfo.AppendLine("Select an execution provider (and device if required) then click 'Load / Reload Model'.");
+                providerInfo.AppendLine("Auto-loading model with default execution provider...");
                 ResultsText.Text = providerInfo.ToString();
+
+                // Auto-load model and run inference on startup
+                try
+                {
+                    await LoadModelAsync();
+                    if (_session != null)
+                    {
+                        await LoadAndRunDemoAsync();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ResultsText.Text = providerInfo.ToString()
+                        + $"\nAuto-load failed: {ex.Message}"
+                        + "\nSelect an execution provider and click 'Load / Reload Model' to retry.";
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Instead of requiring the user to manually select an execution provider and click **Load / Reload Model**, the WinUI WindowsML sample now automatically loads the model with the default EP and runs inference on startup.

If auto-load fails (e.g., no GPU available for DML), the error is shown and the user can still manually select a different EP and retry.

## Changes

- **Samples/WindowsML/cs-winui/MainWindow.xaml.cs** — After EP initialization, automatically calls LoadModelAsync() and LoadAndRunDemoAsync() with graceful error handling fallback.

## Testing

- Built and deployed on a Hyper-V VM (no GPU) — app auto-runs with CPU EP successfully
- Manual reload button still works for switching EPs