### PR TITLE
Add missing App.InitializeComponent() call in WinUI sample

### DIFF
--- a/Samples/WindowsML/cs-winui/App.xaml.cs
+++ b/Samples/WindowsML/cs-winui/App.xaml.cs
@@ -11,6 +11,11 @@ namespace WindowsMLSample
 {
     public partial class App : Application
     {
+        public App()
+        {
+            this.InitializeComponent();
+        }
+
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
             Window = new MainWindow();


### PR DESCRIPTION
Fixes ADO #61791038

The WinUI cs-winui sample was missing the App.InitializeComponent() call, which could cause XAML resources to not load properly.