### PR TITLE
[Cherry-Pick] Windows ML: Enable Control Flow Guard for cpp-abi sample (BinSkim BA2008)

### DIFF
--- a/Samples/WindowsML/cpp-abi/CppAbiEPEnumerationSample.vcxproj
+++ b/Samples/WindowsML/cpp-abi/CppAbiEPEnumerationSample.vcxproj
@@ -57,6 +57,8 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\Shared\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- Enable Control Flow Guard (compiler /guard:cf, linker /GUARD:CF) to satisfy SDL/BinSkim BA2008 -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
## Summary

Cherry-pick of #648 to `release/2.0-stable`.

Enables **Control Flow Guard** on the Windows ML `cpp-abi` sample (`CppAbiEPEnumerationSample`) so it passes the SDL/BinSkim **BA2008 (EnableControlFlowGuard)** check.

## Why

`CppAbiEPEnumerationSample.exe` is compiled without `/guard:cf`, which trips BinSkim **BA2008** (error severity) in the Windows App SDK build's `SamplesCompatTest WindowsML` SDL gate. It was previously masked by a temporary `.gdn/OneBranch.gdnsuppress` waiver (*"Temp workaround until Bug:60433419 is properly fixed"*) that expired on 2026-06-30. `release/2.0-stable` has the same gap.

## Fix

Adds `<ControlFlowGuard>Guard</ControlFlowGuard>` to the project's `<ClCompile>`; the C++ targets propagate it to the compiler (`/guard:cf`) and linker (`/GUARD:CF`).

```diff
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\Shared\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- Enable Control Flow Guard (compiler /guard:cf, linker /GUARD:CF) to satisfy SDL/BinSkim BA2008 -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
```

Cherry-picked from 26eddcdf (PR #648, merged to `release/experimental`).

Tracking: Bug 60433419.
