### PR TITLE
Windows ML: Enable Control Flow Guard for cpp-abi sample (BinSkim BA2008)

### DIFF
--- a/Samples/WindowsML/cpp-abi/CppAbiEPEnumerationSample.vcxproj
+++ b/Samples/WindowsML/cpp-abi/CppAbiEPEnumerationSample.vcxproj
@@ -57,6 +57,8 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\Shared\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- Enable Control Flow Guard (compiler /guard:cf, linker /GUARD:CF) to satisfy SDL/BinSkim BA2008 -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
## Summary

Enable **Control Flow Guard** on the Windows ML `cpp-abi` sample (`CppAbiEPEnumerationSample`) so it passes the SDL/BinSkim **BA2008 (EnableControlFlowGuard)** check.

## Why

The Windows App SDK build's `SamplesCompatTest WindowsML` leg fails at the **`Guardian: Post Analysis`** SDL gate (exit code 8, *"Guardian detected one or more breaking results"*). The only breaking results are BA2008 **errors** on `CppAbiEPEnumerationSample.exe` (x64 + ARM64, Debug + Release) — the binary is compiled without `/guard:cf`.

This was previously masked by a temporary waiver in the consuming repo's `.gdn/OneBranch.gdnsuppress` (*"Temp workaround until Bug:60433419 is properly fixed"*) whose `expirationDate` was **2026-06-30**. Once that lapsed, the finding became an active break:

| WinAppSDK build | Date | Guardian (WindowsML) | Result |
|---|---|---|---|
| 150507810 | 2026-06-23 | `Suppressed: 11`, `Active: 0` | passed |
| 151120282 | 2026-06-30 | `Suppressed: 0`, `Active: 2` | **failed** |

The other WindowsML C++ samples already satisfy BA2008; `cpp-abi` was the only one still missing CFG (no Windows ML sample sets `<ControlFlowGuard>` today).

## Fix

Add `<ControlFlowGuard>Guard</ControlFlowGuard>` to the project's `<ClCompile>`. The C++ targets propagate this to the compiler (`/guard:cf`) and linker (`/GUARD:CF`), which is the canonical way to enable CFG.

```diff
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\Shared\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- Enable Control Flow Guard (compiler /guard:cf, linker /GUARD:CF) to satisfy SDL/BinSkim BA2008 -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
```

## Notes / follow-ups

- Targeting `release/experimental` because that is the branch the failing WinAppSDK mono-build consumes (`SamplesBranch`). The same gap exists on `main` and `release/2.0-stable` and should be ported there.
- Once this merges, the now-stale `cpp-abi` BA2008 entries in the WinAppSDK `OneBranch.gdnsuppress` can be removed in a follow-up.
- Scope is intentionally limited to BA2008 (the breaking rule). The sample's BA2024 (Spectre) waiver also expired on 2026-06-30 but is below the SDL break threshold and does not fail the gate.

Tracking: Bug 60433419.
