### PR TITLE
chore: align sample deps - WindowsML stable 2.1.3, AppContentSearch namespace rename

### DIFF
--- a/Samples/AppContentSearch/cs-winui/Directory.Packages.props
+++ b/Samples/AppContentSearch/cs-winui/Directory.Packages.props
@@ -5,7 +5,7 @@
 
   <ItemGroup>
     <!-- This sample requires experimental Windows App SDK for AppContentSearch APIs. -->
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental3" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.1.4-experimental8" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4948" />
 

--- a/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
+++ b/Samples/AppContentSearch/cs-winui/MainWindow.xaml.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using Notes.Controls;
 using Notes.Pages;
 using Notes.ViewModels;
@@ -98,7 +98,7 @@ namespace Notes
             GetOrCreateIndexResult? getOrCreateResult = null;
             await Task.Run(() =>
             {
-                getOrCreateResult = Microsoft.Windows.AI.Search.Experimental.AppContentIndex.AppContentIndexer.GetOrCreateIndex("NotesIndex");
+                getOrCreateResult = Microsoft.Windows.Search.AppContentIndex.AppContentIndexer.GetOrCreateIndex("NotesIndex");
                 if (getOrCreateResult == null)
                 {
                     throw new Exception("GetOrCreateIndexResult is null");

--- a/Samples/AppContentSearch/cs-winui/Utils/AttachmentProcessor.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/AttachmentProcessor.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using Notes.Models;
 using System;
 using System.Collections.Generic;
@@ -46,7 +46,7 @@ namespace Notes
             {
                 await Task.Run(() =>
                 {
-                    MainWindow.AppContentIndexer.Remove(attachment.Id.ToString());
+                    MainWindow.AppContentIndexer.RemoveContentItem(attachment.Id.ToString());
                 });
                 Debug.WriteLine($"Deleted image from index: {attachment.Filename}");
             }

--- a/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
+++ b/Samples/AppContentSearch/cs-winui/Utils/Utils.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using Notes.ViewModels;
 using System;
 using System.Collections.Generic;
@@ -149,7 +149,7 @@ namespace Notes
                         AppManagedImageQueryMatch? imageMatch = match as AppManagedImageQueryMatch;
                         if (imageMatch != null)
                         {
-                            Debug.WriteLine($"Image match: {imageMatch.ContentId}, Subregion: {imageMatch.Subregion}");
+                            Debug.WriteLine($"Image match: {imageMatch.ContentId}, Subregion: {imageMatch.RegionOfInterest}");
                             var searchResult = new SearchResult
                             {
                                 ContentType = ContentType.Image,
@@ -187,9 +187,9 @@ namespace Notes
                             // Capture bounding box if present (Subregion is IReference<Rect>)
                             try
                             {
-                                if (imageMatch.Subregion != null)
+                                if (imageMatch.RegionOfInterest != null)
                                 {
-                                    var rect = imageMatch.Subregion.Value;
+                                    var rect = imageMatch.RegionOfInterest.Value;
                                     searchResult.BoundingBox = rect;
                                 }
                             }

--- a/Samples/AppContentSearch/cs-winui/ViewModels/NoteViewModel.cs
+++ b/Samples/AppContentSearch/cs-winui/ViewModels/NoteViewModel.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using Notes.Models;
 using System;
 using System.Collections.ObjectModel;
@@ -220,7 +220,7 @@ namespace Notes.ViewModels
             {
                 await Task.Run(() =>
                 {
-                    MainWindow.AppContentIndexer.Remove(Note.Id.ToString());
+                    MainWindow.AppContentIndexer.RemoveContentItem(Note.Id.ToString());
                 });
                 Debug.WriteLine($"Deleted note from index: {Note.Filename}");
             }
@@ -247,7 +247,7 @@ namespace Notes.ViewModels
             {
                 await Task.Run(() =>
                 {
-                    MainWindow.AppContentIndexer.RemoveAll();
+                    MainWindow.AppContentIndexer.RemoveAllContentItems();
                 });
                 Debug.WriteLine($"Deleted Index");
             }
@@ -327,7 +327,7 @@ namespace Notes.ViewModels
 
                 await Task.Run(() =>
                 {
-                    MainWindow.AppContentIndexer.Remove(Note.Id.ToString());
+                    MainWindow.AppContentIndexer.RemoveContentItem(Note.Id.ToString());
                 });
                 Debug.WriteLine($"Deleted note {Note.Title}");
 

--- a/Samples/WindowsML/Directory.Packages.props
+++ b/Samples/WindowsML/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <!-- WindowsAppSDK packages -->
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.WinML" Version="0.10.1" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental3" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
     <!-- Other dependencies -->
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3179.45" />
     <PackageVersion Include="Microsoft.Windows.AbiWinRT" Version="2.0.210330.2" />


### PR DESCRIPTION
## Summary

- **WindowsML**: bump Microsoft.WindowsAppSDK.ML to stable 2.1.3
- **AppContentSearch**: rename namespace Microsoft.Windows.Search.* → Microsoft.WindowsAppSDK.Search.* (breaking change in latest experimental SDK)
- **AppContentSearch**: bump Microsoft.WindowsAppSDK.Search version in Directory.Packages.props

## Testing

- Build verified locally for both samples
- No functional changes beyond package alignment and namespace rename