### PR TITLE
Fix TensorRT RTX provider name matching

### DIFF
--- a/Samples/WindowsML/Shared/cpp/PerformanceConfigurator.h
+++ b/Samples/WindowsML/Shared/cpp/PerformanceConfigurator.h
@@ -34,7 +34,7 @@ namespace Shared
             {
                 return GetMiGraphXOptions(mode);
             }
-            if (normalized == "TENSORRTRTXEXECUTIONPROVIDER")
+            if (normalized == "NVTENSORRTRTXEXECUTIONPROVIDER")
             {
                 return GetTensorRtRtxOptions(mode);
             }

--- a/Samples/WindowsML/Shared/cs/PerformanceConfigurator.cs
+++ b/Samples/WindowsML/Shared/cs/PerformanceConfigurator.cs
@@ -17,7 +17,7 @@ namespace WindowsML.Shared
                 "QNNEXECUTIONPROVIDER" => GetQnnOptions(mode),
                 "VITISAIEXECUTIONPROVIDER" => GetVitisAiOptions(mode),
                 "MIGRAPHXEXECUTIONPROVIDER" => GetMiGraphxOptions(mode),
-                "TENSORRTRTXEXECUTIONPROVIDER" => GetTensorRtRtxOptions(mode),
+                "NVTENSORRTRTXEXECUTIONPROVIDER" or "NVTENSORRTRTX" => GetTensorRtRtxOptions(mode),
                 _ => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             };
         }

--- a/Samples/WindowsML/cpp/CppConsoleDesktop.GenAI/GenAIPerformanceConfigurator.h
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop.GenAI/GenAIPerformanceConfigurator.h
@@ -43,7 +43,7 @@ public:
         {
             return GetMiGraphXOptions(mode);
         }
-        if (normalized == "TENSORRTRTXEXECUTIONPROVIDER")
+        if (normalized == "NVTENSORRTRTX")
         {
             return GetTensorRtRtxOptions(mode);
         }


### PR DESCRIPTION
## Summary
- Replace the non-existent `TensorRTRTXExecutionProvider` match with the real Windows TensorRT RTX EP name `NvTensorRTRTXExecutionProvider` in shared helpers.
- Add the ONNX Runtime GenAI canonical provider name `NvTensorRtRtx` for HelloPhi/shared C# and C++ GenAI performance options.
- Cover the C# catalog path, C# GenAI path, C++ catalog path, and C++ GenAI path.

## Rationale
ADO 61791041 is not only a C# catalog mismatch. ONNX Runtime GenAI uses `NvTensorRtRtx` as the provider name, while Windows EP registration/catalog data uses `NvTensorRTRTXExecutionProvider`. The previous `TensorRTRTXExecutionProvider` string is not a real provider name.

## Validation
- `git diff --check`
- `dotnet restore Samples/WindowsML/cs/HelloPhi/HelloPhi.csproj -p:Platform=x64`
- `dotnet build Samples/WindowsML/cs/HelloPhi/HelloPhi.csproj -c Release -p:Platform=x64 --no-restore`
- `MSBuild Samples/WindowsML/cpp/CppConsoleDesktop.GenAI/CppConsoleDesktop.GenAI.vcxproj /p:Configuration=Release /p:Platform=x64 /p:BuildProjectReferences=false`

Notes: HelloPhi restore/build reports existing NU1603 package-resolution warning. C++ GenAI build reports existing WindowsAppRuntimeAutoInitializer duplicate-object warnings, but succeeds.

Fixes ADO 61791041.
