### PR TITLE
Bug Bash - removing ep_policy option DISABLE

### DIFF
--- a/Samples/WindowsML/Shared/cpp/ArgumentParser.cpp
+++ b/Samples/WindowsML/Shared/cpp/ArgumentParser.cpp
@@ -65,13 +65,10 @@ namespace Shared
             {
                 options.ep_policy = OrtExecutionProviderDevicePolicy_DEFAULT;
             }
-            else if (policy_str == L"DISABLE")
-            {
-                options.ep_policy = std::nullopt;
-            }
             else
             {
-                std::wcout << L"Unknown EP policy: " << policy_str << L", using default (DISABLE)\n";
+                std::wcout << L"Unknown EP policy: " << policy_str << L", using default (DEFAULT)\n";
+                options.ep_policy = OrtExecutionProviderDevicePolicy_DEFAULT;
             }
         }
         else if (arguments[i] == L"--perf_mode" && i + 1 < arguments.size())
@@ -183,7 +180,7 @@ namespace Shared
     {
         std::wcout << L"Usage: Application.exe [options]\n"
                    << L"Options:\n"
-                   << L"  --ep_policy <policy>          Set execution provider selection policy (NPU, CPU, GPU, DEFAULT, DISABLE)\n"
+                   << L"  --ep_policy <policy>          Set execution provider selection policy (NPU, CPU, GPU, DEFAULT)\n"
                    << L"  --ep_name <name>              Explicit execution provider name (mutually exclusive with --ep_policy)\n"
                    << L"  --device_type <type>          Device type for OpenVINOExecutionProvider (NPU, GPU, CPU) when multiple present\n"
                    << L"  --perf_mode <mode>            Set EP performance mode (MAX_PERFORMANCE, MAX_EFFICIENCY, DEFAULT)\n"

--- a/Samples/WindowsML/Shared/cs/ArgumentParser.cs
+++ b/Samples/WindowsML/Shared/cs/ArgumentParser.cs
@@ -75,12 +75,9 @@ namespace WindowsML.Shared
                                 case "DEFAULT":
                                     options.EpPolicy = ExecutionProviderDevicePolicy.DEFAULT;
                                     break;
-                                case "DISABLE":
-                                    options.EpPolicy = null;
-                                    break;
                                 default:
-                                    Console.WriteLine($"Unknown EP policy: {policyStr}, using default (DISABLE)");
-                                    options.EpPolicy = null;
+                                    Console.WriteLine($"Unknown EP policy: {policyStr}, using default (DEFAULT)");
+                                    options.EpPolicy = ExecutionProviderDevicePolicy.DEFAULT;
                                     break;
                             }
                         }
@@ -213,7 +210,7 @@ namespace WindowsML.Shared
         public static void PrintHelp()
         {
             Console.WriteLine("Options:");
-            Console.WriteLine("  --ep_policy <policy>        Set execution provider policy (NPU, CPU, GPU, DEFAULT, DISABLE)");
+            Console.WriteLine("  --ep_policy <policy>        Set execution provider policy (NPU, CPU, GPU, DEFAULT)");
             Console.WriteLine("  --ep_name <name>            Explicit execution provider name (mutually exclusive with --ep_policy)");
             Console.WriteLine("  --device_type <type>        Optional hardware device type to use when EP supports multiple (e.g. CPU, GPU, NPU)");
             Console.WriteLine("  --perf_mode <mode>          Set EP performance mode (MAX_PERFORMANCE, MAX_EFFICIENCY, DEFAULT)");

--- a/Samples/WindowsML/cpp/CppConsoleDesktop/README.md
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop/README.md
@@ -11,7 +11,7 @@ This sample demonstrates how to use ONNX Runtime in a C++ desktop application, f
 ```
 CppConsoleDesktop.exe [options]
 Options:
-  --ep_policy <policy>  Set execution provider policy (NPU, CPU, GPU, DEFAULT, DISABLE). Default: DISABLE
+  --ep_policy <policy>  Set execution provider policy (NPU, CPU, GPU, DEFAULT). Default: DEFAULT
   --compile            Compile the model
   --download           Download required packages
   --model <path>       Path to input ONNX model (default: SqueezeNet.onnx in executable directory)

--- a/Samples/WindowsML/cs/CSharpConsoleDesktop/README.md
+++ b/Samples/WindowsML/cs/CSharpConsoleDesktop/README.md
@@ -11,7 +11,7 @@ This sample demonstrates how to use ONNX Runtime in a C# desktop application, fo
 ```shell
 CSharpConsoleDesktop.exe [options]
 Options:
-  --ep_policy <policy>          Set execution provider policy (NPU, CPU, GPU, DEFAULT, DISABLE). Default: DISABLE
+  --ep_policy <policy>          Set execution provider policy (NPU, CPU, GPU, DEFAULT). Default: DEFAULT
   --compile                     Compile the model
   --download                    Download required packages
   --model <path>                Path to input ONNX model (default: SqueezeNet.onnx in executable directory)


### PR DESCRIPTION
Remove the DISABLE option from ep_policy in both C# and C++ ArgumentParser. Unknown policies now default to DEFAULT instead of DISABLE. Updated READMEs accordingly.


## Description
The samples require either --ep_policy or --ep_name to be set. The following scenarios fail due to DISABLE:

Scenario 1 : User explicitly passes DISABLE: The user runs --ep_policy DISABLE. The parser sets ep_policy = null and ep_name remains empty. Validation sees neither is set and throws: "Missing EP selection" - even though the user did specify a policy.

Scenario 2 : User passes an invalid value (e.g., a typo): The user runs --ep_policy NPUU. The parser prints "Unknown EP policy: NPUU, using default (DISABLE)" and silently sets ep_policy = null. Validation again throws "Missing EP selection" : masking the real error (an invalid value)

Thus I would propose this resolution

Removed DISABLE as a valid --ep_policy option. If the user's intention is to default to CPU behavior, they can use DEFAULT instead, making DISABLE redundant.
Unknown values now fall back to DEFAULT with a warning so typos and invalid inputs are caught at parse time rather than falling through to a incorrect validation error
