### PR TITLE
Retry feed upstream state changes

### DIFF
--- a/eng/SetSamplesFeedUpstream.ps1
+++ b/eng/SetSamplesFeedUpstream.ps1
@@ -43,28 +43,38 @@ $body = @{
     upstreamSources = $upstreamSources
 } | ConvertTo-Json -Depth 4
 
-Invoke-RestMethod `
-    -Method Patch `
-    -Uri $feedUri `
-    -Headers $headers `
-    -ContentType "application/json" `
-    -Body $body | Out-Null
-
-$feed = Invoke-RestMethod -Method Get -Uri $feedUri -Headers $headers
-$activeUpstreams = @(
-    $feed.upstreamSources | Where-Object {
-        !$_.PSObject.Properties["deletedDate"] -or !$_.deletedDate
-    }
-)
-
-if ($Action -eq "Enable" -and $activeUpstreams.Count -ne 1)
+for ($attempt = 1; $attempt -le 5; $attempt++)
 {
-    throw "Expected one active upstream after enabling NuGet Gallery, but found $($activeUpstreams.Count)."
+    Invoke-RestMethod `
+        -Method Patch `
+        -Uri $feedUri `
+        -Headers $headers `
+        -ContentType "application/json" `
+        -Body $body | Out-Null
+
+    $feed = Invoke-RestMethod -Method Get -Uri $feedUri -Headers $headers
+    $activeUpstreams = @(
+        $feed.upstreamSources | Where-Object {
+            !$_.PSObject.Properties["deletedDate"] -or !$_.deletedDate
+        }
+    )
+
+    $expectedCount = if ($Action -eq "Enable") { 1 } else { 0 }
+    if ($activeUpstreams.Count -eq $expectedCount)
+    {
+        break
+    }
+
+    if ($attempt -lt 5)
+    {
+        Write-Warning "$Action attempt $attempt left $($activeUpstreams.Count) active upstreams; retrying."
+        Start-Sleep -Seconds 5
+    }
 }
 
-if ($Action -eq "Disable" -and $activeUpstreams.Count -ne 0)
+if ($activeUpstreams.Count -ne $expectedCount)
 {
-    throw "Expected no active upstreams after disabling NuGet Gallery, but found $($activeUpstreams.Count)."
+    throw "Expected $expectedCount active upstreams after $Action, but found $($activeUpstreams.Count)."
 }
 
 Write-Host "$Action completed for feed '$($feed.name)'. Active upstream count: $($activeUpstreams.Count)."


### PR DESCRIPTION
## Summary
- retry Azure Artifacts upstream state changes when immediate verification still reports the previous state
- reapply the PATCH up to five times with a bounded delay
- preserve the existing hard failure if the requested state cannot be reached

## Failure addressed
[Hydration run 387300](https://dev.azure.com/shine-oss/WinAppSDK-Samples/_build/results?buildId=387300) completed package hydration but failed its `always()` cleanup because the first disable PATCH left one active NuGet Gallery upstream. The upstream was subsequently disabled manually and the feed was confirmed to have zero active upstreams.

## Validation
- a mocked disable operation that retains one active upstream after the first PATCH succeeds on the second attempt
- [run 387301](https://dev.azure.com/shine-oss/WinAppSDK-Samples/_build/results?buildId=387301) hydrated the complete `main` package closure, completed cleanup, and passed anonymous validation; the feed has zero active upstreams