### PR TITLE
Fix CppConsoleDll README output

### DIFF
--- a/Samples/WindowsML/cpp/CppConsoleDll/ConsoleClient/ConsoleClient.cpp
+++ b/Samples/WindowsML/cpp/CppConsoleDll/ConsoleClient/ConsoleClient.cpp
@@ -6,7 +6,6 @@
 
 // Function pointer type for the DLL exports
 typedef char*(__stdcall* GetOrtVersionStringFunc)();
-typedef char*(__stdcall* GetTestMessageFunc)();
 
 int main()
 {

--- a/Samples/WindowsML/cpp/CppConsoleDll/README.md
+++ b/Samples/WindowsML/cpp/CppConsoleDll/README.md
@@ -44,11 +44,8 @@ After building, you can run ConsoleClient.exe directly. It will:
 
 Expected output:
 ```
-Calling GetTestMessage from DLL...
-Test message: WindowsML DLL is working correctly!
 Calling GetOrtVersionString from DLL...
 ONNX Runtime version: [ONNX Runtime version string]
-DLL functions called successfully!
 ```
 
 ## Architecture Notes


### PR DESCRIPTION
## Summary
- Align the CppConsoleDll README expected output with the actual `GetOrtVersionString` call path.
- Remove the unused `GetTestMessageFunc` typedef from the console client.

## Rationale
ADO 61791036 reports a README/code mismatch around `GetTestMessage`. Instead of adding a new sample DLL export just to satisfy the README, this keeps the sample focused on the real exported function already used by the client.

## Validation
- `git diff --check`
- `MSBuild ConsoleClient.vcxproj /p:Configuration=Release /p:Platform=x64 /p:BuildProjectReferences=false`

Full project-reference build is currently blocked by an existing `WindowsAppRuntimeAutoInitializer.cpp` duplicate object output issue in `WindowsMLWrapper.vcxproj`, unrelated to this README/typedef cleanup.

Fixes ADO 61791036.
