### PR TITLE
Use WinAppSDK-SampleDeps as the single Samples source

### DIFF
--- a/Samples/BackgroundTask/InProc BackgroundTask/cpp-winui/nuget.config
+++ b/Samples/BackgroundTask/InProc BackgroundTask/cpp-winui/nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/Samples/WindowsML/nuget.config
+++ b/Samples/WindowsML/nuget.config
@@ -4,9 +4,7 @@
         <!-- Set the packages directory for packages.config projects (C++ projects) -->
         <add key="repositoryPath" value="packages" />
     </config>
-    <packageSources>
-        <!-- Add local packages directory as a source -->
-        <add key="localpackages" value="../localpackages" />
-    </packageSources>
-    <!-- Package sources are inherited from parent NuGet.Config -->
+    <!-- Run SamplesFeed-Hydration.yml whenever samples are updated. -->
+    <!-- Do not add package sources other than WinAppSDK-SampleDeps or localpackages. -->
+    <!-- Package sources are inherited from Samples/nuget.config. -->
 </configuration>

--- a/Samples/nuget.config
+++ b/Samples/nuget.config
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- This file was added for building in the CI pipeline. It is not used when building locally. -->
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageRestore>
         <!-- Allow NuGet to download missing packages -->
@@ -9,23 +8,9 @@
     </packageRestore>
     <packageSources>
         <clear />
-        <!-- publicly accessible NuGet feed -->
+        <!-- Run SamplesFeed-Hydration.yml whenever samples are updated. -->
+        <!-- Do not add package sources other than WinAppSDK-SampleDeps or localpackages. -->
+        <!-- Public Azure Artifacts feed used by both external developers and CI. -->
         <add key="WinAppSDK-SampleDeps" value="https://pkgs.dev.azure.com/shine-oss/WinAppSDK-Samples/_packaging/WinAppSDK-SampleDeps/nuget/v3/index.json" />
-
-        <!-- a local directory to allow testing nupkg files without pushing to a remote feed -->
-        <add key="localpackages" value="localpackages" />
-        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
-
-    <packageSourceMapping>
-        <packageSource key="WinAppSDK-SampleDeps">
-            <package pattern="Microsoft.WindowsAppSDK.*" />
-        </packageSource>
-        <packageSource key="nuget.org">
-            <package pattern="System.*" />
-            <package pattern="Microsoft.*" />
-        </packageSource>
-    </packageSourceMapping>
-
-    <disabledPackageSources />
 </configuration>


### PR DESCRIPTION
## Summary
- make the public `WinAppSDK-SampleDeps` feed the only checked-in package source
- remove direct nuget.org access and package source mapping
- remove the nested BackgroundTask nuget.org override
- make WindowsML inherit the root Samples package source
- document that Samples updates require hydration and that no feed other than `WinAppSDK-SampleDeps` or an explicit localpackages override should be introduced

## Dependency and merge order
This PR is stacked on #658 and currently targets its topic branch so the diff contains only the NuGet configuration migration.

1. Merge #658.
2. Retarget this PR to `main`.
3. Merge this PR only after the successful hydration/anonymous-validation run [386957](https://dev.azure.com/shine-oss/WinAppSDK-Samples/_build/results?buildId=386957).

The feed had zero active upstreams after that run.