### PR TITLE
Add LoRA sample with the WASDK 2.1.3 release

### DIFF
--- a/Samples/WindowsAIFoundry/cs-winui/Directory.Packages.props
+++ b/Samples/WindowsAIFoundry/cs-winui/Directory.Packages.props
@@ -5,6 +5,6 @@
 
   <ItemGroup>
     <!-- Core -->
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental3" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
   </ItemGroup>
 </Project>

--- a/Samples/WindowsAIFoundry/cs-winui/Examples/LanguageModelWithAdapter.md
+++ b/Samples/WindowsAIFoundry/cs-winui/Examples/LanguageModelWithAdapter.md
@@ -1,0 +1,18 @@
+using Microsoft.Windows.AI.Text;
+
+// Load the adapter
+LanguageModelLowRankAdapter lowRankAdapter = LanguageModelLowRankAdapter.CreateFromPath(adapterPath);
+
+LanguageModelOptions options = new LanguageModelOptions
+{
+    LowRankAdapter = lowRankAdapter
+};
+
+// Create the LanguageModel instance
+using LanguageModel languageModel = await LanguageModel.CreateAsync();
+
+// Define a prompt
+string prompt = "Provide the molecular formula for glucose";
+
+// Generate a response using the options
+var result = await languageModel.GenerateResponseAsync(prompt, options);

--- a/Samples/WindowsAIFoundry/cs-winui/Models/LanguageModelModel.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/Models/LanguageModelModel.cs
@@ -166,4 +166,38 @@ internal class LanguageModelModel : IModelManager
 
         return result;
     }
+
+    public IAsyncOperationWithProgress<LanguageModelResponseResult, string>
+    GenerateResponseWithLoraAdapterAndContextAsync(string contextPrompt, string prompt, string filePath)
+    {
+        IAsyncOperationWithProgress<LanguageModelResponseResult, string> response;
+
+        var adapterResult = LanguageModelLowRankAdapter.CreateFromPath(filePath);
+        int hr = adapterResult.ExtendedError?.HResult ?? 0;
+        if (hr != 0)
+        {
+            throw new InvalidOperationException($"Could not create LoRA from the provided file path: 0x{hr:X8}");
+        }
+
+        var options = new LanguageModelOptions {
+            LowRankAdapter = !string.IsNullOrEmpty(filePath) ? adapterResult.LowRankAdapter : null
+        };
+
+        if (contextPrompt != null)
+        {
+            var contentFilterOptions = new ContentFilterOptions();
+            var languageModelContext = Session.CreateContext(contextPrompt, contentFilterOptions);
+            response = Session.GenerateResponseAsync(languageModelContext, prompt, options);
+        }
+        else
+        {
+            response = Session.GenerateResponseAsync(prompt, options);
+        }
+
+        return new AsyncOperationWithProgressAdapter<LanguageModelResponseResult, string, LanguageModelResponseResult, string>(
+            response,
+            result => result /* LanguageModelResponseResult */,
+            progress => progress
+        );
+    }
 }

--- a/Samples/WindowsAIFoundry/cs-winui/Pages/LanguageModelPage.xaml
+++ b/Samples/WindowsAIFoundry/cs-winui/Pages/LanguageModelPage.xaml
@@ -435,6 +435,97 @@
                             Margin="10"/>
                 </StackPanel>
             </Border>
+
+            <!--  Low Rank Adapters  -->
+            <TextBlock Text="Low Rank Adapter (LoRA)"
+                Style="{StaticResource SubtitleTextBlockStyle}"
+                Margin="10"/>
+            <TextBlock Text="LoRAs (Low Rank Adapters) allow developers to customize Phi-Silica in a scalable manner. You can train your own LoRA using the AI Toolkit for Visual Studio Code."
+                Style="{StaticResource BodyTextBlockStyle}"
+                Margin="10"/>
+
+            <TextBlock Text="To compare how LoRA affects Phi-Silica, first select an adapter file in .safetensors format. Then enter a context and prompt into the input below, and press the Generate button to see the inferencing results with and without the LoRA applied."
+                Style="{StaticResource BodyTextBlockStyle}"
+                Margin="10"/>
+
+            <Border Margin="10"
+                CornerRadius="10"
+                BorderThickness="2"
+                BorderBrush="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                Background="{ThemeResource CardBackgroundFillColorSecondary}">
+
+                <StackPanel Orientation="Vertical">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <!-- Select Adapter -->
+                        <TextBlock Text="Adapter" Margin="10" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" />
+                        <TextBox x:Name="AdapterTextBox" Text="{Binding AdapterFilePath, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="True" Margin="0,10" Grid.Row="0" Grid.Column="1" />
+                        <Button Content="Select file" Command="{Binding PickInputAdapterCommand}" Width="100" Margin="10" Grid.Row="0" Grid.Column="2" />
+
+                        <!-- System Prompt/Context -->
+                        <TextBlock Text="Context" Margin="10" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0" />
+                        <TextBox x:Name="ContextTextbox" PlaceholderText="Enter context here" Text="{Binding Context, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="{Binding GenerateResponseWithLoRACommand.IsExecuting}"
+                            Margin="0,10" Grid.Row="1" Grid.Column="1" />
+
+                        <!-- Prompt -->
+                        <TextBlock Text="Prompt" Margin="10" VerticalAlignment="Center" Grid.Row="2" Grid.Column="0" />
+                        <TextBox x:Name="PromptTextBox" PlaceholderText="Enter prompt here" Text="{Binding LoRAPrompt, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="{Binding GenerateResponseWithLoRACommand.IsExecuting}"
+                                 Margin="0,10" Grid.Row="2" Grid.Column="1" />
+                    </Grid>
+
+                    <!-- Response results -->
+                    <Grid Margin="10" Height="Auto">
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="0">
+                            <Button x:Name="GenerateResponseWithoutAdapterButton" Content="Generate Response without Adapter" Command="{Binding GenerateResponseWithoutLoRACommand}" CommandParameter="{Binding LoRAPrompt}" Margin="10"/>
+                            <ProgressRing Visibility="{Binding GenerateResponseWithoutLoRACommand.IsExecuting, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                            <!-- Error -->
+                            <TextBox Header="Generate Response Error:"
+                             Text="{Binding GenerateResponseWithoutLoRACommand.Error.Message}"
+                             IsReadOnly="True"
+                             TextWrapping="Wrap"
+                             Margin="10"
+                             Visibility="{Binding GenerateResponseWithoutLoRACommand.Error, Converter={StaticResource NullToVisibilityConverter}}"/>
+                        </StackPanel>
+                        <TextBox x:Name="WithoutAdapterResult" Header="Result without Adapter" IsReadOnly="True" Text="{Binding ResponseProgressWithoutLoRA}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" TextWrapping="Wrap" AcceptsReturn="True" Grid.Row="1" Grid.Column="0" Margin="10"/>
+
+                        <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1">
+                            <Button x:Name="GenerateResponseWithAdapterButton" Content="Generate Response with Adapter" Command="{Binding GenerateResponseWithLoRACommand}" CommandParameter="{Binding LoRAPrompt}" Margin="10"/>
+                            <ProgressRing Visibility="{Binding GenerateResponseWithLoRACommand.IsExecuting, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            <!-- Error -->
+                            <TextBox Header="Generate Response Error:"
+                             Text="{Binding GenerateResponseWithLoRACommand.Error.Message}"
+                             IsReadOnly="True"
+                             TextWrapping="Wrap"
+                             Margin="10"
+                             Visibility="{Binding GenerateResponseWithLoRACommand.Error, Converter={StaticResource NullToVisibilityConverter}}"/>
+                        </StackPanel>
+                        <TextBox x:Name="WithAdapterResult" Header="Result with Adapter" IsReadOnly="True" Text="{Binding ResponseProgressWithLoRA}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" TextWrapping="Wrap" AcceptsReturn="True" Grid.Row="1" Grid.Column="1" Margin="10"/>
+                    </Grid>
+
+                    <!-- Code sample -->
+                    <controls:CodeBlockControl SourceFile="Examples/LanguageModelWithAdapter.md" Margin="10"/>
+                </StackPanel>
+            </Border>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Samples/WindowsAIFoundry/cs-winui/ViewModels/LanguageModelViewModel.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/ViewModels/LanguageModelViewModel.cs
@@ -22,6 +22,8 @@ internal partial class LanguageModelViewModel : CopilotModelBase<LanguageModelMo
     private string? _textIntelligencePrompt;
     private string? _embeddingPrompt;
     private string? _context;
+    private string? _adapterFilePath;
+    private string? _loraPrompt;
 
     // LanguageModelOptions
     //private LanguageModelSkill _languageModelOptionsSkill = LanguageModelSkill.General;
@@ -51,8 +53,15 @@ internal partial class LanguageModelViewModel : CopilotModelBase<LanguageModelMo
 
     private readonly AsyncCommand<string, LanguageModelEmbeddingVectorResult> _generateEmbeddingVectorCommand;
 
+    private readonly AsyncCommand<object, bool> _pickInputAdapterCommand;
+    private readonly AsyncCommandWithProgress<string, LanguageModelResponseResult, string> _generateResponseWithLoRACommand;
+    private readonly AsyncCommandWithProgress<string, LanguageModelResponseResult, string> _generateResponseWithoutLoRACommand;
+
     private readonly StringBuilder _responseProgress = new();
     private readonly StringBuilder _responseProgressTextIntelligence = new();
+
+    private readonly StringBuilder _responseProgressWithLoRA = new();
+    private readonly StringBuilder _responseProgressWithoutLoRA = new();
 
     public ObservableCollection<SeverityLevel> ContentFilterSeverityLevels { get; } = new ObservableCollection<SeverityLevel> {
         SeverityLevel.Minimum,
@@ -170,10 +179,73 @@ internal partial class LanguageModelViewModel : CopilotModelBase<LanguageModelMo
                 return Session.GenerateEmbeddingVectors(prompt!);
             },
             (prompt) => IsAvailable && !string.IsNullOrEmpty(prompt));
+
+        // GenerateResponseWithLoRA
+        _generateResponseWithLoRACommand = new(
+            prompt =>
+            {
+                _responseProgressWithLoRA.Clear();
+                DispatchPropertyChanged(nameof(ResponseProgressWithLoRA));
+
+                return Session.GenerateResponseWithLoraAdapterAndContextAsync(Context ?? string.Empty, prompt!, AdapterFilePath!);
+            },
+            (prompt) => IsAvailable && !string.IsNullOrEmpty(LoRAPrompt));
+
+        _generateResponseWithLoRACommand.ResultProgressHandler += OnResultProgressWithLoRA;
+        _generateResponseWithLoRACommand.ResultHandler += OnResultWithLoRA;
+
+        // GenerateResponseWithoutLoRA
+        _generateResponseWithoutLoRACommand = new(
+            prompt =>
+            {
+                _responseProgressWithoutLoRA.Clear();
+                DispatchPropertyChanged(nameof(ResponseProgressWithoutLoRA));
+
+                if (string.IsNullOrEmpty(Context))
+                {
+                    return Session.GenerateResponseWithProgressAsync(prompt);
+                }
+                else
+                {
+                    return Session.GenerateResponseWithContextAsync(prompt, Context!);
+                }
+            },
+            (prompt) => IsAvailable && !string.IsNullOrEmpty(LoRAPrompt));
+
+        _generateResponseWithoutLoRACommand.ResultProgressHandler += OnResultProgressWithoutLoRA;
+        _generateResponseWithoutLoRACommand.ResultHandler += OnResultWithoutLoRA;
+
+        _pickInputAdapterCommand = new(async _ =>
+        {
+            var picker = new FileOpenPicker();
+            var window = App.Window;
+            var hwnd = WindowNative.GetWindowHandle(window);
+            InitializeWithWindow.Initialize(picker, hwnd);
+
+            picker.ViewMode = PickerViewMode.List;
+            picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+            picker.FileTypeFilter.Add(".safetensors");
+
+            var file = await picker.PickSingleFileAsync();
+            if (file != null)
+            {
+                await DispatcherQueue.EnqueueAsync(() =>
+                {
+                    AdapterFilePath = file.Path;
+                });
+
+                return true;
+            }
+            return false;
+
+        },
+        _ => true);
     }
 
     public string ResponseProgress => _responseProgress.ToString();
     public string ResponseProgressTextIntelligence => _responseProgressTextIntelligence.ToString();
+    public string ResponseProgressWithLoRA => _responseProgressWithLoRA.ToString();
+    public string ResponseProgressWithoutLoRA => _responseProgressWithoutLoRA.ToString();
 
 
     public string? Prompt
@@ -201,10 +273,22 @@ internal partial class LanguageModelViewModel : CopilotModelBase<LanguageModelMo
         }
     }
 
+    public string? LoRAPrompt
+    {
+        get => _loraPrompt;
+        set => SetField(ref _loraPrompt, value);
+    }
+
     public string? Context
     {
         get => _context;
         set => SetField(ref _context, value);
+    }
+
+    public string? AdapterFilePath
+    {
+        get => _adapterFilePath;
+        set => SetField(ref _adapterFilePath, value);
     }
 
     public string? LanguageModelOptionsTemp
@@ -286,6 +370,11 @@ internal partial class LanguageModelViewModel : CopilotModelBase<LanguageModelMo
 
     public ICommand GenerateResponseWithContextProgressCommand => _generateResponseWithContextProgressCommand;
 
+    public ICommand GenerateResponseWithLoRACommand => _generateResponseWithLoRACommand;
+    public ICommand GenerateResponseWithoutLoRACommand => _generateResponseWithoutLoRACommand;
+
+    public ICommand PickInputAdapterCommand => _pickInputAdapterCommand;
+
     /// <summary>
     /// Exercise the GenerateEmbeddingVector method API for a language model session
     /// </summary>
@@ -313,6 +402,18 @@ internal partial class LanguageModelViewModel : CopilotModelBase<LanguageModelMo
         DispatchPropertyChanged(nameof(ResponseProgressTextIntelligence));
     }
 
+    private void OnResultProgressWithLoRA(object? sender, string progress)
+    {
+        _responseProgressWithLoRA.Append(progress);
+        DispatchPropertyChanged(nameof(ResponseProgressWithLoRA));
+    }
+
+    private void OnResultProgressWithoutLoRA(object? sender, string progress)
+    {
+        _responseProgressWithoutLoRA.Append(progress);
+        DispatchPropertyChanged(nameof(ResponseProgressWithoutLoRA));
+    }
+
     private void OnResult(object? sender, LanguageModelResponseResult finalLanguageModelResponse)
     {
         if ((finalLanguageModelResponse.Status != LanguageModelResponseStatus.Complete)
@@ -335,5 +436,29 @@ internal partial class LanguageModelViewModel : CopilotModelBase<LanguageModelMo
         }
 
         DispatchPropertyChanged(nameof(ResponseProgressTextIntelligence));
+    }
+
+    private void OnResultWithLoRA(object? sender, LanguageModelResponseResult finalLanguageModelResponse)
+    {
+        if ((finalLanguageModelResponse.Status != LanguageModelResponseStatus.Complete)
+              && (finalLanguageModelResponse.Status != LanguageModelResponseStatus.InProgress))
+        {
+            _responseProgressWithLoRA.Clear();
+            _responseProgressWithLoRA.Append($"LanguageModelResponseStatus: {finalLanguageModelResponse.Status}");
+        }
+
+        DispatchPropertyChanged(nameof(ResponseProgressWithLoRA));
+    }
+
+    private void OnResultWithoutLoRA(object? sender, LanguageModelResponseResult finalLanguageModelResponse)
+    {
+        if ((finalLanguageModelResponse.Status != LanguageModelResponseStatus.Complete)
+              && (finalLanguageModelResponse.Status != LanguageModelResponseStatus.InProgress))
+        {
+            _responseProgressWithoutLoRA.Clear();
+            _responseProgressWithoutLoRA.Append($"LanguageModelResponseStatus: {finalLanguageModelResponse.Status}");
+        }
+
+        DispatchPropertyChanged(nameof(ResponseProgressWithoutLoRA));
     }
 }


### PR DESCRIPTION
## Description

Add LoRA samples in the WindowsAISample project as part of the update to consume WASDK 2.1.3.
This is an existing sample ported from the `release/experimental` branch as a result of the LoRA GA to stable.

## Target Release

WASDK 2.1.3.

## Checklist

Note that /azp run currently isn't working for this repo.

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
