### PR TITLE
Build C++ samples with C++20 to fix STL1011, and map VS 2026 to v145

### DIFF
--- a/Samples/AppLifecycle/Activation/cpp/cpp-win32-packaged/CppWinMainActivation/CppWinMainActivation.vcxproj
+++ b/Samples/AppLifecycle/Activation/cpp/cpp-win32-packaged/CppWinMainActivation/CppWinMainActivation.vcxproj
@@ -129,7 +129,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -144,7 +144,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -159,7 +159,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -172,7 +172,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -187,7 +187,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -204,7 +204,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Samples/AppLifecycle/Activation/cpp/cpp-win32-unpackaged/CppWinMainActivation/CppWinMainActivation.vcxproj
+++ b/Samples/AppLifecycle/Activation/cpp/cpp-win32-unpackaged/CppWinMainActivation/CppWinMainActivation.vcxproj
@@ -129,7 +129,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -144,7 +144,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -159,7 +159,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -172,7 +172,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -187,7 +187,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -204,7 +204,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Samples/AppLifecycle/EnvironmentVariables/cpp-win32-unpackaged/CppWinMainEnv/CppWinMainEnv.vcxproj
+++ b/Samples/AppLifecycle/EnvironmentVariables/cpp-win32-unpackaged/CppWinMainEnv/CppWinMainEnv.vcxproj
@@ -130,7 +130,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -145,7 +145,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -160,7 +160,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -173,7 +173,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -188,7 +188,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -205,7 +205,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Samples/AppLifecycle/Instancing/cpp/cpp-win32-packaged/CppWinMainInstancing/CppWinMainInstancing.vcxproj
+++ b/Samples/AppLifecycle/Instancing/cpp/cpp-win32-packaged/CppWinMainInstancing/CppWinMainInstancing.vcxproj
@@ -157,7 +157,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -170,7 +170,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -185,7 +185,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -202,7 +202,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Samples/AppLifecycle/Instancing/cpp/cpp-win32-unpackaged/CppWinMainInstancing/CppWinMainInstancing.vcxproj
+++ b/Samples/AppLifecycle/Instancing/cpp/cpp-win32-unpackaged/CppWinMainInstancing/CppWinMainInstancing.vcxproj
@@ -157,7 +157,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -170,7 +170,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -185,7 +185,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -202,7 +202,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Samples/AppLifecycle/StateNotifications/cpp/cpp-win32-packaged/CppWinMainState/CppWinMainState.vcxproj
+++ b/Samples/AppLifecycle/StateNotifications/cpp/cpp-win32-packaged/CppWinMainState/CppWinMainState.vcxproj
@@ -130,7 +130,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -147,7 +147,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -164,7 +164,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -179,7 +179,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -196,7 +196,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -215,7 +215,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Samples/AppLifecycle/StateNotifications/cpp/cpp-win32-unpackaged/CppWinMainState/CppWinMainState.vcxproj
+++ b/Samples/AppLifecycle/StateNotifications/cpp/cpp-win32-unpackaged/CppWinMainState/CppWinMainState.vcxproj
@@ -130,7 +130,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -147,7 +147,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -164,7 +164,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -179,7 +179,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -196,7 +196,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -215,7 +215,7 @@
       <ConformanceMode>
       </ConformanceMode>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Samples/Build.Common.Cpp.props
+++ b/Samples/Build.Common.Cpp.props
@@ -13,11 +13,13 @@ Licensed under the MIT License. See LICENSE in the project root for license info
       v142 is the Visual Studio 2017 toolset. (15.0)
       v142 is the Visual Studio 2019 toolset. (16.0)
       v143 is the Visual Studio 2022 toolset. (17.0)
+      v145 is the Visual Studio 2026 toolset. (18.0)
     -->
     <AutoDetectedPlatformToolset Condition="'$(BuildToolVersion)'=='14'">v140</AutoDetectedPlatformToolset>
     <AutoDetectedPlatformToolset Condition="'$(BuildToolVersion)'=='15'">v141</AutoDetectedPlatformToolset>
     <AutoDetectedPlatformToolset Condition="'$(BuildToolVersion)'=='16'">v142</AutoDetectedPlatformToolset>
     <AutoDetectedPlatformToolset Condition="'$(BuildToolVersion)'=='17'">v143</AutoDetectedPlatformToolset>
+    <AutoDetectedPlatformToolset Condition="'$(BuildToolVersion)'=='18'">v145</AutoDetectedPlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="EmptyDefaultPlatformToolset">
     <DefaultPlatformToolset Condition=" '$(DefaultPlatformToolset)' == '' ">$(AutoDetectedPlatformToolset)</DefaultPlatformToolset>

--- a/Samples/Directory.Build.props
+++ b/Samples/Directory.Build.props
@@ -7,6 +7,7 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>%(AdditionalOptions) /Qspectre</AdditionalOptions>
       <!-- /GS Enable Control Flow Guard -->
       <ControlFlowGuard>Guard</ControlFlowGuard>

--- a/Samples/Islands/UXFrameworksOnIslands/AutomationFragment.cpp
+++ b/Samples/Islands/UXFrameworksOnIslands/AutomationFragment.cpp
@@ -74,7 +74,7 @@ void AutomationFragment::RemoveChild(
         m_children.begin(), m_children.end(), [&child](auto const& childEntry)
     {
         // See if we find a matching child entry in our children.
-        return (childEntry.as<::IUnknown>().get() == child.as<::IUnknown>().get());
+        return (childEntry.template as<::IUnknown>().get() == child.as<::IUnknown>().get());
     });
 
     // We cannot remove a child that isn't ours.

--- a/Samples/Islands/UXFrameworksOnIslands/TextVisual.h
+++ b/Samples/Islands/UXFrameworksOnIslands/TextVisual.h
@@ -13,6 +13,13 @@ template<class T>
 class TextVisual final : public D2DSprite<T>
 {
 public:
+    // D2DSprite<T> is a dependent base, so its members are not found by unqualified
+    // lookup and have to be introduced explicitly.
+    using typename D2DSprite<T>::ContainerVisual;
+    using D2DSprite<T>::GetBackgroundColor;
+    using D2DSprite<T>::GetVisual;
+    using D2DSprite<T>::InvalidateContent;
+
     TextVisual(Output<T> const& output, std::wstring&& text);
 
     TextVisual(

--- a/Samples/Widgets/cpp-win32-packaged/SampleWidgetProviderApp/SampleWidgetProviderApp.vcxproj
+++ b/Samples/Widgets/cpp-win32-packaged/SampleWidgetProviderApp/SampleWidgetProviderApp.vcxproj
@@ -8,6 +8,7 @@
   <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.10.0.22621.3233\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.10.0.22621.3233\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.2.0.221104.6\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.2.0.221104.6\build\native\Microsoft.Windows.CppWinRT.props')" />
   <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.2.0.210806.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.2.0.210806.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\..\..\Build.Common.Cpp.props" Condition="Exists('..\..\..\Build.Common.Cpp.props')"/>
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>


### PR DESCRIPTION
## Description

Fixes the C++ samples failing to build on current toolsets: `error STL1011` from the deprecated `/await` switch, `error MSB8020` on Visual Studio 2026, and the template conformance errors in `UXFrameworksOnIslands`.

Fixes ADO 62276972.

## Root cause

**STL1011** — `Microsoft.Windows.CppWinRT.props` defaults `ClCompile.LanguageStandard` to `stdcpp17` when a project does not set one, and `Microsoft.Windows.CppWinRT.targets` then adds `/await` for `stdcpp17`. Under `/await`, `winrt/base.h` takes the experimental branch and includes the `experimental/coroutine` header, which now hard-errors. This hits every C++/WinRT sample, whether or not it uses coroutines.

**MSB8020** — `Build.Common.Cpp.props` has no `BuildToolVersion` entry for VS 2026, so `PlatformToolset` is assigned an empty value and MSBuild falls back to `v100`.

**C2061 / C4864** — `UXFrameworksOnIslands` relies on unqualified lookup finding members of a dependent base, which current MSVC rejects under two-phase lookup.

## Fix

Set `LanguageStandard` to `stdcpp20` in `Samples/Directory.Build.props`, and map `BuildToolVersion` 18 to `v145` in `Samples/Build.Common.Cpp.props`.

**Why 8 files for the language standard:** `Directory.Build.props` is imported before the project body, so the 7 projects that set their own `stdcpp17` overwrite it — they would still get `/await` and still fail STL1011, so they are updated individually. The other 33 set no value of their own, so they inherit it and need no edit.

`SampleWidgetProviderApp` was the only C++ sample that neither imported `Build.Common.Cpp.props` nor set its own `PlatformToolset`, so it now imports the shared props like the other C++ samples.

For `UXFrameworksOnIslands`: `TextVisual<T>` derives from `D2DSprite<T>`, so `ContainerVisual`, `GetVisual`, `GetBackgroundColor` and `InvalidateContent` are introduced with using-declarations, which also resolves the cascading `C2065`/`C3861`/`C2672` errors in `TextVisual.cpp` and in the `InsertTextVisual` callers. In `AutomationFragment::RemoveChild` the lambda parameter is dependent, so the member template call needs the `template` disambiguator. These are pre-existing conformance gaps unrelated to the language standard — they reproduce at `stdcpp17` with STL1011 suppressed.


## Validation

Built **all 41 C++/WinRT sample solutions** at x64 Release on Visual Studio 2026 (MSVC 14.51.36231), before and after the change, with no command-line overrides:

| | Built | Failed |
|---|---|---|
| `main` | 15 | 26 |
| this PR | 32 | 9 |


Runtime: the rebuilt unpackaged console samples launch without crashing and reach the Windows App SDK bootstrapper. A full functional run was not possible on the validation machine because the matching Windows App Runtime is not installed there.

## Target Release

1.8

## Checklist

Note that /azp run currently isn't working for this repo.

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [x] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [x] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples

Builds were run at x64 Release; x86/ARM64 and Debug are unverified. The change is a language-standard switch applied uniformly across all configurations, so it is not configuration-specific.