### PR TITLE
[Cherry-Pick] Windows ML: Enable Control Flow Guard for cpp-abi sample (BinSkim BA2008)

### DIFF
--- a/Samples/WindowsML/cpp-abi/CppAbiEPEnumerationSample.vcxproj
+++ b/Samples/WindowsML/cpp-abi/CppAbiEPEnumerationSample.vcxproj
@@ -52,6 +52,8 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\Shared\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- Enable Control Flow Guard (compiler /guard:cf, linker /GUARD:CF) to satisfy SDL/BinSkim BA2008 -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
## Summary

Cherry-pick of #648 (commit `26eddcdf`) to `main`.

Enables **Control Flow Guard** on the Windows ML `cpp-abi` sample (`CppAbiEPEnumerationSample`) so it satisfies SDL/BinSkim **BA2008 (EnableControlFlowGuard)**.

## Why

`main` has the `cpp/Directory.Build.props` CFG block (from #577) that covers the `cpp/` samples, but the separate `cpp-abi` project (which is **not** under `cpp/` and doesn't inherit those props) was never given CFG on `main`. #648 fixed it on `release/experimental`; this brings `main` to parity.

## Change

Adds `<ControlFlowGuard>Guard</ControlFlowGuard>` to the project's `<ClCompile>`; the C++ targets propagate it to the compiler (`/guard:cf`) and linker (`/GUARD:CF`).

```diff
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\Shared\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- Enable Control Flow Guard (compiler /guard:cf, linker /GUARD:CF) to satisfy SDL/BinSkim BA2008 -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
```

Cherry-picked from `26eddcdf` (PR #648).
