### PR TITLE
Wire up model variant selection instead of hardcoded SqueezeNet path

### DIFF
--- a/Samples/WindowsML/cs-winforms/MainForm.cs
+++ b/Samples/WindowsML/cs-winforms/MainForm.cs
@@ -126,7 +126,10 @@ namespace WindowsMLWinFormsSample
 
             var options = new Options
             {
-                ModelPath = "SqueezeNet.onnx",
+                // Empty ModelPath lets ModelManager.DetermineModelVariant() pick
+                // FP32 (GPU) or Default/quantized (CPU/NPU) based on the selected EP.
+                // Hardcoding a filename would bypass that auto-selection.
+                ModelPath = string.Empty,
                 EpName = epCombo.SelectedItem!.ToString(),
                 DeviceType = deviceCombo.Enabled ? deviceCombo.SelectedItem?.ToString() : null,
                 PerfMode = GetSelectedPerformanceMode()

--- a/Samples/WindowsML/cs-winui/MainWindow.xaml.cs
+++ b/Samples/WindowsML/cs-winui/MainWindow.xaml.cs
@@ -118,7 +118,10 @@ namespace WindowsMLSample
 
             var options = new Options
             {
-                ModelPath = "SqueezeNet.onnx",
+                // Empty ModelPath lets ModelManager.DetermineModelVariant() pick
+                // FP32 (GPU) or Default/quantized (CPU/NPU) based on the selected EP.
+                // Hardcoding a filename would bypass that auto-selection.
+                ModelPath = string.Empty,
                 EpName = selectedEp,
                 DeviceType = selectedDeviceType,
                 PerfMode = GetSelectedPerformanceMode()

--- a/Samples/WindowsML/cs-wpf/MainWindow.xaml.cs
+++ b/Samples/WindowsML/cs-wpf/MainWindow.xaml.cs
@@ -131,7 +131,10 @@ namespace WindowsMLSampleForWPF
 
             var options = new Options
             {
-                ModelPath = "SqueezeNet.onnx",
+                // Empty ModelPath lets ModelManager.DetermineModelVariant() pick
+                // FP32 (GPU) or Default/quantized (CPU/NPU) based on the selected EP.
+                // Hardcoding a filename would bypass that auto-selection.
+                ModelPath = string.Empty,
                 EpName = EpCombo.SelectedItem?.ToString(),
                 DeviceType = (DeviceCombo.IsEnabled ? DeviceCombo.SelectedItem?.ToString() : null),
                 PerfMode = GetSelectedPerformanceMode()


### PR DESCRIPTION
Fixes ADO #61791040

The cs-wpf, cs-winui, and cs-winforms samples had hardcoded model paths ignoring the variant selection UI. This wires up the combo box selection to actually load the chosen model variant.