### PR TITLE
WindowsML cpp-abi: enable Control Flow Guard to fix BinSkim BA2008 (release/2.0-experimental)

### DIFF
--- a/Samples/WindowsML/cpp-abi/CppAbiEPEnumerationSample.vcxproj
+++ b/Samples/WindowsML/cpp-abi/CppAbiEPEnumerationSample.vcxproj
@@ -57,6 +57,8 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\Shared\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- Enable Control Flow Guard (compiler /guard:cf, linker /GUARD:CF) to satisfy SDL/BinSkim BA2008 -->
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Cherry-picks the CFG fix (#648, commit c4bd030b) onto `release/2.0-experimental`. `CppAbiEPEnumerationSample.exe` is built without `/guard:cf`, so BinSkim BA2008 (error severity) breaks the SamplesCompat SDL gate on every WinAppSDK 2.0-experimental build (e.g. the 2.3.2-ci.experimental autosnap, build 152606950).

The fix already shipped to `main`, `release/2.0-stable`, and `release/experimental`; it was never ported to `release/2.0-experimental`, which is the branch the aggregator's experimental samples-compat job builds (`SamplesBranch: release/2.0-experimental`). This closes that gap.

Original fix authored by @kythant; parallel fix (`e32efe4d`) by @v-arlysenko.
