### PR TITLE
Add back Video Super Res sample, update to WASDK 2.4.0

### DIFF
--- a/Samples/WindowsAIFoundry/cs-winui/Directory.Packages.props
+++ b/Samples/WindowsAIFoundry/cs-winui/Directory.Packages.props
@@ -5,6 +5,6 @@
 
   <ItemGroup>
     <!-- Core -->
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
   </ItemGroup>
 </Project>

--- a/Samples/WindowsAIFoundry/cs-winui/Examples/VideoScaler.md
+++ b/Samples/WindowsAIFoundry/cs-winui/Examples/VideoScaler.md
@@ -1,0 +1,14 @@
+var inputImageBuffer = ImageBuffer.CreateForBuffer(
+            inputBuffer.AsBuffer(),
+            ImageBufferPixelFormat.Bgr8,
+            width,
+            height,
+            width * 3);
+var outputImageBuffer = ImageBuffer.CreateForBuffer(
+            outputBuffer.AsBuffer(),
+            ImageBufferPixelFormat.Bgr8,
+            width,
+            height,
+            width * 3);
+
+var result = model.ScaleFrame(inputImageBuffer, outputImageBuffer, new VideoScalerOptions());

--- a/Samples/WindowsAIFoundry/cs-winui/Examples/VideoScaler.md
+++ b/Samples/WindowsAIFoundry/cs-winui/Examples/VideoScaler.md
@@ -11,4 +11,4 @@ var outputImageBuffer = ImageBuffer.CreateForBuffer(
             height,
             width * 3);
 
-var result = model.ScaleFrame(inputImageBuffer, outputImageBuffer, new VideoScalerOptions());
+var result = model.ScaleImageBuffer(inputImageBuffer, outputImageBuffer, null);

--- a/Samples/WindowsAIFoundry/cs-winui/Examples/VideoScalerInit.md
+++ b/Samples/WindowsAIFoundry/cs-winui/Examples/VideoScalerInit.md
@@ -1,0 +1,9 @@
+var catalog = ExecutionProviderCatalog.GetDefault();
+await catalog.EnsureAndRegisterCertifiedAsync();
+
+if (VideoScaler.GetReadyState() == AIFeatureReadyState.NotReady)
+{
+    var videoScalerDeploymentOperation = VideoScaler.EnsureReadyAsync();
+    await videoScalerDeploymentOperation;
+}
+VideoScaler _session = await VideoScaler.CreateAsync();

--- a/Samples/WindowsAIFoundry/cs-winui/MainWindow.xaml
+++ b/Samples/WindowsAIFoundry/cs-winui/MainWindow.xaml
@@ -38,6 +38,9 @@
             <NavigationViewItem Content="Image Object Remover"
                     Tag="ImageObjectRemover"
                     Icon="Cut"/>
+            <NavigationViewItem Content="Video Scaler"
+                    Tag="VideoScaler"
+                    Icon="Video"/>
         </NavigationView.MenuItems>
         <Frame Margin="0,0,0,0"
                 x:Name="rootFrame"/>

--- a/Samples/WindowsAIFoundry/cs-winui/MainWindow.xaml.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/MainWindow.xaml.cs
@@ -44,6 +44,9 @@ public sealed partial class MainWindow : Window
                 case "ImageObjectRemover":
                     rootFrame.Navigate(typeof(ImageObjectRemoverPage));
                     break;
+                case "VideoScaler":
+                    rootFrame.Navigate(typeof(VideoScalerPage));
+                    break;
             }
         }
     }

--- a/Samples/WindowsAIFoundry/cs-winui/Models/VideoScalerModel.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/Models/VideoScalerModel.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Graphics.Imaging;
+using Microsoft.Windows.AI;
+using Microsoft.Windows.AI.MachineLearning;
+using Microsoft.Windows.AI.Video;
+using Microsoft.Windows.Management.Deployment;
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Graphics.Imaging;
+using Windows.Media;
+using Windows.Storage.Streams;
+using WindowsAISample.Models.Contracts;
+using WindowsAISample.Util;
+
+namespace WindowsAISample.Models;
+
+internal class VideoScalerModel : IModelManager
+{
+    private VideoScaler? _session;
+
+    private VideoScaler Session => _session ?? throw new InvalidOperationException("Video Scaler session was not created yet");
+
+    public async Task CreateModelSessionWithProgress(IProgress<double> progress, CancellationToken cancellationToken = default)
+    {
+        var catalog = ExecutionProviderCatalog.GetDefault();
+        await catalog.EnsureAndRegisterCertifiedAsync();
+
+        progress.Report(0.5);
+
+        var readyState = VideoScaler.GetReadyState();
+        if (readyState == AIFeatureReadyState.NotSupportedOnCurrentSystem)
+        {
+            throw new InvalidOperationException("VideoScaler not supported on current system (hardware requirements not met)");
+        }
+
+        if (readyState == AIFeatureReadyState.NotReady)
+        {
+            var videoScalerDeploymentOperation = VideoScaler.EnsureReadyAsync();
+            videoScalerDeploymentOperation.Progress = (_, modelDeploymentProgress) =>
+            {
+                progress.Report(0.5 + (modelDeploymentProgress * 0.25) % 0.25);  // all progress is within 50% and 75%
+            };
+            using var _ = cancellationToken.Register(() => videoScalerDeploymentOperation.Cancel());
+            await videoScalerDeploymentOperation;
+        }
+        else
+        {
+            progress.Report(0.75);
+        }
+        _session = await VideoScaler.CreateAsync();
+        progress.Report(1.0); // 100% progress
+    }
+
+    public SoftwareBitmap ScaleVideoFrame(SoftwareBitmap inputFrame)
+    {
+        ImageBuffer inputImageBuffer = inputFrame.ConvertToBgr8ImageBuffer();
+        var size = (uint)(inputFrame.PixelWidth * inputFrame.PixelHeight * 3);
+        IBuffer outputBuffer = new global::Windows.Storage.Streams.Buffer(size);
+        outputBuffer.Length = size;
+        ImageBuffer outputImageBuffer = ImageBuffer.CreateForBuffer(
+            outputBuffer,
+            ImageBufferPixelFormat.Bgr8,
+            inputFrame.PixelWidth,
+            inputFrame.PixelHeight,
+            inputFrame.PixelWidth * 3);
+        var result = Session.ScaleFrame(inputImageBuffer, outputImageBuffer, new VideoScalerOptions());
+        if (result.Status != ScaleFrameStatus.Success)
+        {
+            throw new Exception($"Failed to scale video frame: {result.Status}");
+        }
+
+        return outputImageBuffer.ConvertBgr8ImageBufferToBgra8SoftwareBitmap();
+    }
+}

--- a/Samples/WindowsAIFoundry/cs-winui/Models/VideoScalerModel.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/Models/VideoScalerModel.cs
@@ -67,8 +67,8 @@ internal class VideoScalerModel : IModelManager
             inputFrame.PixelWidth,
             inputFrame.PixelHeight,
             inputFrame.PixelWidth * 3);
-        var result = Session.ScaleFrame(inputImageBuffer, outputImageBuffer, new VideoScalerOptions());
-        if (result.Status != ScaleFrameStatus.Success)
+        var result = Session.ScaleImageBuffer(inputImageBuffer, outputImageBuffer, null);
+        if (result.Status != VideoScalerStatus.Success)
         {
             throw new Exception($"Failed to scale video frame: {result.Status}");
         }

--- a/Samples/WindowsAIFoundry/cs-winui/Pages/VideoScalerPage.xaml
+++ b/Samples/WindowsAIFoundry/cs-winui/Pages/VideoScalerPage.xaml
@@ -1,0 +1,84 @@
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+<Page
+    x:Class="WindowsAISample.Pages.VideoScalerPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:WindowsAISample"
+    xmlns:pages="using:WindowsAISample.Pages"
+    xmlns:controls="using:WindowsAISample.Controls"
+    xmlns:models="using:WindowsAISample.ViewModels"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    d:DataContext="{d:DesignInstance Type=models:VideoScalerViewModel}"
+    DataContext="{Binding VideoScaler}"
+    NavigationCacheMode="Enabled">
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto"
+            HorizontalAlignment="Stretch">
+        <StackPanel Orientation="Vertical"
+                HorizontalAlignment="Stretch"
+                Margin="20">
+
+            <TextBlock Text="Video Scaler"
+                    Style="{StaticResource TitleTextBlockStyle}"
+                    Margin="10"/>
+            <TextBlock Text="The Video Scaler API lets you scale video frames to better resolution using an AI model."
+                    Style="{StaticResource BodyTextBlockStyle}"
+                    Margin="10"/>
+
+            <controls:ModelInitializationControl SourceFile="Examples/VideoScalerInit.md"/>
+
+            <TextBlock Text="Scale Video Frame"
+                    Style="{StaticResource SubtitleTextBlockStyle}"
+                    Margin="10"/>
+            <TextBlock Text="Once the model is initialized, load a video frame and click the button below to scale it up."
+                    Style="{StaticResource BodyTextBlockStyle}"
+                    Margin="10"/>
+
+            <Border Margin="10"
+                    CornerRadius="10"
+                    BorderThickness="2"
+                    BorderBrush="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                    Background="{ThemeResource CardBackgroundFillColorDefault}">
+                <StackPanel Orientation="Vertical">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Orientation="Vertical"
+                                Margin="10">
+                            <TextBlock Margin="10"
+                                    Style="{StaticResource BodyStrongTextBlockStyle}">Input image</TextBlock>
+                            <Image Source="{Binding InputSource}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Vertical"
+                                Margin="10"
+                                Grid.Column="1">
+                            <TextBlock Margin="10"
+                                    Style="{StaticResource BodyStrongTextBlockStyle}">Output image</TextBlock>
+                            <Image x:Name="OutputImage"
+                                    Source="{Binding ScaleCommand.Result}"/>
+                        </StackPanel>
+                    </Grid>
+                    <StackPanel Orientation="Horizontal"
+                            HorizontalAlignment="Left"
+                            Margin="10">
+                        <Button Margin="0,0,10,0"
+                                Command="{Binding PickInputImageCommand}">Load Image</Button>
+
+                        <Button Margin="0,0,10,0"
+                                Command="{Binding ScaleCommand}">Scale Image</Button>
+                        <ProgressRing Visibility="{Binding ScaleCommand.IsExecuting, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                    </StackPanel>
+                    <controls:CodeBlockControl SourceFile="Examples/VideoScaler.md"
+                            Margin="10"/>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Samples/WindowsAIFoundry/cs-winui/Pages/VideoScalerPage.xaml.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/Pages/VideoScalerPage.xaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml.Controls;
+
+namespace WindowsAISample.Pages;
+
+public sealed partial class VideoScalerPage : Page
+{
+    public VideoScalerPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Samples/WindowsAIFoundry/cs-winui/Util/SoftwareBitmapExtensions.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/Util/SoftwareBitmapExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using Microsoft.Graphics.Imaging;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -94,5 +95,72 @@ internal static class SoftwareBitmapExtensions
         var segmentedBitmap = new SoftwareBitmap(BitmapPixelFormat.Bgra8, inputBitmap.PixelWidth, inputBitmap.PixelHeight);
         segmentedBitmap.CopyFromBuffer(inputBuffer.AsBuffer());
         return segmentedBitmap;
+    }
+
+    public static ImageBuffer ConvertToBgr8ImageBuffer(this SoftwareBitmap input)
+    {
+        var bgraBitmap = input;
+        if (input.BitmapPixelFormat != BitmapPixelFormat.Bgra8)
+        {
+            bgraBitmap = SoftwareBitmap.Convert(input, BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied);
+        }
+
+        int width = bgraBitmap.PixelWidth;
+        int height = bgraBitmap.PixelHeight;
+
+        byte[] bgraBuffer = new byte[width * height * 4];
+        bgraBitmap.CopyToBuffer(bgraBuffer.AsBuffer());
+
+        byte[] bgrBuffer = new byte[width * height * 3];
+        for (int i = 0, j = 0; i < bgraBuffer.Length; i += 4, j += 3)
+        {
+            bgrBuffer[j] = bgraBuffer[i];
+            bgrBuffer[j + 1] = bgraBuffer[i + 1];
+            bgrBuffer[j + 2] = bgraBuffer[i + 2];
+        }
+
+        return ImageBuffer.CreateForBuffer(
+            bgrBuffer.AsBuffer(),
+            ImageBufferPixelFormat.Bgr8,
+            width,
+            height,
+            width * 3);
+    }
+
+    public static SoftwareBitmap ConvertBgr8ImageBufferToBgra8SoftwareBitmap(this ImageBuffer bgrImageBuffer)
+    {
+        if (bgrImageBuffer.PixelFormat != ImageBufferPixelFormat.Bgr8)
+        {
+            throw new ArgumentException("Input ImageBuffer must be in Bgr8 format");
+        }
+
+        int width = bgrImageBuffer.PixelWidth;
+        int height = bgrImageBuffer.PixelHeight;
+
+        // Get BGR data from ImageBuffer
+        byte[] bgrBuffer = new byte[width * height * 3];
+        bgrImageBuffer.CopyToByteArray(bgrBuffer);
+
+        // Create BGRA buffer (4 bytes per pixel)
+        byte[] bgraBuffer = new byte[width * height * 4];
+
+        for (int i = 0, j = 0; i < bgrBuffer.Length; i += 3, j += 4)
+        {
+            bgraBuffer[j] = bgrBuffer[i];           // B
+            bgraBuffer[j + 1] = bgrBuffer[i + 1];   // G
+            bgraBuffer[j + 2] = bgrBuffer[i + 2];   // R
+            bgraBuffer[j + 3] = 255;                // A (full opacity)
+        }
+
+        // Create SoftwareBitmap and copy data
+        var softwareBitmap = new SoftwareBitmap(
+            BitmapPixelFormat.Bgra8,
+            width,
+            height,
+            BitmapAlphaMode.Premultiplied);
+
+        softwareBitmap.CopyFromBuffer(bgraBuffer.AsBuffer());
+
+        return softwareBitmap;
     }
 }

--- a/Samples/WindowsAIFoundry/cs-winui/ViewModels/CopilotRootViewModel.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/ViewModels/CopilotRootViewModel.cs
@@ -17,6 +17,7 @@ internal class CopilotRootViewModel
         ImageObjectExtractor = new(new Models.ImageObjectExtractorModel());
         ImageDescriptionGenerator = new(new Models.ImageDescriptionModel());
         ImageObjectRemover = new(new Models.ImageObjectRemoverModel());
+        VideoScaler = new(new Models.VideoScalerModel());
     }
 
     public LanguageModelViewModel LanguageModel { get; }
@@ -30,4 +31,6 @@ internal class CopilotRootViewModel
     public ImageObjectExtractorViewModel ImageObjectExtractor { get; }
 
     public ImageObjectRemoverViewModel ImageObjectRemover { get; }
+
+    public VideoScalerViewModel VideoScaler { get; }
 }

--- a/Samples/WindowsAIFoundry/cs-winui/ViewModels/VideoScalerViewModel.cs
+++ b/Samples/WindowsAIFoundry/cs-winui/ViewModels/VideoScalerViewModel.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using WindowsAISample.Models.Contracts;
+using WindowsAISample.Util;
+using Microsoft.UI.Xaml.Media.Imaging;
+using System.Windows.Input;
+using Windows.Media;
+using WindowsAISample.Models;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+
+namespace WindowsAISample.ViewModels;
+
+internal partial class VideoScalerViewModel : InputImageViewModelBase<VideoScalerModel>
+{
+    private readonly AsyncCommand<(VideoFrame, int, int), SoftwareBitmapSource> _scaleVideoFrameCommand;
+
+    public VideoScalerViewModel(VideoScalerModel videoScalerSession)
+    : base(videoScalerSession)
+    {
+        _scaleVideoFrameCommand = new(
+            async _ =>
+            { 
+                var softwareBitmap = Session.ScaleVideoFrame(Input!);
+                return await DispatcherQueue.EnqueueAsync(async () =>
+                {
+                    return await softwareBitmap.ToSourceAsync();
+                });
+            },
+            (_) => IsAvailable && Input is not null);
+    }
+
+    public ICommand ScaleCommand => _scaleVideoFrameCommand;
+
+    protected override void OnIsAvailableChanged()
+    {
+        _scaleVideoFrameCommand.FireCanExecuteChanged();
+    }
+}

--- a/Samples/WindowsAIFoundry/cs-winui/WindowsAISample.csproj
+++ b/Samples/WindowsAIFoundry/cs-winui/WindowsAISample.csproj
@@ -33,10 +33,12 @@
     <None Remove="Examples\LanguageModelWithProgress.md" />
     <None Remove="Examples\TextRecognizer.md" />
     <None Remove="Examples\TextRecognizerInit.md" />
+    <None Remove="Examples\VideoScalerInit.md" />
     <None Remove="Pages\ExampleCode.xaml" />
     <None Remove="Pages\ImageDescriptionPage.xaml" />
     <None Remove="Pages\ImageObjectExtractorPage.xaml" />
     <None Remove="Pages\ImageScalerPage.xaml" />
+    <None Remove="Pages\VideoScalerPage.xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -99,6 +101,11 @@
   </ItemGroup>
   <ItemGroup>
     <Page Update="Pages\TextRecognizerPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Pages\VideoScalerPage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>


### PR DESCRIPTION
## Description

This re-adds the Video Super Res sample back to the release/2.0-stable branch now that it is a stable API by porting #575 and #633 from the release/2.0-experimental branch, while updating the WindowsAppSDK version to 2.4.0.

## Target Release

WASDK 2.4.0.

## Checklist

Note that /azp run currently isn't working for this repo.

- [x] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [x] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [x] Samples set the minimum supported OS version to Windows 10 version 1809.
- [x] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
