### PR TITLE
[Cherry-Pick] Windows ML: CFG/security switches for native cpp samples (BinSkim BA2008)

### DIFF
--- a/Samples/WindowsML/cpp/Directory.Build.props
+++ b/Samples/WindowsML/cpp/Directory.Build.props
@@ -1,4 +1,23 @@
 <Project>
+  <!-- Security settings for Control Flow Guard (CFG) and other mitigations -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) /Qspectre</AdditionalOptions>
+      <!-- /GS Enable Control Flow Guard -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <!-- Setting this to be compatible with CFG -->
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <!-- dynamicbase is required for enabling CFG -->
+      <AdditionalOptions>%(AdditionalOptions) /dynamicbase</AdditionalOptions>
+      <!-- /GS Enable Control Flow Guard -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
+    </Link>
+  </ItemDefinitionGroup>
+
   <PropertyGroup>
     <!-- C++ specific settings only -->
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>


### PR DESCRIPTION
## Summary

Cherry-pick of #577/#599 (commit `c7006675`) to `release/2.0-stable`.

Adds the CFG/security switches to `Samples/WindowsML/cpp/Directory.Build.props` so the native WindowsML C++ samples under `cpp/` build with **Control Flow Guard**, satisfying SDL/BinSkim **BA2008 (EnableControlFlowGuard)**.

## Why

The standalone aggregator build (ProjectReunion `WinAppSDK-Build-PR` #151264964, samples from `release/2.0-stable`) fails BinSkim with **14 BA2008 errors** on the `cpp/` samples: `ConsoleClient`, `CppConsoleDesktop` (+ `.FrameworkDependent`, `.GenAI`, `.SelfContained`), `CppResnetBuildDemo`, and `WindowsMLWrapper.dll`.

These projects inherit their CFG settings from `Samples/WindowsML/cpp/Directory.Build.props`. That security block exists on `release/experimental` (added by #577/#599) but was never brought to `release/2.0-stable`, so the `cpp/` binaries build without `/guard:cf`.

(The separate `cpp-abi` sample was already fixed on this branch by #651 and passes BA2008.)

## Change

Ports the security `ItemDefinitionGroup` (ControlFlowGuard on ClCompile + Link, `/Qspectre`, `/dynamicbase`, `CETCompat`, `DebugInformationFormat=OldStyle`) — identical to `release/experimental`.

Cherry-picked from `c7006675`.
