### PR TITLE
Fix CsWinRTAuthoringWinUI.sln build ordering for C++ consumers

### DIFF
--- a/Samples/CustomControls/CsWinRTAuthoringWinUI.sln
+++ b/Samples/CustomControls/CsWinRTAuthoringWinUI.sln
@@ -88,6 +88,11 @@ Global
 		{B71D15EF-F17B-4E8F-B023-08C4E3B32DAB}.Release|x86.Build.0 = Release|Win32
 		{B71D15EF-F17B-4E8F-B023-08C4E3B32DAB}.Release|x86.Deploy.0 = Release|Win32
 	EndGlobalSection
+	GlobalSection(ProjectDependencies) = postSolution
+		{34A4AD19-A703-47F3-B279-E505C6A2A935}.0 = {BCC816DC-0F01-4F0F-8506-DF6AFEFAEA92}
+		{B71D15EF-F17B-4E8F-B023-08C4E3B32DAB}.0 = {BCC816DC-0F01-4F0F-8506-DF6AFEFAEA92}
+		{4B4FA4E7-D50E-4059-A906-6F78F6DFEBCD}.0 = {BCC816DC-0F01-4F0F-8506-DF6AFEFAEA92}
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Description

Adds an explicit sln-level GlobalSection(ProjectDependencies) = postSolution so that `CppApp`, `CppAppUnpackaged`, and `CsApp` are built **after** `WinUIComponentCs`.

The C# projects `CsApp` and `WinUIComponentCs` already share a project reference, so MSBuild orders them correctly. However the two C++ projects consume `WinUIComponentCs` via the projected C++/WinRT header `winrt/WinUIComponentCs.h` and the runtime `.dll` — they cannot use a managed `<ProjectReference>`. Without the sln-level declaration, MSBuild has no ordering signal and can race the C++ compile against the still-missing header/winmd from `WinUIComponentCs`, producing intermittent `C1083: Cannot open include file 'winrt/WinUIComponentCs.h'` failures.

Reproduced locally: reverting just the sln block resurrects the `C1083` error on a clean build; with the block, the C# half (`CsApp`) builds and runs cleanly and dependency ordering is correct end-to-end.

This is a build-correctness fix only — no source code, no API surface, no scenario behavior changes.

## Target Release

N/A — sln/build fix.

## Checklist

- [x] Samples build and run using the Visual Studio versions listed in the Windows development docs.
- [x] Sample builds clean (CsApp verified via `winapp run` end-to-end).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release). _Verified x64/Debug; the change is configuration-agnostic._
- [x] Samples set the minimum supported OS version to Windows 10 version 1809. _(Unchanged.)_
- [x] Sample builds clean with no warnings or errors. _(CsApp; CppApp/CppAppUnpackaged have a preexisting CppWinRT/CsWinRT version mismatch tracked separately.)_

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>