### PR TITLE
[Cherry-Pick] Update LoRA samples for WASDK 2.1.4-experimental8

### DIFF
--- a/Samples/WindowsAIFoundry/cs-winui/Directory.Packages.props
+++ b/Samples/WindowsAIFoundry/cs-winui/Directory.Packages.props
@@ -5,6 +5,6 @@
 
   <ItemGroup>
     <!-- Core -->
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental7" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.1.4-experimental8" />
   </ItemGroup>
 </Project>

--- a/Samples/WindowsAIFoundry/cs-winui/Examples/LanguageModelWithAdapter.md
+++ b/Samples/WindowsAIFoundry/cs-winui/Examples/LanguageModelWithAdapter.md
@@ -1,22 +1,18 @@
 using Microsoft.Windows.AI.Text;
-using Microsoft.Windows.AI.Text.Experimental;
+
+// Load the adapter
+LanguageModelLowRankAdapter lowRankAdapter = LanguageModelLowRankAdapter.CreateFromPath(adapterPath);
+
+LanguageModelOptions options = new LanguageModelOptions
+{
+    LowRankAdapter = lowRankAdapter
+};
 
 // Create the LanguageModel instance
 using LanguageModel languageModel = await LanguageModel.CreateAsync();
-
-// Create the LanguageModelExperimental instance
-LanguageModelExperimental languageModelExperimental = new LanguageModelExperimental(languageModel);
-
-// Load the adapter
-LowRankAdaptation loraAdapter = languageModelExperimental.LoadAdapter(loraAdapterPath);
-
-LanguageModelOptionsExperimental options = new LanguageModelOptionsExperimental
-{
-    LoraAdapter = loraAdapter
-};
 
 // Define a prompt
 string prompt = "Provide the molecular formula for glucose";
 
 // Generate a response using the options
-var result = await languageModelExperimental.GenerateResponseAsync(prompt, options);
+var result = await languageModel.GenerateResponseAsync(prompt, options);

--- a/Samples/WindowsAIFoundry/cs-winui/Models/LanguageModelModel.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/Models/LanguageModelModel.cs
@@ -3,7 +3,6 @@
 using Microsoft.Windows.AI;
 using Microsoft.Windows.AI.ContentSafety;
 using Microsoft.Windows.AI.Text;
-using Microsoft.Windows.AI.Text.Experimental;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +18,6 @@ internal class LanguageModelModel : IModelManager
     private TextSummarizer? _sessionTextSummarize;
     private TextRewriter? _sessionTextRewrite;
     private TextToTableConverter? _sessionTextToTable;
-    private LanguageModelExperimental? _languageModelExperimental;
 
     public async Task CreateModelSessionWithProgress(IProgress<double> progress,
                                                             CancellationToken cancellationToken = default)
@@ -43,7 +41,6 @@ internal class LanguageModelModel : IModelManager
         _sessionTextSummarize = new TextSummarizer(_session);
         _sessionTextRewrite = new TextRewriter(_session);
         _sessionTextToTable = new TextToTableConverter(_session);
-        _languageModelExperimental = new LanguageModelExperimental(_session);
 
         progress.Report(1.0); // 100% progress
     }
@@ -52,7 +49,6 @@ internal class LanguageModelModel : IModelManager
     private TextSummarizer SessionTextSummarize => _sessionTextSummarize ?? throw new InvalidOperationException("Text summarizer session was not created yet");
     private TextRewriter SessionTextRewrite => _sessionTextRewrite ?? throw new InvalidOperationException("Text Rewriter session was not created yet");
     private TextToTableConverter SessionTextToTable => _sessionTextToTable ?? throw new InvalidOperationException("TextToTable converter session was not created yet");
-    private LanguageModelExperimental SessionLanguageModelExperimental => _languageModelExperimental ?? throw new InvalidOperationException("Language Model Experimental session was not created yet");
 
     public IAsyncOperationWithProgress<LanguageModelResponseResult, string> 
         GenerateResponseWithProgressAsync(string prompt, CancellationToken cancellationToken = default)
@@ -176,20 +172,26 @@ internal class LanguageModelModel : IModelManager
     {
         IAsyncOperationWithProgress<LanguageModelResponseResult, string> response;
 
-        var loraAdapter = SessionLanguageModelExperimental.LoadAdapter(filePath);
-        var options = new LanguageModelOptionsExperimental {
-            LoraAdapter = !string.IsNullOrEmpty(filePath) ? loraAdapter : null
+        var adapterResult = LanguageModelLowRankAdapter.CreateFromPath(filePath);
+        int hr = adapterResult.ExtendedError?.HResult ?? 0;
+        if (hr != 0)
+        {
+            throw new InvalidOperationException($"Could not create LoRA from the provided file path: 0x{hr:X8}");
+        }
+
+        var options = new LanguageModelOptions {
+            LowRankAdapter = !string.IsNullOrEmpty(filePath) ? adapterResult.LowRankAdapter : null
         };
 
         if (contextPrompt != null)
         {
             var contentFilterOptions = new ContentFilterOptions();
             var languageModelContext = Session.CreateContext(contextPrompt, contentFilterOptions);
-            response = SessionLanguageModelExperimental.GenerateResponseAsync(languageModelContext, prompt, options);
+            response = Session.GenerateResponseAsync(languageModelContext, prompt, options);
         }
         else
         {
-            response = SessionLanguageModelExperimental.GenerateResponseAsync(prompt, options);
+            response = Session.GenerateResponseAsync(prompt, options);
         }
 
         return new AsyncOperationWithProgressAdapter<LanguageModelResponseResult, string, LanguageModelResponseResult, string>(

--- a/Samples/WindowsAIFoundry/cs-winui/Pages/LanguageModelPage.xaml
+++ b/Samples/WindowsAIFoundry/cs-winui/Pages/LanguageModelPage.xaml
@@ -436,15 +436,15 @@
                 </StackPanel>
             </Border>
 
-            <!--  LoRA Adapters  -->
-            <TextBlock Text="Low Rank Adaptation (LoRA)"
+            <!--  Low Rank Adapters  -->
+            <TextBlock Text="Low Rank Adapter (LoRA)"
                 Style="{StaticResource SubtitleTextBlockStyle}"
                 Margin="10"/>
-            <TextBlock Text="LoRA (Low Rank Adaptations) allow developers to customize Phi-Silica in a scalable manner. You can train your own LoRA adapter using the AI Toolkit for Visual Studio Code."
+            <TextBlock Text="LoRAs (Low Rank Adapters) allow developers to customize Phi-Silica in a scalable manner. You can train your own LoRA using the AI Toolkit for Visual Studio Code."
                 Style="{StaticResource BodyTextBlockStyle}"
                 Margin="10"/>
 
-            <TextBlock Text="To compare how a LoRA adapter affects Phi-Silica, first select an adapter file in .safetensors format. Then enter a context and prompt into the input below, and press the Generate button to see the inferencing results with and without the LoRA adapter applied."
+            <TextBlock Text="To compare how LoRA affects Phi-Silica, first select an adapter file in .safetensors format. Then enter a context and prompt into the input below, and press the Generate button to see the inferencing results with and without the LoRA applied."
                 Style="{StaticResource BodyTextBlockStyle}"
                 Margin="10"/>
 
@@ -467,7 +467,7 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <!-- Select LoRA Adapter -->
+                        <!-- Select Adapter -->
                         <TextBlock Text="Adapter" Margin="10" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" />
                         <TextBox x:Name="AdapterTextBox" Text="{Binding AdapterFilePath, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="True" Margin="0,10" Grid.Row="0" Grid.Column="1" />
                         <Button Content="Select file" Command="{Binding PickInputAdapterCommand}" Width="100" Margin="10" Grid.Row="0" Grid.Column="2" />

--- a/Samples/WindowsAIFoundry/cs-winui/ViewModels/LanguageModelViewModel.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/ViewModels/LanguageModelViewModel.cs
@@ -291,12 +291,6 @@ internal partial class LanguageModelViewModel : CopilotModelBase<LanguageModelMo
         set => SetField(ref _adapterFilePath, value);
     }
 
-    //public LanguageModelSkill LanguageModelOptionsSkill
-    //{
-    //    get => _languageModelOptionsSkill;
-    //    set => SetField(ref _languageModelOptionsSkill, value);
-    //}
-
     public string? LanguageModelOptionsTemp
     {
         get => _languageModelOptionsTemp;


### PR DESCRIPTION
## Description

Cherry-picked from #639.
Update LoRA samples in the WindowsAISample project as part of the update to consume WASDK 2.1.4-experimental8.

## Target Release

WASDK 2.1.4-experimental8.

## Checklist

Note that /azp run currently isn't working for this repo.

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
