### PR TITLE
Windows ML: Fix crash with null provider options for VitisAI EP

### DIFF
--- a/Samples/WindowsML/Shared/cpp/PerformanceConfigurator.h
+++ b/Samples/WindowsML/Shared/cpp/PerformanceConfigurator.h
@@ -93,7 +93,8 @@ namespace Shared
 
         static Ort::KeyValuePairs GetVitisAiOptions(PerformanceMode /*mode*/)
         {
-            return Ort::KeyValuePairs(nullptr);
+            Ort::KeyValuePairs options;
+            return options;
         }
 
         static Ort::KeyValuePairs GetMiGraphXOptions(PerformanceMode mode)


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

CppConsoleDesktop.SelfContained.exe was crashing with an access violation when using VitisAIExecutionProvider. My command line was `CppConsoleDesktop.SelfContained.exe --ep_name VitisAIExecutionProvider --device_type NPU --compile`

The crash is because ONNX dereferences a null OrtKeyValuePairs* when reading the EP options. 

In the Performance Configurator header, GetVitisAIOptions was returning Ort::KeyValuePairs(nullptr), which wraps a null internal pointer. This fix changed it to return a default-constructed Ort::KeyValuePairs which should be a valid object for ORT to query.

Tested by rebuilding and running the sample. The app no longer crashes and successfully completes inference on the SqueezeNet model using the EP. 

## Target Release

2.0

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
