### PR TITLE
Fix BA2022 telemetry DLL binplacement on release/experimental

### DIFF
--- a/Samples/Directory.Build.props
+++ b/Samples/Directory.Build.props
@@ -4,6 +4,9 @@
     <!-- Suppress CS8305: Feature is for evaluation purposes only and is subject to change or removal in future updates. -->
     <NoWarn>$(NoWarn);8305</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <AppxLogTelemetryFromSideloadingScript>false</AppxLogTelemetryFromSideloadingScript>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>%(AdditionalOptions) /Qspectre</AdditionalOptions>


### PR DESCRIPTION
Manual port of WindowsAppSDK-Samples PR #609 for Bug 57941660.

Agg pipelines consume the release/experimental branch through SamplesBranch. The fix from PR #609 exists on main but is missing from release/experimental, so VS/MSBuild still binplaces sideloading telemetry DLLs into the AppLifecycle package layout under TelemetryDependencies.

This change adds AppxLogTelemetryFromSideloadingScript=false to Samples/Directory.Build.props on release/experimental to prevent those sideloading telemetry DLLs from being emitted.

Validation plan:

* Run WinAppSDK-Aggregate-PR or Agg Nightly using the patched release/experimental branch.
* Verify AppLifecycle TelemetryDependencies no longer contains:

  * Microsoft.Diagnostics.Tracing.EventSource.dll
  * Microsoft.VisualStudio.Telemetry.dll
  * Microsoft.VisualStudio.RemoteControl.dll
  * Microsoft.VisualStudio.Utilities.Internal.dll
  * Newtonsoft.Json.dll
  * System.Runtime.CompilerServices.Unsafe.dll
* Only after layout validation should BinSkim exclusion cleanup be evaluated separately.
