### PR TITLE
Bug Bash - EP+Performance compile paths and fixes

### DIFF
--- a/Samples/WindowsML/Shared/cpp/ArgumentParser.cpp
+++ b/Samples/WindowsML/Shared/cpp/ArgumentParser.cpp
@@ -65,13 +65,10 @@ namespace Shared
             {
                 options.ep_policy = OrtExecutionProviderDevicePolicy_DEFAULT;
             }
-            else if (policy_str == L"DISABLE")
-            {
-                options.ep_policy = std::nullopt;
-            }
             else
             {
-                std::wcout << L"Unknown EP policy: " << policy_str << L", using default (DISABLE)\n";
+                std::wcout << L"Unknown EP policy: " << policy_str << L". Valid values are: NPU, CPU, GPU, DEFAULT\n";
+                throw std::invalid_argument("Unknown EP policy value");
             }
         }
         else if (arguments[i] == L"--perf_mode" && i + 1 < arguments.size())
@@ -183,7 +180,7 @@ namespace Shared
     {
         std::wcout << L"Usage: Application.exe [options]\n"
                    << L"Options:\n"
-                   << L"  --ep_policy <policy>          Set execution provider selection policy (NPU, CPU, GPU, DEFAULT, DISABLE)\n"
+                   << L"  --ep_policy <policy>          Set execution provider selection policy (NPU, CPU, GPU, DEFAULT)\n"
                    << L"  --ep_name <name>              Explicit execution provider name (mutually exclusive with --ep_policy)\n"
                    << L"  --device_type <type>          Device type for OpenVINOExecutionProvider (NPU, GPU, CPU) when multiple present\n"
                    << L"  --perf_mode <mode>            Set EP performance mode (MAX_PERFORMANCE, MAX_EFFICIENCY, DEFAULT)\n"

--- a/Samples/WindowsML/Shared/cpp/ArgumentParser.cpp
+++ b/Samples/WindowsML/Shared/cpp/ArgumentParser.cpp
@@ -65,10 +65,13 @@ namespace Shared
             {
                 options.ep_policy = OrtExecutionProviderDevicePolicy_DEFAULT;
             }
+            else if (policy_str == L"DISABLE")
+            {
+                options.ep_policy = std::nullopt;
+            }
             else
             {
-                std::wcout << L"Unknown EP policy: " << policy_str << L". Valid values are: NPU, CPU, GPU, DEFAULT\n";
-                throw std::invalid_argument("Unknown EP policy value");
+                std::wcout << L"Unknown EP policy: " << policy_str << L", using default (DISABLE)\n";
             }
         }
         else if (arguments[i] == L"--perf_mode" && i + 1 < arguments.size())
@@ -180,7 +183,7 @@ namespace Shared
     {
         std::wcout << L"Usage: Application.exe [options]\n"
                    << L"Options:\n"
-                   << L"  --ep_policy <policy>          Set execution provider selection policy (NPU, CPU, GPU, DEFAULT)\n"
+                   << L"  --ep_policy <policy>          Set execution provider selection policy (NPU, CPU, GPU, DEFAULT, DISABLE)\n"
                    << L"  --ep_name <name>              Explicit execution provider name (mutually exclusive with --ep_policy)\n"
                    << L"  --device_type <type>          Device type for OpenVINOExecutionProvider (NPU, GPU, CPU) when multiple present\n"
                    << L"  --perf_mode <mode>            Set EP performance mode (MAX_PERFORMANCE, MAX_EFFICIENCY, DEFAULT)\n"

--- a/Samples/WindowsML/Shared/cpp/ArgumentParser.cpp
+++ b/Samples/WindowsML/Shared/cpp/ArgumentParser.cpp
@@ -188,7 +188,7 @@ namespace Shared
                    << L"  --download                    Download required packages\n"
                    << L"  --use_model_catalog           Use the model catalog for model selection\n"
                    << L"  --model <path>                Path to the input ONNX model (default: SqueezeNet.onnx in executable directory)\n"
-                   << L"  --compiled_output <path>      Path for compiled output model (default: SqueezeNet_ctx.onnx)\n"
+                   << L"  --compiled_output <path>      Path for compiled output model (default: auto-generated with device info)\n"
                    << L"  --image_path <path>           Path to the input image (default: sample kitten image)\n"
                    << L"\n"
                    << L"Exactly one of --ep_policy or --ep_name must be specified.\n"

--- a/Samples/WindowsML/Shared/cpp/ModelManager.cpp
+++ b/Samples/WindowsML/Shared/cpp/ModelManager.cpp
@@ -256,8 +256,7 @@ namespace Shared
     std::filesystem::path ModelManager::GenerateCompiledModelPath(
         const std::filesystem::path& modelPath,
         const std::filesystem::path& executableFolder,
-        const CommandLineOptions& options,
-        Ort::Env& env)
+        const CommandLineOptions& options)
     {
         // If user explicitly specified --compiled_output, use it as-is
         if (!options.output_path.empty())

--- a/Samples/WindowsML/Shared/cpp/ModelManager.cpp
+++ b/Samples/WindowsML/Shared/cpp/ModelManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.md in the repo root for license information.
 #include "ModelManager.h"
 #include <iostream>
@@ -251,6 +251,58 @@ namespace Shared
         // Default fallback
         std::wcout << L"Auto-selected Default model variant (fallback)\n";
         return ModelVariant::Default;
+    }
+
+    std::filesystem::path ModelManager::GenerateCompiledModelPath(
+        const std::filesystem::path& modelPath,
+        const std::filesystem::path& executableFolder,
+        const CommandLineOptions& options,
+        Ort::Env& env)
+    {
+        // If user explicitly specified --compiled_output, use it as-is
+        if (!options.output_path.empty())
+        {
+            return std::filesystem::path(options.output_path);
+        }
+
+        std::wstring baseName = modelPath.stem().wstring();
+        std::wstring suffix;
+
+        if (options.ep_policy.has_value())
+        {
+            std::string policyStr = ArgumentParser::ToString(options.ep_policy.value());
+            suffix = L"_" + std::wstring(policyStr.begin(), policyStr.end());
+        }
+        else if (!options.ep_name.empty())
+        {
+            suffix = L"_" + options.ep_name;
+
+            // Try to determine device type
+            std::wstring deviceType;
+            if (options.device_type.has_value())
+            {
+                deviceType = options.device_type.value();
+            }
+
+            if (!deviceType.empty())
+            {
+                suffix += L"_" + deviceType;
+            }
+        }
+
+        if (options.perf_mode == PerformanceMode::MaxPerformance)
+        {
+            suffix += L"_MaxPerformance";
+        }
+        else if (options.perf_mode == PerformanceMode::MaxEfficiency)
+        {
+            suffix += L"_MaxEfficiency";
+        }
+
+        std::wstring fileName = baseName + L"_ctx" + suffix + L".onnx";
+        auto result = executableFolder / fileName;
+        std::wcout << L"Compiled model path: " << result.wstring() << std::endl;
+        return result;
     }
 
 } // namespace Shared

--- a/Samples/WindowsML/Shared/cpp/ModelManager.h
+++ b/Samples/WindowsML/Shared/cpp/ModelManager.h
@@ -55,6 +55,17 @@ namespace Shared
             std::wstring& outputImagePath);
 
         /// <summary>
+        /// Generate a device-specific compiled model path.
+        /// Encodes EP policy/name, device type, and performance mode so compiled models
+        /// for different device configurations don't collide.
+        /// </summary>
+        static std::filesystem::path GenerateCompiledModelPath(
+            const std::filesystem::path& modelPath,
+            const std::filesystem::path& executableFolder,
+            const CommandLineOptions& options,
+            Ort::Env& env);
+
+        /// <summary>
         /// Get model path for specified variant
         /// </summary>
         static std::wstring GetModelVariantPath(

--- a/Samples/WindowsML/Shared/cpp/ModelManager.h
+++ b/Samples/WindowsML/Shared/cpp/ModelManager.h
@@ -62,8 +62,7 @@ namespace Shared
         static std::filesystem::path GenerateCompiledModelPath(
             const std::filesystem::path& modelPath,
             const std::filesystem::path& executableFolder,
-            const CommandLineOptions& options,
-            Ort::Env& env);
+            const CommandLineOptions& options);
 
         /// <summary>
         /// Get model path for specified variant

--- a/Samples/WindowsML/Shared/cs/ArgumentParser.cs
+++ b/Samples/WindowsML/Shared/cs/ArgumentParser.cs
@@ -75,8 +75,13 @@ namespace WindowsML.Shared
                                 case "DEFAULT":
                                     options.EpPolicy = ExecutionProviderDevicePolicy.DEFAULT;
                                     break;
+                                case "DISABLE":
+                                    options.EpPolicy = null;
+                                    break;
                                 default:
-                                    throw new Exception($"Unknown EP policy: {policyStr}. Valid values are: NPU, CPU, GPU, DEFAULT.");
+                                    Console.WriteLine($"Unknown EP policy: {policyStr}, using default (DISABLE)");
+                                    options.EpPolicy = null;
+                                    break;
                             }
                         }
                         break;
@@ -208,7 +213,7 @@ namespace WindowsML.Shared
         public static void PrintHelp()
         {
             Console.WriteLine("Options:");
-            Console.WriteLine("  --ep_policy <policy>        Set execution provider policy (NPU, CPU, GPU, DEFAULT)");
+            Console.WriteLine("  --ep_policy <policy>        Set execution provider policy (NPU, CPU, GPU, DEFAULT, DISABLE)");
             Console.WriteLine("  --ep_name <name>            Explicit execution provider name (mutually exclusive with --ep_policy)");
             Console.WriteLine("  --device_type <type>        Optional hardware device type to use when EP supports multiple (e.g. CPU, GPU, NPU)");
             Console.WriteLine("  --perf_mode <mode>          Set EP performance mode (MAX_PERFORMANCE, MAX_EFFICIENCY, DEFAULT)");

--- a/Samples/WindowsML/Shared/cs/ArgumentParser.cs
+++ b/Samples/WindowsML/Shared/cs/ArgumentParser.cs
@@ -75,13 +75,8 @@ namespace WindowsML.Shared
                                 case "DEFAULT":
                                     options.EpPolicy = ExecutionProviderDevicePolicy.DEFAULT;
                                     break;
-                                case "DISABLE":
-                                    options.EpPolicy = null;
-                                    break;
                                 default:
-                                    Console.WriteLine($"Unknown EP policy: {policyStr}, using default (DISABLE)");
-                                    options.EpPolicy = null;
-                                    break;
+                                    throw new Exception($"Unknown EP policy: {policyStr}. Valid values are: NPU, CPU, GPU, DEFAULT.");
                             }
                         }
                         break;
@@ -213,7 +208,7 @@ namespace WindowsML.Shared
         public static void PrintHelp()
         {
             Console.WriteLine("Options:");
-            Console.WriteLine("  --ep_policy <policy>        Set execution provider policy (NPU, CPU, GPU, DEFAULT, DISABLE)");
+            Console.WriteLine("  --ep_policy <policy>        Set execution provider policy (NPU, CPU, GPU, DEFAULT)");
             Console.WriteLine("  --ep_name <name>            Explicit execution provider name (mutually exclusive with --ep_policy)");
             Console.WriteLine("  --device_type <type>        Optional hardware device type to use when EP supports multiple (e.g. CPU, GPU, NPU)");
             Console.WriteLine("  --perf_mode <mode>          Set EP performance mode (MAX_PERFORMANCE, MAX_EFFICIENCY, DEFAULT)");

--- a/Samples/WindowsML/Shared/cs/ArgumentParser.cs
+++ b/Samples/WindowsML/Shared/cs/ArgumentParser.cs
@@ -38,7 +38,7 @@ namespace WindowsML.Shared
         public bool Download { get; set; } = false;
         public bool UseModelCatalog { get; set; } = false;
         public string ModelPath { get; set; } = string.Empty;
-        public string OutputPath { get; set; } = "SqueezeNet_ctx.onnx";
+        public string OutputPath { get; set; } = string.Empty;
         public string ImagePath { get; set; } = string.Empty;
         public ModelVariant Variant { get; set; } = ModelVariant.Default;
         public PerformanceMode PerfMode { get; set; } = PerformanceMode.Default;
@@ -216,7 +216,7 @@ namespace WindowsML.Shared
             Console.WriteLine("  --download                  Download required packages");
             Console.WriteLine("  --use_model_catalog         Use the model catalog for model discovery");
             Console.WriteLine("  --model <path>              Path to input ONNX model (default: SqueezeNet.onnx)");
-            Console.WriteLine("  --compiled_output <path>    Path for compiled output model (default: SqueezeNet_ctx.onnx)");
+            Console.WriteLine("  --compiled_output <path>    Path for compiled output model (default: auto-generated with device info)");
             Console.WriteLine("  --image_path <path>         Path to the input image (default: sample kitten image)");
             Console.WriteLine("  --help, -h                  Display this help message");
             Console.WriteLine();

--- a/Samples/WindowsML/Shared/cs/ExecutionProviderManager.cs
+++ b/Samples/WindowsML/Shared/cs/ExecutionProviderManager.cs
@@ -42,6 +42,7 @@ namespace WindowsML.Shared
                     if (allowDownload || readyState != ExecutionProviderReadyState.NotPresent)
                     {
                         await provider.EnsureReadyAsync();
+                        Console.WriteLine($"  Updated Ready state: {provider.ReadyState}");
                     }
 
                     provider.TryRegister();

--- a/Samples/WindowsML/Shared/cs/ModelManager.cs
+++ b/Samples/WindowsML/Shared/cs/ModelManager.cs
@@ -115,7 +115,7 @@ namespace WindowsML.Shared
         /// Encodes EP policy/name, device type, and performance mode into the filename
         /// so that compiled models for different device configurations don't collide.
         /// </summary>
-        public static string GenerateCompiledModelPath(string modelPath, string executableFolder, Options options, OrtEnv? ortEnv = null)
+        public static string GenerateCompiledModelPath(string modelPath, string executableFolder, Options options)
         {
             // If user explicitly specified --compiled_output, use it as-is
             if (!string.IsNullOrEmpty(options.OutputPath))
@@ -125,7 +125,7 @@ namespace WindowsML.Shared
             }
 
             string baseName = Path.GetFileNameWithoutExtension(modelPath);
-            string suffix = BuildDeviceSuffix(options, ortEnv);
+            string suffix = BuildDeviceSuffix(options);
 
             string fileName = $"{baseName}_ctx{suffix}.onnx";
             Console.WriteLine($"Compiled model path: {Path.Combine(executableFolder, fileName)}");
@@ -135,7 +135,7 @@ namespace WindowsML.Shared
         /// <summary>
         /// Build a device-identifying suffix for the compiled model filename.
         /// </summary>
-        private static string BuildDeviceSuffix(Options options, OrtEnv? ortEnv)
+        private static string BuildDeviceSuffix(Options options)
         {
             var parts = new List<string>();
 
@@ -246,7 +246,7 @@ namespace WindowsML.Shared
                 modelPath = GetModelVariantPath(executableFolder, variant);
             }
 
-            string compiledModelPath = GenerateCompiledModelPath(modelPath, executableFolder, options, ortEnv);
+            string compiledModelPath = GenerateCompiledModelPath(modelPath, executableFolder, options);
 
             if (!File.Exists(labelsPath))
             {

--- a/Samples/WindowsML/Shared/cs/ModelManager.cs
+++ b/Samples/WindowsML/Shared/cs/ModelManager.cs
@@ -111,6 +111,60 @@ namespace WindowsML.Shared
         }
 
         /// <summary>
+        /// Generate a device-specific compiled model path.
+        /// Encodes EP policy/name, device type, and performance mode into the filename
+        /// so that compiled models for different device configurations don't collide.
+        /// </summary>
+        public static string GenerateCompiledModelPath(string modelPath, string executableFolder, Options options, OrtEnv? ortEnv = null)
+        {
+            // If user explicitly specified --compiled_output, use it as-is
+            if (!string.IsNullOrEmpty(options.OutputPath))
+            {
+                return options.OutputPath.Contains(Path.DirectorySeparatorChar) ?
+                    options.OutputPath : Path.Combine(executableFolder, options.OutputPath);
+            }
+
+            string baseName = Path.GetFileNameWithoutExtension(modelPath);
+            string suffix = BuildDeviceSuffix(options, ortEnv);
+
+            string fileName = $"{baseName}_ctx{suffix}.onnx";
+            Console.WriteLine($"Compiled model path: {Path.Combine(executableFolder, fileName)}");
+            return Path.Combine(executableFolder, fileName);
+        }
+
+        /// <summary>
+        /// Build a device-identifying suffix for the compiled model filename.
+        /// </summary>
+        private static string BuildDeviceSuffix(Options options, OrtEnv? ortEnv)
+        {
+            var parts = new List<string>();
+
+            if (options.EpPolicy.HasValue)
+            {
+                parts.Add(options.EpPolicy.Value.ToString());
+            }
+            else if (!string.IsNullOrEmpty(options.EpName))
+            {
+                parts.Add(options.EpName);
+
+                // Try to determine device type
+                string? deviceType = options.DeviceType;
+
+                if (!string.IsNullOrEmpty(deviceType))
+                {
+                    parts.Add(deviceType);
+                }
+            }
+
+            if (options.PerfMode != PerformanceMode.Default)
+            {
+                parts.Add(options.PerfMode.ToString());
+            }
+
+            return parts.Count > 0 ? "_" + string.Join("_", parts) : "";
+        }
+
+        /// <summary>
         /// Resolve model paths with intelligent variant selection
         /// </summary>
         public static async Task<(string modelPath, string compiledModelPath, string labelsPath)> ResolvePaths(Options options, OrtEnv ortEnv)
@@ -192,8 +246,7 @@ namespace WindowsML.Shared
                 modelPath = GetModelVariantPath(executableFolder, variant);
             }
 
-            string compiledModelPath = options.OutputPath.Contains(Path.DirectorySeparatorChar) ?
-                options.OutputPath : Path.Combine(executableFolder, options.OutputPath);
+            string compiledModelPath = GenerateCompiledModelPath(modelPath, executableFolder, options, ortEnv);
 
             if (!File.Exists(labelsPath))
             {
@@ -225,8 +278,7 @@ namespace WindowsML.Shared
                 modelPath = GetModelVariantPath(executableFolder, options.Variant);
             }
 
-            string compiledModelPath = options.OutputPath.Contains(Path.DirectorySeparatorChar) ?
-                options.OutputPath : Path.Combine(executableFolder, options.OutputPath);
+            string compiledModelPath = GenerateCompiledModelPath(modelPath, executableFolder, options);
 
             string labelsPath = Path.Combine(executableFolder, "SqueezeNet.Labels.txt");
 

--- a/Samples/WindowsML/cpp/CppConsoleDesktop/CppConsoleDesktop.cpp
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop/CppConsoleDesktop.cpp
@@ -110,7 +110,7 @@ IAsyncAction RunInferenceAsync(const CommandLineOptions& options)
         std::vector<std::string> labels = ModelManager::LoadLabels(labelsPath);
 
         std::filesystem::path outputPath =
-            ModelManager::GenerateCompiledModelPath(modelPath, executableFolder, options, env);
+            ModelManager::GenerateCompiledModelPath(modelPath, executableFolder, options);
 
         std::filesystem::path imagePath =
             options.image_path.empty() ? executableFolder / L"image.png" : std::filesystem::path(options.image_path);

--- a/Samples/WindowsML/cpp/CppConsoleDesktop/CppConsoleDesktop.cpp
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop/CppConsoleDesktop.cpp
@@ -110,7 +110,7 @@ IAsyncAction RunInferenceAsync(const CommandLineOptions& options)
         std::vector<std::string> labels = ModelManager::LoadLabels(labelsPath);
 
         std::filesystem::path outputPath =
-            options.output_path.empty() ? executableFolder / L"SqueezeNet_ctx.onnx" : std::filesystem::path(options.output_path);
+            ModelManager::GenerateCompiledModelPath(modelPath, executableFolder, options, env);
 
         std::filesystem::path imagePath =
             options.image_path.empty() ? executableFolder / L"image.png" : std::filesystem::path(options.image_path);

--- a/Samples/WindowsML/cpp/CppConsoleDesktop/README.md
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop/README.md
@@ -11,7 +11,7 @@ This sample demonstrates how to use ONNX Runtime in a C++ desktop application, f
 ```
 CppConsoleDesktop.exe [options]
 Options:
-  --ep_policy <policy>  Set execution provider policy (NPU, CPU, GPU, DEFAULT, DISABLE). Default: DISABLE
+  --ep_policy <policy>  Set execution provider policy (NPU, CPU, GPU, DEFAULT)
   --compile            Compile the model
   --download           Download required packages
   --model <path>       Path to input ONNX model (default: SqueezeNet.onnx in executable directory)

--- a/Samples/WindowsML/cpp/CppConsoleDesktop/README.md
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop/README.md
@@ -11,7 +11,7 @@ This sample demonstrates how to use ONNX Runtime in a C++ desktop application, f
 ```
 CppConsoleDesktop.exe [options]
 Options:
-  --ep_policy <policy>  Set execution provider policy (NPU, CPU, GPU, DEFAULT)
+  --ep_policy <policy>  Set execution provider policy (NPU, CPU, GPU, DEFAULT, DISABLE). Default: DISABLE
   --compile            Compile the model
   --download           Download required packages
   --model <path>       Path to input ONNX model (default: SqueezeNet.onnx in executable directory)

--- a/Samples/WindowsML/cpp/CppConsoleDesktop/README.md
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop/README.md
@@ -15,7 +15,7 @@ Options:
   --compile            Compile the model
   --download           Download required packages
   --model <path>       Path to input ONNX model (default: SqueezeNet.onnx in executable directory)
-  --compiled_output <path>      Path for compiled output model (default: SqueezeNet_ctx.onnx)
+  --compiled_output <path>      Path for compiled output model (default: auto-generated with device info)
   --image_path <path>           Path to the input image (default: sample kitten image)
 ```
 
@@ -68,7 +68,14 @@ for (const auto& [ep_name, devices] : ep_device_map)
 
 ### 2. Model Compilation
 
-The sample shows how to compile an ONNX model for optimized execution:
+The sample shows how to compile an ONNX model for optimized execution. Compiled model filenames
+are automatically generated with device-specific identifiers to prevent collisions:
+
+- Policy mode: `SqueezeNet_ctx_PREFER_GPU.onnx`
+- Explicit EP: `SqueezeNet_ctx_DML_GPU.onnx`
+- With perf mode: `SqueezeNet_ctx_PREFER_NPU_MaxPerformance.onnx`
+
+Use `--compiled_output` to override with a custom path.
 
 ```cpp
 #include <win_onnxruntime_cxx_api.h>

--- a/Samples/WindowsML/cs/CSharpConsoleDesktop/README.md
+++ b/Samples/WindowsML/cs/CSharpConsoleDesktop/README.md
@@ -11,7 +11,7 @@ This sample demonstrates how to use ONNX Runtime in a C# desktop application, fo
 ```shell
 CSharpConsoleDesktop.exe [options]
 Options:
-  --ep_policy <policy>          Set execution provider policy (NPU, CPU, GPU, DEFAULT)
+  --ep_policy <policy>          Set execution provider policy (NPU, CPU, GPU, DEFAULT, DISABLE). Default: DISABLE
   --compile                     Compile the model
   --download                    Download required packages
   --model <path>                Path to input ONNX model (default: SqueezeNet.onnx in executable directory)

--- a/Samples/WindowsML/cs/CSharpConsoleDesktop/README.md
+++ b/Samples/WindowsML/cs/CSharpConsoleDesktop/README.md
@@ -15,7 +15,7 @@ Options:
   --compile                     Compile the model
   --download                    Download required packages
   --model <path>                Path to input ONNX model (default: SqueezeNet.onnx in executable directory)
-  --compiled_output <path>      Path for compiled output model (default: SqueezeNet_ctx.onnx)
+  --compiled_output <path>      Path for compiled output model (default: auto-generated with device info)
   --image_path <path>           Path to the input image (default: sample kitten image)
 ```
 
@@ -80,7 +80,14 @@ foreach (KeyValuePair<string, List<OrtEpDevice>> epGroup in epDeviceMap)
 
 ### 2. Model Compilation
 
-The sample shows how to compile an ONNX model for optimized execution:
+The sample shows how to compile an ONNX model for optimized execution. Compiled model filenames
+are automatically generated with device-specific identifiers to prevent collisions:
+
+- Policy mode: `SqueezeNet_ctx_PREFER_GPU.onnx`
+- Explicit EP: `SqueezeNet_ctx_DML_GPU.onnx`
+- With perf mode: `SqueezeNet_ctx_PREFER_NPU_MaxPerformance.onnx`
+
+Use `--compiled_output` to override with a custom path.
 
 ```csharp
 // Create compilation options from session options

--- a/Samples/WindowsML/cs/CSharpConsoleDesktop/README.md
+++ b/Samples/WindowsML/cs/CSharpConsoleDesktop/README.md
@@ -11,7 +11,7 @@ This sample demonstrates how to use ONNX Runtime in a C# desktop application, fo
 ```shell
 CSharpConsoleDesktop.exe [options]
 Options:
-  --ep_policy <policy>          Set execution provider policy (NPU, CPU, GPU, DEFAULT, DISABLE). Default: DISABLE
+  --ep_policy <policy>          Set execution provider policy (NPU, CPU, GPU, DEFAULT)
   --compile                     Compile the model
   --download                    Download required packages
   --model <path>                Path to input ONNX model (default: SqueezeNet.onnx in executable directory)


### PR DESCRIPTION
## Changes
 Bug 1 – Missing ready state output after EnsureReadyAsync

   - No feedback was printed after calling EnsureReadyAsync(), making EP readiness hard to debug
   - Added a Console.WriteLine to show the updated ReadyState after the call completes

  Bug 2 – Remove DISABLE from ep_policy options

   - DISABLE was listed as a valid --ep_policy value but just set policy to null
   - Unknown values silently fell back to DISABLE instead of reporting an error
   - Removed DISABLE, unknown values now throw an error with valid options listed
   - Updated help text and READMEs in both C++ and C#

  Bug 3 – EP+Performance-specific compiled model paths

   - Compiled models always saved as SqueezeNet_ctx.onnx, so different EP/perf configs overwrote each other
   - Added GenerateCompiledModelPath() in both C++ and C# that encodes EP policy/name, device type, and perf mode into the filename
   - Example: SqueezeNet_ctx_PREFER_NPU_MaxPerformance.onnx
   - Users can still override with --compiled_output
   - Updated READMEs with examples of auto-generated filenames
