### PR TITLE
[WinAppSDK Experimental CMake Support]: Update versions for sample

### DIFF
--- a/Samples/CMake/CMakeLists.txt
+++ b/Samples/CMake/CMakeLists.txt
@@ -33,8 +33,8 @@ add_nuget_packages(
     LOCK_FILE ${CMAKE_SOURCE_DIR}/packages.lock.json
     FRAMEWORK native
     PACKAGES
-        Microsoft.Windows.CppWinRT 2.0.251203.1
-        Microsoft.WindowsAppSDK.Base 2.0.3-experimental1
+        Microsoft.Windows.CppWinRT 2.0.250303.1
+        Microsoft.WindowsAppSDK.Base 2.0.5-experimental2
         Microsoft.WindowsAppSDK.Foundation 2.0.19-experimental
         Microsoft.WindowsAppSDK.InteractiveExperiences 2.0.11-experimental
         Microsoft.WindowsAppSDK.DWrite 2.0.2-experimental

--- a/Samples/CMake/MetapackageFrameworkDependent/CMakeLists.txt
+++ b/Samples/CMake/MetapackageFrameworkDependent/CMakeLists.txt
@@ -35,7 +35,7 @@ add_nuget_packages(
     LOCK_FILE ${CMAKE_SOURCE_DIR}/packages.lock.json
     FRAMEWORK native
     PACKAGES
-        Microsoft.Windows.CppWinRT 2.0.251203.1
+        Microsoft.Windows.CppWinRT 2.0.250303.1
         Microsoft.WindowsAppSDK 2.0.0-experimental7
         Microsoft.Web.WebView2 1.0.3719.77
 )


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Please include a summary of the change and/or which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The package versions are being updated for the Base and CppWinRT NuGet package. 

## Target Release

Please specify which release this PR should align with. e.g., 1.0, 1.1, 1.1 Preview 1.

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
