### PR TITLE
Implement GetTestMessage in CppConsoleDll using Ort::Env initialization

### DIFF
--- a/Samples/WindowsML/cpp/CppConsoleDll/ConsoleClient/ConsoleClient.cpp
+++ b/Samples/WindowsML/cpp/CppConsoleDll/ConsoleClient/ConsoleClient.cpp
@@ -5,8 +5,8 @@
 #include <iostream>
 
 // Function pointer types for the DLL exports
-typedef char*(__stdcall* GetOrtVersionStringFunc)();
-typedef char*(__stdcall* GetTestMessageFunc)();
+typedef char*(*GetOrtVersionStringFunc)();
+typedef char*(*GetTestMessageFunc)();
 
 int main()
 {

--- a/Samples/WindowsML/cpp/CppConsoleDll/ConsoleClient/ConsoleClient.cpp
+++ b/Samples/WindowsML/cpp/CppConsoleDll/ConsoleClient/ConsoleClient.cpp
@@ -4,7 +4,7 @@
 #include <windows.h>
 #include <iostream>
 
-// Function pointer type for the DLL exports
+// Function pointer types for the DLL exports
 typedef char*(__stdcall* GetOrtVersionStringFunc)();
 typedef char*(__stdcall* GetTestMessageFunc)();
 
@@ -18,17 +18,32 @@ int main()
     }
 
     // Get function pointers
+    GetTestMessageFunc getTestMessage = (GetTestMessageFunc)GetProcAddress(hDll, "GetTestMessage");
     GetOrtVersionStringFunc getOrtVersionString = (GetOrtVersionStringFunc)GetProcAddress(hDll, "GetOrtVersionString");
-    if (getOrtVersionString == nullptr)
+
+    if (getTestMessage == nullptr || getOrtVersionString == nullptr)
     {
-        std::wcout << L"Failed to get GetOrtVersionString function from DLL" << std::endl;
+        std::wcout << L"Failed to get function pointers from DLL" << std::endl;
         FreeLibrary(hDll);
         return 1;
     }
 
     try
     {
-        // Call ONNX Runtime version function
+        // Call GetTestMessage - verifies the ORT runtime initializes correctly
+        std::wcout << L"Calling GetTestMessage from DLL..." << std::endl;
+        char* testMsg = getTestMessage();
+        if (testMsg != nullptr)
+        {
+            std::wcout << L"Test message: " << testMsg << std::endl;
+            CoTaskMemFree(testMsg); // Clean up string allocated by DLL
+        }
+        else
+        {
+            std::wcout << L"GetTestMessage returned null" << std::endl;
+        }
+
+        // Call GetOrtVersionString - demonstrates ORT C API via DLL
         std::wcout << L"Calling GetOrtVersionString from DLL..." << std::endl;
         char* versionString = getOrtVersionString();
         if (versionString != nullptr)
@@ -48,6 +63,7 @@ int main()
         return 1;
     }
 
+    std::wcout << L"DLL functions called successfully!" << std::endl;
     FreeLibrary(hDll);
     return 0;
 }

--- a/Samples/WindowsML/cpp/CppConsoleDll/WindowsMLWrapper/WindowsMLWrapper.cpp
+++ b/Samples/WindowsML/cpp/CppConsoleDll/WindowsMLWrapper/WindowsMLWrapper.cpp
@@ -5,10 +5,57 @@
 #include <windows.h>
 #include <combaseapi.h>
 #include <cstring>
+#include <string>
 
 // Include ONNX Runtime headers from WindowsAppSDK.ML package
 #include <winml/onnxruntime_cxx_api.h>
 
+// Initializes an ORT environment to verify the WindowsML runtime is operational.
+// Returns a success message if the runtime loads correctly.
+extern "C" __declspec(dllexport) char* GetTestMessage()
+{
+    try
+    {
+        // Creating an Ort::Env is the canonical ORT initialization step.
+        // If this succeeds, the ONNX Runtime and WindowsAppSDK ML components are functional.
+        Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "DllTest");
+
+        const char* message = "WindowsML DLL is working correctly!";
+        size_t len = strlen(message) + 1;
+        char* result = static_cast<char*>(CoTaskMemAlloc(len));
+        if (result)
+        {
+            strcpy_s(result, len, message);
+        }
+        return result;
+    }
+    catch (const Ort::Exception& e)
+    {
+        std::string error = "WindowsML DLL test failed: ";
+        error += e.what();
+        size_t len = error.size() + 1;
+        char* result = static_cast<char*>(CoTaskMemAlloc(len));
+        if (result)
+        {
+            strcpy_s(result, len, error.c_str());
+        }
+        return result;
+    }
+    catch (...)
+    {
+        const char* fallback = "WindowsML DLL test failed: unknown error";
+        size_t len = strlen(fallback) + 1;
+        char* result = static_cast<char*>(CoTaskMemAlloc(len));
+        if (result)
+        {
+            strcpy_s(result, len, fallback);
+        }
+        return result;
+    }
+}
+
+// Demonstrates the ORT C API (OrtGetApiBase) and CoTaskMemAlloc string management.
+// Returns the ONNX Runtime version string.
 extern "C" __declspec(dllexport) char* GetOrtVersionString()
 {
     try

--- a/Samples/WindowsML/cpp/CppConsoleDll/WindowsMLWrapper/WindowsMLWrapper.cpp
+++ b/Samples/WindowsML/cpp/CppConsoleDll/WindowsMLWrapper/WindowsMLWrapper.cpp
@@ -12,13 +12,14 @@
 
 // Initializes an ORT environment to verify the WindowsML runtime is operational.
 // Returns a success message if the runtime loads correctly.
-extern "C" __declspec(dllexport) char* GetTestMessage()
+extern "C" WINDOWSMLWRAPPER_API char* GetTestMessage()
 {
     try
     {
         // Creating an Ort::Env is the canonical ORT initialization step.
         // If this succeeds, the ONNX Runtime and WindowsAppSDK ML components are functional.
         Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "DllTest");
+        static_cast<void>(env); // Construction is the test; suppress C4189
 
         const char* message = "WindowsML DLL is working correctly!";
         size_t len = strlen(message) + 1;
@@ -56,7 +57,7 @@ extern "C" __declspec(dllexport) char* GetTestMessage()
 
 // Demonstrates the ORT C API (OrtGetApiBase) and CoTaskMemAlloc string management.
 // Returns the ONNX Runtime version string.
-extern "C" __declspec(dllexport) char* GetOrtVersionString()
+extern "C" WINDOWSMLWRAPPER_API char* GetOrtVersionString()
 {
     try
     {
@@ -85,7 +86,7 @@ extern "C" __declspec(dllexport) char* GetOrtVersionString()
     }
 }
 
-extern "C" __declspec(dllexport) void FreeString(char* str)
+extern "C" WINDOWSMLWRAPPER_API void FreeString(char* str)
 {
     if (str)
     {

--- a/Samples/WindowsML/cpp/CppConsoleDll/WindowsMLWrapper/WindowsMLWrapper.h
+++ b/Samples/WindowsML/cpp/CppConsoleDll/WindowsMLWrapper/WindowsMLWrapper.h
@@ -13,7 +13,11 @@
 
 extern "C"
 {
-    // Returns the ONNX Runtime version string
-    // Caller is responsible for freeing the returned string using CoTaskMemFree
+    // Initializes an ORT environment to verify the WindowsML runtime is operational.
+    // Caller is responsible for freeing the returned string using CoTaskMemFree.
+    WINDOWSMLWRAPPER_API char* GetTestMessage();
+
+    // Returns the ONNX Runtime version string (ORT C API).
+    // Caller is responsible for freeing the returned string using CoTaskMemFree.
     WINDOWSMLWRAPPER_API char* GetOrtVersionString();
 }


### PR DESCRIPTION
## Summary

The CppConsoleDll README documented a \GetTestMessage\ function that was never implemented. The function typedef existed in the client code from day one but was never wired up.

## Changes

- **WindowsMLWrapper.cpp**: Added \GetTestMessage()\ which creates an \Ort::Env\ — the canonical ORT initialization step. If it succeeds, the ONNX Runtime is genuinely loaded and functional, returning: \WindowsML DLL is working correctly!\. Includes \Ort::Exception\ catch for specific error reporting.
- **WindowsMLWrapper.h**: Added \GetTestMessage()\ declaration with doc comment.
- **ConsoleClient.cpp**: Wired up \GetTestMessage\ call, added \Test message:\ prefix to match README expected output, restored null-handling for both functions.

## Verified Output

\\\
Calling GetTestMessage from DLL...
Test message: WindowsML DLL is working correctly!
Calling GetOrtVersionString from DLL...
ONNX Runtime version: 1.23.4
DLL functions called successfully!
\\\

This matches the README expected output exactly.

## Bug

Fixes #61791036