### PR TITLE
Fix TensorRT RTX EP name to match catalog JSON

### DIFF
--- a/Samples/WindowsML/Shared/cs/PerformanceConfigurator.cs
+++ b/Samples/WindowsML/Shared/cs/PerformanceConfigurator.cs
@@ -8,16 +8,32 @@ namespace WindowsML.Shared
 {
     public static class PerformanceConfigurator
     {
+        /// <summary>
+        /// Returns EP-specific session options for the given execution provider name.
+        ///
+        /// The string literals below come from two sources that may use different names
+        /// for the same provider:
+        ///   1. ORT runtime — OrtEpDevice.EpName returned by ExecutionProviderCatalog.FindAllProviders()
+        ///   2. Model catalog JSON — the "executionProviders[].name" field in files like
+        ///      Resources/SqueezeNetModelCatalog.json
+        ///
+        /// When a provider appears under different names in these two sources, both forms
+        /// must be listed here so the lookup succeeds regardless of which name is passed in.
+        /// If a new EP is added to the ORT runtime or the catalog introduces an alias,
+        /// a corresponding entry should be added below.
+        /// </summary>
         public static Dictionary<string, string> GetEpOptions(string epName, PerformanceMode mode)
         {
             string normalized = (epName ?? string.Empty).Trim().ToUpperInvariant();
             return normalized switch
             {
-                "OPENVINOEXECUTIONPROVIDER" => GetOpenVinoOptions(mode),
-                "QNNEXECUTIONPROVIDER" => GetQnnOptions(mode),
-                "VITISAIEXECUTIONPROVIDER" => GetVitisAiOptions(mode),
-                "MIGRAPHXEXECUTIONPROVIDER" => GetMiGraphxOptions(mode),
-                "TENSORRTRTXEXECUTIONPROVIDER" => GetTensorRtRtxOptions(mode),
+                "OPENVINOEXECUTIONPROVIDER" => GetOpenVinoOptions(mode),           // ORT runtime name
+                "QNNEXECUTIONPROVIDER" => GetQnnOptions(mode),                     // ORT runtime name
+                "VITISAIEXECUTIONPROVIDER" => GetVitisAiOptions(mode),             // ORT runtime name
+                "MIGRAPHXEXECUTIONPROVIDER" => GetMiGraphxOptions(mode),           // ORT runtime name
+                "TENSORRTRTXEXECUTIONPROVIDER"                                     // ORT runtime name
+                    or "NVTENSORRTRTXEXECUTIONPROVIDER"                            // catalog JSON name (SqueezeNetModelCatalog.json)
+                    => GetTensorRtRtxOptions(mode),
                 _ => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             };
         }


### PR DESCRIPTION
## Summary

The model catalog (\SqueezeNetModelCatalog.json\) uses \NvTensorRTRTXExecutionProvider\ as the execution provider name for the \squeezenet-fp32\ model entry, but \PerformanceConfigurator.GetEpOptions()\ only matched the ORT runtime name \TensorRtRtxExecutionProvider\.

This meant that when the catalog-supplied EP name was passed to the configurator, no performance options were applied.

## Changes

- Added \NVTENSORRTRTXEXECUTIONPROVIDER\ as an alternative match in the C# \PerformanceConfigurator\ switch expression
- Added XML doc and inline comments explaining that EP name strings come from two sources:
  1. **ORT runtime** — \OrtEpDevice.EpName\ from \ExecutionProviderCatalog.FindAllProviders()\
  2. **Model catalog JSON** — \xecutionProviders[].name\ in files like \Resources/SqueezeNetModelCatalog.json\

## Validation

- ✅ \CSharpConsoleDesktop\ builds cleanly
- ✅ App launches and parses \--ep_name NvTensorRTRTXExecutionProvider\ correctly
- ❌ Cannot runtime-test the TensorRT RTX code path without NVIDIA GPU hardware

Fixes AB#61791041