### PR TITLE
Windows ML: Add compiled model compatibility samples

### DIFF
--- a/Samples/WindowsML/Directory.Packages.props
+++ b/Samples/WindowsML/Directory.Packages.props
@@ -5,7 +5,9 @@
   <ItemGroup>
     <!-- WindowsAppSDK packages -->
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.WinML" Version="0.14.0" />
-    <PackageVersion Include="Microsoft.Windows.AI.MachineLearning" Version="2.1.1" />
+    <!-- Managed compatibility metadata extraction requires the newer Windows ML binding.
+         Native samples remain on packages.config 2.1.1, whose C++ API already includes it. -->
+    <PackageVersion Include="Microsoft.Windows.AI.MachineLearning" Version="2.3.42" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
     <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="2.1.10" />
     <PackageVersion Include="Microsoft.WindowsAppSDK.Base" Version="2.0.4" />

--- a/Samples/WindowsML/README.md
+++ b/Samples/WindowsML/README.md
@@ -8,6 +8,7 @@ Windows ML enables high-performance, reliable inferencing of machine learning mo
 
 - **Execution Provider Selection** - Automatic discovery and acquisition of execution providers for hardware-accelerated inference
 - **Model Compilation** - Optimize models for specific hardware during first run
+- **Compiled Model Compatibility** - Validate cached compiled models against the current execution provider and devices before reuse
 - **Windows App SDK Deployment Types** - Use models in a variety of different Windows App SDK deployment modes (e.g., self-contained, framework-based deployment)
 
 ## Prerequisites
@@ -69,10 +70,13 @@ Most samples follow this pattern:
 
 1. **Initialize Environment** - Create ONNX Runtime environment
 2. **Register Execution Providers** - Discover and register available hardware accelerators
-3. **Load Model** - Load ONNX model, optionally compile for target hardware
-4. **Preprocess Input** - Convert images to model input format
-5. **Run Inference** - Execute model and get predictions
-6. **Process Results** - Apply softmax and display top predictions
+3. **Validate Cached Model** - Extract compatibility metadata from an existing compiled model and validate it against devices from the matching execution provider
+4. **Compile or Load Model** - Reuse only an optimal compiled model; otherwise compile when requested or use the original ONNX model
+5. **Preprocess Input** - Convert images to model input format
+6. **Run Inference** - Execute model and get predictions
+7. **Process Results** - Apply softmax and display top predictions
+
+Compatibility is reported through `OrtCompiledModelCompatibility`. The samples reuse a compiled model only for `EP_SUPPORTED_OPTIMAL`; `EP_SUPPORTED_PREFER_RECOMPILATION`, `EP_UNSUPPORTED`, `EP_NOT_APPLICABLE`, and missing compatibility metadata trigger recompilation or fallback. Because `GetModelCompatibilityForEpDevices` requires devices from a single execution provider, the samples validate one EP device group at a time.
 
 ## Model Files
 

--- a/Samples/WindowsML/Shared/cpp/InferenceEngine.cpp
+++ b/Samples/WindowsML/Shared/cpp/InferenceEngine.cpp
@@ -3,7 +3,209 @@
 #include "InferenceEngine.h"
 #include "ExecutionProviderManager.h"
 #include "ModelManager.h"
+#include <algorithm>
 #include <iostream>
+#include <iterator>
+#include <map>
+#include <optional>
+#include <system_error>
+
+namespace
+{
+    enum class ExistingCompiledModelStatus
+    {
+        Optimal,
+        MissingMetadata,
+        NotApplicable,
+        PreferRecompilation,
+        Unsupported,
+        NoMatchingDevices,
+        ValidationError
+    };
+
+    struct CompatibilityProbe
+    {
+        std::string executionProvider;
+        std::vector<std::string> deviceTypes;
+        std::optional<OrtCompiledModelCompatibility> compatibility;
+        std::string detail;
+    };
+
+    struct ExistingCompiledModelCheck
+    {
+        ExistingCompiledModelStatus status = ExistingCompiledModelStatus::ValidationError;
+        std::string detail;
+        std::vector<CompatibilityProbe> probes;
+    };
+
+    struct EpDeviceGroup
+    {
+        std::string name;
+        std::vector<Ort::ConstEpDevice> devices;
+    };
+
+    std::string WideToUtf8(const std::wstring& value)
+    {
+        if (value.empty())
+        {
+            return {};
+        }
+
+        const int size = WideCharToMultiByte(CP_UTF8, 0, value.c_str(), static_cast<int>(value.size()), nullptr, 0, nullptr, nullptr);
+        if (size <= 0)
+        {
+            return {};
+        }
+
+        std::string result(static_cast<size_t>(size), '\0');
+        WideCharToMultiByte(CP_UTF8, 0, value.c_str(), static_cast<int>(value.size()), result.data(), size, nullptr, nullptr);
+        return result;
+    }
+
+    std::vector<EpDeviceGroup> GroupDevicesByExecutionProvider(const std::vector<Ort::ConstEpDevice>& devices)
+    {
+        std::vector<EpDeviceGroup> groups;
+        std::map<std::string, size_t> groupIndexes;
+
+        for (const auto& device : devices)
+        {
+            const std::string epName(device.EpName());
+            auto [it, inserted] = groupIndexes.emplace(epName, groups.size());
+            if (inserted)
+            {
+                groups.push_back({epName, {}});
+            }
+            groups[it->second].devices.push_back(device);
+        }
+
+        return groups;
+    }
+
+    OrtHardwareDeviceType GetPreferredDeviceType(OrtExecutionProviderDevicePolicy policy)
+    {
+        switch (policy)
+        {
+        case OrtExecutionProviderDevicePolicy_PREFER_NPU:
+        case OrtExecutionProviderDevicePolicy_MAX_EFFICIENCY:
+        case OrtExecutionProviderDevicePolicy_MIN_OVERALL_POWER:
+            return OrtHardwareDeviceType_NPU;
+        case OrtExecutionProviderDevicePolicy_PREFER_GPU:
+        case OrtExecutionProviderDevicePolicy_MAX_PERFORMANCE:
+            return OrtHardwareDeviceType_GPU;
+        case OrtExecutionProviderDevicePolicy_DEFAULT:
+        case OrtExecutionProviderDevicePolicy_PREFER_CPU:
+        default:
+            return OrtHardwareDeviceType_CPU;
+        }
+    }
+
+    std::vector<EpDeviceGroup> SelectDeviceGroups(
+        const std::vector<EpDeviceGroup>& groups,
+        const WindowsML::Shared::CommandLineOptions& options)
+    {
+        std::vector<EpDeviceGroup> selectedGroups;
+
+        if (!options.ep_name.empty())
+        {
+            const std::string requestedEp = WideToUtf8(options.ep_name);
+            const auto group = std::find_if(groups.begin(), groups.end(), [&](const EpDeviceGroup& candidate) {
+                return candidate.name == requestedEp;
+            });
+            if (group == groups.end())
+            {
+                return selectedGroups;
+            }
+
+            if (!options.device_type.has_value())
+            {
+                selectedGroups.push_back(*group);
+                return selectedGroups;
+            }
+
+            const std::string requestedDeviceType = WideToUtf8(options.device_type.value());
+            const auto device = std::find_if(group->devices.begin(), group->devices.end(), [&](const Ort::ConstEpDevice& candidate) {
+                return WindowsML::Shared::ArgumentParser::ToString(candidate.Device().Type()) == requestedDeviceType;
+            });
+            if (device != group->devices.end())
+            {
+                selectedGroups.push_back({group->name, {*device}});
+            }
+            return selectedGroups;
+        }
+
+        const OrtHardwareDeviceType preferredType =
+            GetPreferredDeviceType(options.ep_policy.value_or(OrtExecutionProviderDevicePolicy_DEFAULT));
+        for (const auto& group : groups)
+        {
+            EpDeviceGroup selectedGroup{group.name, {}};
+            std::copy_if(group.devices.begin(), group.devices.end(), std::back_inserter(selectedGroup.devices),
+                [&](const Ort::ConstEpDevice& device) {
+                    const OrtHardwareDeviceType deviceType = device.Device().Type();
+                    return deviceType == preferredType || deviceType == OrtHardwareDeviceType_CPU;
+                });
+            if (!selectedGroup.devices.empty())
+            {
+                selectedGroups.push_back(std::move(selectedGroup));
+            }
+        }
+
+        return selectedGroups;
+    }
+
+    ExistingCompiledModelStatus ToStatus(OrtCompiledModelCompatibility compatibility)
+    {
+        switch (compatibility)
+        {
+        case OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL:
+            return ExistingCompiledModelStatus::Optimal;
+        case OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION:
+            return ExistingCompiledModelStatus::PreferRecompilation;
+        case OrtCompiledModelCompatibility_EP_UNSUPPORTED:
+            return ExistingCompiledModelStatus::Unsupported;
+        case OrtCompiledModelCompatibility_EP_NOT_APPLICABLE:
+        default:
+            return ExistingCompiledModelStatus::NotApplicable;
+        }
+    }
+
+    const char* ToString(ExistingCompiledModelStatus status)
+    {
+        switch (status)
+        {
+        case ExistingCompiledModelStatus::Optimal:
+            return "optimal";
+        case ExistingCompiledModelStatus::MissingMetadata:
+            return "missing metadata";
+        case ExistingCompiledModelStatus::NotApplicable:
+            return "not applicable";
+        case ExistingCompiledModelStatus::PreferRecompilation:
+            return "recompilation preferred";
+        case ExistingCompiledModelStatus::Unsupported:
+            return "unsupported";
+        case ExistingCompiledModelStatus::NoMatchingDevices:
+            return "no matching devices";
+        case ExistingCompiledModelStatus::ValidationError:
+        default:
+            return "validation error";
+        }
+    }
+
+    const char* ToString(OrtCompiledModelCompatibility compatibility)
+    {
+        switch (compatibility)
+        {
+        case OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL:
+            return "EP_SUPPORTED_OPTIMAL";
+        case OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION:
+            return "EP_SUPPORTED_PREFER_RECOMPILATION";
+        case OrtCompiledModelCompatibility_EP_UNSUPPORTED:
+            return "EP_UNSUPPORTED";
+        case OrtCompiledModelCompatibility_EP_NOT_APPLICABLE:
+        default:
+            return "EP_NOT_APPLICABLE";
+        }
+    }
+}
 
 namespace WindowsML
 {
@@ -43,33 +245,167 @@ namespace Shared
         Ort::Env& env)
     {
         std::filesystem::path actualModelPath;
-        bool isCompiledModelAvailable = std::filesystem::exists(compiledModelPath);
+        std::error_code compiledModelPathError;
+        bool isCompiledModelAvailable = std::filesystem::exists(compiledModelPath, compiledModelPathError);
+        bool shouldCompile = options.compile_model;
+
+        if (compiledModelPathError)
+        {
+            std::cout << "Could not inspect compiled model path " << compiledModelPath
+                      << ": " << compiledModelPathError.message()
+                      << ". Using the original model unless compilation succeeds." << std::endl;
+            isCompiledModelAvailable = false;
+        }
 
         if (isCompiledModelAvailable)
         {
-            std::cout << "Using existing compiled model: " << compiledModelPath << std::endl;
-            actualModelPath = compiledModelPath;
+            std::cout << "Validating existing compiled model: " << compiledModelPath << std::endl;
+            ExistingCompiledModelCheck check;
+
+            try
+            {
+                const auto deviceGroups =
+                    SelectDeviceGroups(GroupDevicesByExecutionProvider(env.GetEpDevices()), options);
+                if (deviceGroups.empty())
+                {
+                    check.status = ExistingCompiledModelStatus::NoMatchingDevices;
+                    check.detail = "No execution provider devices matched the requested selection.";
+                }
+                else
+                {
+                    bool foundMetadata = false;
+                    bool validationFailed = false;
+                    std::optional<ExistingCompiledModelStatus> bestNonOptimalStatus;
+                    Ort::AllocatorWithDefaultOptions allocator;
+
+                    for (const auto& group : deviceGroups)
+                    {
+                        CompatibilityProbe probe;
+                        probe.executionProvider = group.name;
+                        for (const auto& device : group.devices)
+                        {
+                            probe.deviceTypes.push_back(ArgumentParser::ToString(device.Device().Type()));
+                        }
+
+                        try
+                        {
+                            auto compatibilityInfo =
+                                Ort::GetCompatibilityInfoFromModelAllocated(compiledModelPath.c_str(), group.name.c_str(), allocator);
+                            if (!compatibilityInfo)
+                            {
+                                probe.detail = "No compatibility metadata was found for this execution provider.";
+                                check.probes.push_back(std::move(probe));
+                                continue;
+                            }
+
+                            foundMetadata = true;
+                            const OrtCompiledModelCompatibility compatibility =
+                                Ort::GetModelCompatibilityForEpDevices(group.devices, compatibilityInfo.get());
+                            probe.compatibility = compatibility;
+                            probe.detail = ToString(compatibility);
+                            check.probes.push_back(std::move(probe));
+
+                            const ExistingCompiledModelStatus status = ToStatus(compatibility);
+                            if (status != ExistingCompiledModelStatus::Optimal &&
+                                (!bestNonOptimalStatus.has_value() ||
+                                 status == ExistingCompiledModelStatus::PreferRecompilation ||
+                                 (status == ExistingCompiledModelStatus::Unsupported &&
+                                  bestNonOptimalStatus.value() == ExistingCompiledModelStatus::NotApplicable)))
+                            {
+                                bestNonOptimalStatus = status;
+                            }
+                        }
+                        catch (const Ort::Exception& ex)
+                        {
+                            validationFailed = true;
+                            probe.detail = std::string("Compatibility validation failed: ") + ex.what();
+                            check.probes.push_back(std::move(probe));
+                        }
+                    }
+
+                    if (validationFailed)
+                    {
+                        check.status = ExistingCompiledModelStatus::ValidationError;
+                        check.detail = "Compatibility validation failed for one or more applicable execution provider groups.";
+                    }
+                    else if (!foundMetadata)
+                    {
+                        check.status = ExistingCompiledModelStatus::MissingMetadata;
+                        check.detail = "The compiled model contains no compatibility metadata for the selected execution providers.";
+                    }
+                    else if (bestNonOptimalStatus.has_value())
+                    {
+                        check.status = bestNonOptimalStatus.value();
+                        check.detail = "At least one applicable execution provider reported non-optimal compatibility.";
+                    }
+                    else
+                    {
+                        check.status = ExistingCompiledModelStatus::Optimal;
+                        check.detail = "All metadata-bearing execution provider groups reported optimal compatibility.";
+                    }
+                }
+            }
+            catch (const Ort::Exception& ex)
+            {
+                check.status = ExistingCompiledModelStatus::ValidationError;
+                check.detail = std::string("Failed to enumerate execution provider devices: ") + ex.what();
+            }
+
+            std::cout << "Compiled model compatibility: " << ToString(check.status) << ". " << check.detail << std::endl;
+            for (const auto& probe : check.probes)
+            {
+                std::cout << "  EP: " << probe.executionProvider << "; devices:";
+                for (const auto& deviceType : probe.deviceTypes)
+                {
+                    std::cout << " " << deviceType;
+                }
+                std::cout << "; result: " << probe.detail << std::endl;
+            }
+
+            if (check.status == ExistingCompiledModelStatus::Optimal)
+            {
+                std::cout << "Using existing compiled model: " << compiledModelPath << std::endl;
+                return compiledModelPath;
+            }
+
+            if (!options.compile_model)
+            {
+                std::cout << "The existing compiled model is not optimal; using original model: " << modelPath << std::endl;
+                return modelPath;
+            }
+
+            std::cout << "The existing compiled model is not optimal; attempting to recompile it." << std::endl;
         }
-        else if (options.compile_model)
+        else if (shouldCompile)
         {
             std::cout << "No compiled model found, attempting to create compiled model" << std::endl;
+        }
 
+        if (shouldCompile)
+        {
             const OrtApi& ortApi = Ort::GetApi();
             OrtStatus* status = ModelManager::CompileModel(ortApi, env, sessionOptions, modelPath, compiledModelPath);
+            std::error_code compiledOutputError;
+            const bool compiledOutputExists = std::filesystem::exists(compiledModelPath, compiledOutputError);
 
-            if (status == nullptr && std::filesystem::exists(compiledModelPath))
+            if (status == nullptr && !compiledOutputError && compiledOutputExists)
             {
                 std::cout << "Compiled model created successfully at " << compiledModelPath << std::endl;
                 actualModelPath = compiledModelPath;
             }
             else
             {
-                std::cout << "Falling back to original model: " << modelPath << std::endl;
-                actualModelPath = modelPath;
                 if (status != nullptr)
                 {
                     ortApi.ReleaseStatus(status);
                 }
+                if (compiledOutputError)
+                {
+                    std::cout << "Could not inspect compiled output " << compiledModelPath
+                              << ": " << compiledOutputError.message() << std::endl;
+                }
+                std::cout << "Compilation did not produce a usable model; falling back to original model: " << modelPath << std::endl;
+                actualModelPath = modelPath;
             }
         }
         else

--- a/Samples/WindowsML/Shared/cpp/ModelManager.cpp
+++ b/Samples/WindowsML/Shared/cpp/ModelManager.cpp
@@ -34,6 +34,30 @@ namespace Shared
         std::cout << "Compiling model from " << modelPath << std::endl;
         std::cout << "Output path: " << compiledModelPath << std::endl;
 
+        std::error_code pathError;
+        const bool compiledModelExists = std::filesystem::exists(compiledModelPath, pathError);
+        if (pathError)
+        {
+            const std::string message =
+                "Failed to inspect compiled model output path: " + pathError.message();
+            std::cerr << message << std::endl;
+            return ortApi.CreateStatus(ORT_FAIL, message.c_str());
+        }
+
+        if (compiledModelExists && std::filesystem::equivalent(modelPath, compiledModelPath, pathError))
+        {
+            const std::string message = "Compilation output path must be different from the original model path.";
+            std::cerr << message << std::endl;
+            return ortApi.CreateStatus(ORT_INVALID_ARGUMENT, message.c_str());
+        }
+        if (pathError)
+        {
+            const std::string message =
+                "Failed to compare input and compiled model paths: " + pathError.message();
+            std::cerr << message << std::endl;
+            return ortApi.CreateStatus(ORT_FAIL, message.c_str());
+        }
+
         // Get compile API
         const OrtCompileApi* compileApi = ortApi.GetCompileApi();
         if (!compileApi)

--- a/Samples/WindowsML/Shared/cpp/ModelManager.cpp
+++ b/Samples/WindowsML/Shared/cpp/ModelManager.cpp
@@ -1,10 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.md in the repo root for license information.
 #include "ModelManager.h"
-#include <iostream>
-#include <fstream>
 #include <chrono>
+#include <fstream>
+#include <iostream>
+#include <system_error>
 #include <windows.h>
+
+namespace
+{
+    std::filesystem::path CreateTemporaryCompiledModelPath(const std::filesystem::path& compiledModelPath)
+    {
+        const auto uniqueValue = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+        const std::wstring temporaryName =
+            compiledModelPath.stem().wstring() + L".tmp." + std::to_wstring(GetCurrentProcessId()) + L"." +
+            std::to_wstring(uniqueValue) + compiledModelPath.extension().wstring();
+        return compiledModelPath.parent_path() / temporaryName;
+    }
+}
 
 namespace WindowsML
 {
@@ -26,8 +39,12 @@ namespace Shared
         if (!compileApi)
         {
             std::cerr << "Failed to get compile API" << std::endl;
-            return nullptr;
+            return ortApi.CreateStatus(ORT_FAIL, "Failed to get compile API");
         }
+
+        const std::filesystem::path temporaryModelPath = CreateTemporaryCompiledModelPath(compiledModelPath);
+        std::error_code cleanupError;
+        std::filesystem::remove(temporaryModelPath, cleanupError);
 
         // Create compilation options from session options
         OrtModelCompilationOptions* compileOptions = nullptr;
@@ -47,10 +64,20 @@ namespace Shared
             return status;
         }
 
-        status = compileApi->ModelCompilationOptions_SetOutputModelPath(compileOptions, compiledModelPath.c_str());
+        status = compileApi->ModelCompilationOptions_SetOutputModelPath(compileOptions, temporaryModelPath.c_str());
         if (status != nullptr)
         {
             std::cerr << "Failed to set output model path: " << ortApi.GetErrorMessage(status) << std::endl;
+            compileApi->ReleaseModelCompilationOptions(compileOptions);
+            return status;
+        }
+
+        // Keep the compiled EP context in the ONNX file so atomic replacement
+        // cannot strand a model that references a temp-named sidecar.
+        status = compileApi->ModelCompilationOptions_SetEpContextEmbedMode(compileOptions, true);
+        if (status != nullptr)
+        {
+            std::cerr << "Failed to configure embedded EP context: " << ortApi.GetErrorMessage(status) << std::endl;
             compileApi->ReleaseModelCompilationOptions(compileOptions);
             return status;
         }
@@ -67,7 +94,36 @@ namespace Shared
 
         if (status == nullptr)
         {
-            std::cout << "Model compiled successfully in " << duration.count() << " ms" << std::endl;
+            std::error_code outputError;
+            const bool outputExists = std::filesystem::exists(temporaryModelPath, outputError);
+            if (outputError)
+            {
+                const std::string message =
+                    "Failed to inspect temporary compiled model: " + outputError.message();
+                status = ortApi.CreateStatus(ORT_FAIL, message.c_str());
+                std::cerr << message << std::endl;
+            }
+            else if (!outputExists)
+            {
+                status = ortApi.CreateStatus(ORT_FAIL, "Compilation completed without creating an output model");
+                std::cerr << ortApi.GetErrorMessage(status) << std::endl;
+            }
+            else if (!MoveFileExW(
+                         temporaryModelPath.c_str(),
+                         compiledModelPath.c_str(),
+                         MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+            {
+                const DWORD error = GetLastError();
+                const std::string message =
+                    "Failed to replace compiled model atomically. Win32 error: " + std::to_string(error);
+                status = ortApi.CreateStatus(ORT_FAIL, message.c_str());
+                std::wcerr << L"Failed to replace temporary compiled model '" << temporaryModelPath
+                           << L"' with cache '" << compiledModelPath << L"'. Win32 error: " << error << std::endl;
+            }
+            else
+            {
+                std::cout << "Model compiled successfully in " << duration.count() << " ms" << std::endl;
+            }
         }
         else
         {
@@ -75,6 +131,10 @@ namespace Shared
         }
 
         compileApi->ReleaseModelCompilationOptions(compileOptions);
+        if (status != nullptr)
+        {
+            std::filesystem::remove(temporaryModelPath, cleanupError);
+        }
         return status;
     }
 

--- a/Samples/WindowsML/Shared/cs/ModelManager.cs
+++ b/Samples/WindowsML/Shared/cs/ModelManager.cs
@@ -334,17 +334,27 @@ namespace WindowsML.Shared
         /// </summary>
         public static void CompileModel(SessionOptions sessionOptions, string modelPath, string compiledModelPath)
         {
+            TryCompileModel(sessionOptions, modelPath, compiledModelPath);
+        }
+
+        private static bool TryCompileModel(SessionOptions sessionOptions, string modelPath, string compiledModelPath)
+        {
             Console.WriteLine($"Compiling model from {modelPath}");
             Console.WriteLine($"Output path: {compiledModelPath}");
 
             // Create compilation options from session options
-            OrtModelCompilationOptions compileOptions = new(sessionOptions);
+            using OrtModelCompilationOptions compileOptions = new(sessionOptions);
 
             try
             {
                 // Set input and output model paths
                 compileOptions.SetInputModelPath(modelPath);
                 compileOptions.SetOutputModelPath(compiledModelPath);
+
+                // Keep EP context binaries in the ONNX file so temporary-file replacement
+                // cannot strand a compiled model that references a temp-named sidecar.
+                // External initializer output is not configured, so initializers also remain inline.
+                compileOptions.SetEpContextEmbedMode(true);
 
                 Console.WriteLine("Starting compile, this may take a few moments...");
                 DateTime start = DateTime.Now;
@@ -354,10 +364,12 @@ namespace WindowsML.Shared
 
                 TimeSpan duration = DateTime.Now - start;
                 Console.WriteLine($"Model compiled successfully in {duration.TotalMilliseconds} ms");
+                return true;
             }
-            catch
+            catch (Exception ex)
             {
-                Console.Error.WriteLine($"Failed to compile model, continuing ...");
+                Console.Error.WriteLine($"Failed to compile model: {ex.Message}");
+                return false;
             }
         }
 
@@ -366,17 +378,114 @@ namespace WindowsML.Shared
         /// </summary>
         public static string ResolveActualModelPath(Options options, string modelPath, string compiledModelPath, OrtEnv ortEnv)
         {
-            string actualModelPath;
             bool isCompiledModelAvailable = File.Exists(compiledModelPath);
 
             if (isCompiledModelAvailable)
             {
-                Console.WriteLine($"Using existing compiled model: {compiledModelPath}");
-                actualModelPath = compiledModelPath;
+                bool foundCompatibilityMetadata = false;
+                bool foundNonOptimalCompatibility = false;
+                bool compatibilityCheckFailed = false;
+                Console.WriteLine($"Checking compiled model compatibility: {compiledModelPath}");
+
+                try
+                {
+                    IReadOnlyList<OrtEpDevice> discoveredDevices = ortEnv.GetEpDevices();
+                    List<(string EpName, List<OrtEpDevice> Devices)> candidateGroups =
+                        SelectCompatibilityDeviceGroups(discoveredDevices, options);
+
+                    if (candidateGroups.Count == 0)
+                    {
+                        Console.WriteLine(!string.IsNullOrWhiteSpace(options.EpName)
+                            ? $"  No discovered devices match EP '{options.EpName}'" +
+                              (!string.IsNullOrWhiteSpace(options.DeviceType)
+                                  ? $" and device type '{options.DeviceType}'."
+                                  : ".")
+                            : "  No execution provider devices matched the configured EP policy.");
+                    }
+
+                    foreach ((string epName, List<OrtEpDevice> devices) in candidateGroups)
+                    {
+                        Console.WriteLine(
+                            $"  Probing EP '{epName}' with device(s): {FormatDeviceContext(devices)}");
+
+                        try
+                        {
+                            string compatibilityInfo =
+                                ortEnv.GetCompatibilityInfoFromModel(compiledModelPath, epName);
+                            if (string.IsNullOrWhiteSpace(compatibilityInfo))
+                            {
+                                Console.WriteLine(
+                                    $"  Compiled model has no compatibility metadata for EP '{epName}'.");
+                                continue;
+                            }
+
+                            foundCompatibilityMetadata = true;
+                            OrtCompiledModelCompatibility compatibilityStatus =
+                                ortEnv.GetModelCompatibilityForEpDevices(devices, compatibilityInfo);
+                            Console.WriteLine($"  EP '{epName}' compatibility status: {compatibilityStatus}.");
+
+                            if (compatibilityStatus == OrtCompiledModelCompatibility.EP_SUPPORTED_OPTIMAL)
+                            {
+                                Console.WriteLine(
+                                    $"  Compiled model is optimal for EP '{epName}'.");
+                            }
+                            else
+                            {
+                                foundNonOptimalCompatibility = true;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            compatibilityCheckFailed = true;
+                            Console.WriteLine(
+                                $"  Compatibility check failed for EP '{epName}': {ex.Message}");
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    compatibilityCheckFailed = true;
+                    Console.WriteLine($"  Compiled model compatibility check failed: {ex.Message}");
+                }
+
+                bool canReuseCompiledModel =
+                    foundCompatibilityMetadata &&
+                    !foundNonOptimalCompatibility &&
+                    !compatibilityCheckFailed;
+
+                if (canReuseCompiledModel)
+                {
+                    Console.WriteLine(
+                        "All applicable compatibility metadata reports EP_SUPPORTED_OPTIMAL.");
+                    Console.WriteLine($"Using existing compiled model: {compiledModelPath}");
+                    return compiledModelPath;
+                }
+
+                if (!foundCompatibilityMetadata)
+                {
+                    Console.WriteLine(
+                        "No compatibility metadata matched the selected execution provider devices.");
+                }
+                else if (foundNonOptimalCompatibility)
+                {
+                    Console.WriteLine(
+                        "At least one applicable execution provider group reported a non-optimal status.");
+                }
+
+                Console.WriteLine($"Existing compiled model is not optimal and will not be used: {compiledModelPath}");
+
+                if (!options.Compile)
+                {
+                    Console.WriteLine($"Using original model: {modelPath}");
+                    return modelPath;
+                }
             }
-            else if (options.Compile)
+
+            if (options.Compile)
             {
-                Console.WriteLine("No compiled model found, attempting to create compiled model");
+                Console.WriteLine(isCompiledModelAvailable
+                    ? "Attempting to replace the non-optimal compiled model"
+                    : "No compiled model found, attempting to create compiled model");
 
                 try
                 {
@@ -401,33 +510,175 @@ namespace WindowsML.Shared
                         throw new Exception("Could not find an EP selection policy or an explicit execution provider.");
                     }
 
-                    CompileModel(tempSessionOptions, modelPath, compiledModelPath);
-
-                    if (File.Exists(compiledModelPath))
+                    if (TryCompileAndReplaceModel(
+                        tempSessionOptions,
+                        modelPath,
+                        compiledModelPath))
                     {
                         Console.WriteLine($"Compiled model created successfully at {compiledModelPath}");
-                        actualModelPath = compiledModelPath;
-                    }
-                    else
-                    {
-                        Console.WriteLine($"Falling back to original model: {modelPath}");
-                        actualModelPath = modelPath;
+                        return compiledModelPath;
                     }
                 }
                 catch (Exception ex)
                 {
                     Console.WriteLine($"Compilation failed: {ex.Message}");
-                    Console.WriteLine($"Falling back to original model: {modelPath}");
-                    actualModelPath = modelPath;
                 }
-            }
-            else
-            {
-                Console.WriteLine($"Using original model: {modelPath}");
-                actualModelPath = modelPath;
+
+                Console.WriteLine($"Falling back to original model: {modelPath}");
+                return modelPath;
             }
 
-            return actualModelPath;
+            Console.WriteLine($"Using original model: {modelPath}");
+            return modelPath;
+        }
+
+        private static bool TryCompileAndReplaceModel(
+            SessionOptions sessionOptions,
+            string modelPath,
+            string compiledModelPath)
+        {
+            string fullModelPath = Path.GetFullPath(modelPath);
+            string fullCompiledModelPath = Path.GetFullPath(compiledModelPath);
+
+            if (fullModelPath.Equals(fullCompiledModelPath, StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine("Compilation output path must be different from the original model path.");
+                return false;
+            }
+
+            string outputDirectory = Path.GetDirectoryName(fullCompiledModelPath)!;
+            Directory.CreateDirectory(outputDirectory);
+
+            string temporaryCompiledModelPath = Path.Combine(
+                outputDirectory,
+                $".{Path.GetFileNameWithoutExtension(fullCompiledModelPath)}.{Guid.NewGuid():N}.tmp.onnx");
+
+            try
+            {
+                if (!TryCompileModel(sessionOptions, fullModelPath, temporaryCompiledModelPath) ||
+                    !File.Exists(temporaryCompiledModelPath))
+                {
+                    Console.WriteLine("Compilation did not produce a usable temporary model.");
+                    return false;
+                }
+
+                if (File.Exists(fullCompiledModelPath))
+                {
+                    // The temporary model is in the same directory, so replacement is same-volume.
+                    File.Replace(
+                        temporaryCompiledModelPath,
+                        fullCompiledModelPath,
+                        destinationBackupFileName: null,
+                        ignoreMetadataErrors: true);
+                }
+                else
+                {
+                    File.Move(temporaryCompiledModelPath, fullCompiledModelPath);
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(
+                    $"Failed to replace compiled model cache '{fullCompiledModelPath}' " +
+                    $"with temporary output '{temporaryCompiledModelPath}': {ex.Message}");
+                return false;
+            }
+            finally
+            {
+                TryDeleteFile(temporaryCompiledModelPath);
+            }
+        }
+
+        private static List<(string EpName, List<OrtEpDevice> Devices)> SelectCompatibilityDeviceGroups(
+            IReadOnlyList<OrtEpDevice> discoveredDevices,
+            Options options)
+        {
+            List<(string EpName, List<OrtEpDevice> Devices)> groups = discoveredDevices
+                .GroupBy(device => device.EpName, StringComparer.OrdinalIgnoreCase)
+                .Select(group => (group.Key, group.ToList()))
+                .ToList();
+
+            if (!string.IsNullOrWhiteSpace(options.EpName))
+            {
+                (string EpName, List<OrtEpDevice> Devices) group = groups.FirstOrDefault(
+                    candidate => candidate.EpName.Equals(options.EpName, StringComparison.OrdinalIgnoreCase));
+                if (group.Devices == null)
+                {
+                    return [];
+                }
+
+                if (string.IsNullOrWhiteSpace(options.DeviceType))
+                {
+                    return [group];
+                }
+
+                // Explicit session configuration selects the first matching device.
+                OrtEpDevice? device = group.Devices.FirstOrDefault(
+                    candidate => candidate.HardwareDevice.Type.ToString().Equals(
+                        options.DeviceType,
+                        StringComparison.OrdinalIgnoreCase));
+                return device == null ? [] : [(group.EpName, [device])];
+            }
+
+            HashSet<string> policyDeviceTypes = GetPolicyDeviceTypes(
+                options.EpPolicy ?? ExecutionProviderDevicePolicy.DEFAULT);
+
+            // Preserve EP grouping while including the policy's preferred hardware and CPU fallback.
+            return groups
+                .Select(group => (
+                    group.EpName,
+                    group.Devices.Where(device => policyDeviceTypes.Contains(
+                        device.HardwareDevice.Type.ToString())).ToList()))
+                .Where(group => group.Item2.Count > 0)
+                .Select(group => (group.EpName, group.Item2))
+                .ToList();
+        }
+
+        private static HashSet<string> GetPolicyDeviceTypes(ExecutionProviderDevicePolicy policy)
+        {
+            string? preferredDeviceType = policy switch
+            {
+                ExecutionProviderDevicePolicy.PREFER_NPU or
+                ExecutionProviderDevicePolicy.MAX_EFFICIENCY or
+                ExecutionProviderDevicePolicy.MIN_OVERALL_POWER => "NPU",
+                ExecutionProviderDevicePolicy.PREFER_GPU or
+                ExecutionProviderDevicePolicy.MAX_PERFORMANCE => "GPU",
+                _ => null
+            };
+
+            var deviceTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CPU" };
+            if (preferredDeviceType != null)
+            {
+                deviceTypes.Add(preferredDeviceType);
+            }
+
+            return deviceTypes;
+        }
+
+        private static string FormatDeviceContext(IEnumerable<OrtEpDevice> devices)
+        {
+            return string.Join(", ", devices.Select(device =>
+            {
+                OrtHardwareDevice hardwareDevice = device.HardwareDevice;
+                return $"{hardwareDevice.Type} (vendor={hardwareDevice.Vendor}, " +
+                       $"vendorId={hardwareDevice.VendorId}, deviceId={hardwareDevice.DeviceId})";
+            }));
+        }
+
+        private static void TryDeleteFile(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Warning: Could not remove temporary model '{path}': {ex.Message}");
+            }
         }
     }
 }

--- a/Samples/WindowsML/cpp/CppConsoleDesktop.FrameworkDependent/README.md
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop.FrameworkDependent/README.md
@@ -9,6 +9,7 @@ This is a framework-dependent variant of the WindowsML C++ console desktop sampl
 - **Shared Helpers**: Uses the same shared helper classes from `../../Shared/cpp/`
 - **Source Files**: References the main application source from `../CppConsoleDesktop/CppConsoleDesktop.cpp`
 - **Runtime Dependencies**: Requires WindowsAppSDK Runtime to be installed on target machine
+- **Compiled Models**: Reuses an existing compiled model only when compatibility validation reports `EP_SUPPORTED_OPTIMAL`; `--compile` safely replaces non-optimal models
 
 ## Features
 

--- a/Samples/WindowsML/cpp/CppConsoleDesktop.SelfContained/README.md
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop.SelfContained/README.md
@@ -9,6 +9,7 @@ This is a self-contained variant of the WindowsML C++ console desktop sample.
 - **Shared Helpers**: Uses the same shared helper classes from `../../Shared/cpp/`
 - **Source Files**: References the main application source from `../CppConsoleDesktop/CppConsoleDesktop.cpp`
 - **Binary Deployment**: ONNX Runtime binaries are bundled alongside the application
+- **Compiled Models**: Reuses an existing compiled model only when compatibility validation reports `EP_SUPPORTED_OPTIMAL`; `--compile` safely replaces non-optimal models
 
 ## Required NuGet Package References
 

--- a/Samples/WindowsML/cpp/CppConsoleDesktop/README.md
+++ b/Samples/WindowsML/cpp/CppConsoleDesktop/README.md
@@ -81,6 +81,22 @@ are automatically generated with device-specific identifiers to prevent collisio
 
 Use `--compiled_output` to override with a custom path.
 
+Before reusing an existing compiled model, the sample reads its execution-provider
+compatibility metadata and validates it against the currently selected devices. Devices
+are checked in single-EP groups. Explicit `--ep_name`/`--device_type` choices validate
+only that selected group. Policy mode probes candidate groups for the policy's preferred
+device type and CPU fallback, and requires every metadata-bearing candidate group to
+report optimal compatibility. At least one candidate must contain matching compatibility
+metadata.
+
+Only `EP_SUPPORTED_OPTIMAL` models are reused. Missing metadata,
+`EP_NOT_APPLICABLE`, `EP_SUPPORTED_PREFER_RECOMPILATION`, and `EP_UNSUPPORTED`
+are treated as non-optimal. With `--compile`, the replacement is compiled to a temporary
+file with EP context embedded, then atomically moved into place. This prevents the final
+model from referencing a temp-named sidecar. A failed compilation falls back to the
+original ONNX model instead of loading the stale compiled model. Without `--compile`, a
+non-optimal compiled model also falls back to the original model.
+
 ```cpp
 #include <win_onnxruntime_cxx_api.h>
 
@@ -94,6 +110,7 @@ compileApi->CreateModelCompilationOptionsFromSessionOptions(env, sessionOptions,
 // Set input and output paths
 compileApi->ModelCompilationOptions_SetInputModelPath(compileOptions, modelPath.c_str());
 compileApi->ModelCompilationOptions_SetOutputModelPath(compileOptions, compiledModelPath.c_str());
+compileApi->ModelCompilationOptions_SetEpContextEmbedMode(compileOptions, true);
 
 // Compile the model
 compileApi->CompileModel(env, compileOptions);

--- a/Samples/WindowsML/cs-winforms/README.md
+++ b/Samples/WindowsML/cs-winforms/README.md
@@ -68,6 +68,17 @@ var resultTensor = InferenceEngine.ExtractResults(_session, results);
 var topPredictions = ResultProcessor.GetTopPredictions(resultTensor, _labels, 5);
 ```
 
+## Compiled Model Cache Compatibility
+
+When a compiled model is present at the generated cache path, the shared `ModelManager` validates
+its EP compatibility metadata against the selected execution provider and device before reuse.
+Only `EP_SUPPORTED_OPTIMAL` is accepted. Missing metadata and every other compatibility result
+cause the WinForms sample to use the original ONNX model.
+
+The WinForms UI does not request compilation, so it does not replace a missing or non-optimal
+cache. Applications that enable the shared `Options.Compile` path compile to a temporary file and
+replace the cache only after compilation succeeds.
+
 ## Related Samples
 
 - **WPF Version**: [cs-wpf](../cs-wpf/) - Same functionality with WPF UI framework
@@ -82,4 +93,3 @@ This sample uses the **SqueezeNet** model:
 - **Input**: 224x224 RGB images
 - **Output**: Probability distribution over ImageNet classes
 - **Size**: Lightweight model optimized for performance
-

--- a/Samples/WindowsML/cs-winforms/WindowsMLWinFormsSample.csproj
+++ b/Samples/WindowsML/cs-winforms/WindowsMLWinFormsSample.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" />
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="System.Numerics.Tensors" />
   </ItemGroup>

--- a/Samples/WindowsML/cs-winui/README.md
+++ b/Samples/WindowsML/cs-winui/README.md
@@ -83,6 +83,11 @@ This sample uses the **SqueezeNet** model:
 - **Output**: Probability distribution over ImageNet classes
 - **Size**: Lightweight model optimized for performance
 
+> [!NOTE]
+> This WinUI sample loads the original model directly and does not use the shared compiled-model
+> cache path. Compiled-model compatibility validation applies to the console, WPF, and WinForms
+> samples that call `ModelManager.ResolveActualModelPath`.
+
 ## Deployment
 
 The application can be deployed as:

--- a/Samples/WindowsML/cs-winui/WindowsMLSample.csproj
+++ b/Samples/WindowsML/cs-winui/WindowsMLSample.csproj
@@ -56,6 +56,7 @@
   </Target>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" />
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="System.Numerics.Tensors" />
     <Manifest Include="$(ApplicationManifest)" />

--- a/Samples/WindowsML/cs-wpf/README.md
+++ b/Samples/WindowsML/cs-wpf/README.md
@@ -67,6 +67,17 @@ var resultTensor = InferenceEngine.ExtractResults(_session, results);
 var topPredictions = ResultProcessor.GetTopPredictions(resultTensor, _labels, 5);
 ```
 
+## Compiled Model Cache Compatibility
+
+When a compiled model is present at the generated cache path, the shared `ModelManager` validates
+its EP compatibility metadata against the selected execution provider and device before reuse.
+Only `EP_SUPPORTED_OPTIMAL` is accepted. Missing metadata and every other compatibility result
+cause the WPF sample to use the original ONNX model.
+
+The WPF UI does not request compilation, so it does not replace a missing or non-optimal cache.
+Applications that enable the shared `Options.Compile` path compile to a temporary file and replace
+the cache only after compilation succeeds.
+
 ## Related Samples
 
 - **WinForms Version**: [cs-winforms](../cs-winforms/) - Same functionality with Windows Forms UI

--- a/Samples/WindowsML/cs-wpf/WindowsMLSampleForWPF.csproj
+++ b/Samples/WindowsML/cs-wpf/WindowsMLSampleForWPF.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" />
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="System.Numerics.Tensors" />
   </ItemGroup>

--- a/Samples/WindowsML/cs/CSharpConsoleDesktop/CSharpConsoleDesktop/CSharpConsoleDesktop.csproj
+++ b/Samples/WindowsML/cs/CSharpConsoleDesktop/CSharpConsoleDesktop/CSharpConsoleDesktop.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" />
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="System.Numerics.Tensors" />
   </ItemGroup>

--- a/Samples/WindowsML/cs/CSharpConsoleDesktop/README.md
+++ b/Samples/WindowsML/cs/CSharpConsoleDesktop/README.md
@@ -93,30 +93,24 @@ are automatically generated with device-specific identifiers to prevent collisio
 
 Use `--compiled_output` to override with a custom path.
 
-```csharp
-// Create compilation options from session options
-OrtModelCompilationOptions compileOptions = new(sessionOptions);
+Before an existing compiled model is reused, the shared `ModelManager` reads its EP compatibility
+metadata and validates it against the currently discovered devices. Explicit `--ep_name` and
+`--device_type` selections are honored. With `--ep_policy`, devices are grouped by EP and each EP
+group is probed separately.
 
-try
-{
-    // Set input and output model paths
-    compileOptions.SetInputModelPath(modelPath);
-    compileOptions.SetOutputModelPath(compiledModelPath);
+Only `EP_SUPPORTED_OPTIMAL` is reused. `EP_SUPPORTED_PREFER_RECOMPILATION`, `EP_UNSUPPORTED`,
+`EP_NOT_APPLICABLE`, discovery failures, and validation failures cause the sample to use the
+original ONNX model instead. For policy selection, at least one candidate EP group must have
+matching metadata, and every metadata-bearing candidate group must report `EP_SUPPORTED_OPTIMAL`.
+Candidate groups follow policy fallback behavior: CPU for `DEFAULT`/`PREFER_CPU`, NPU plus CPU for
+NPU/efficiency policies, and GPU plus CPU for GPU/performance policies. If no candidate group has
+matching metadata, the cache is also treated as non-optimal.
 
-    Console.WriteLine("Starting compile, this may take a few moments...");
-    DateTime start = DateTime.Now;
-
-    // Compile the model
-    compileOptions.CompileModel();
-
-    TimeSpan duration = DateTime.Now - start;
-    Console.WriteLine($"Model compiled successfully in {duration.TotalMilliseconds} ms");
-}
-catch
-{
-    Console.Error.WriteLine($"Failed to compile model, continuing ...");
-}
-```
+When `--compile` is present and the cached model is missing or non-optimal, compilation writes to a
+temporary file in the output directory and replaces the cache only after compilation succeeds. If
+compilation or replacement fails, a stale compiled model is never selected and inference falls
+back to the original model. EP context data is embedded in the compiled ONNX file so atomic cache
+replacement does not leave references to temporary sidecar files.
 
 ### 3. Execution Provider Selection Policy
 

--- a/Samples/WindowsML/python/SqueezeNetPython/main.py
+++ b/Samples/WindowsML/python/SqueezeNetPython/main.py
@@ -1,11 +1,120 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import os
 from pathlib import Path
+import shutil
+import tempfile
+
 from PIL import Image
 import numpy as np
 import onnxruntime as ort
 from winml import WinML
+
+
+def _get_ort_compatibility_api(name: str):
+    api = getattr(ort, name, None)
+    if api is not None:
+        return api
+
+    from onnxruntime.capi import onnxruntime_pybind11_state
+
+    return getattr(onnxruntime_pybind11_state, name)
+
+
+def _filter_ep_devices_by_types(devices_by_ep, device_type_names: tuple[str, ...]):
+    hardware_device_types = {
+        getattr(getattr(ort, "OrtHardwareDeviceType", None), device_type_name, None)
+        for device_type_name in device_type_names
+    }
+    hardware_device_types.discard(None)
+    matching_groups = {}
+
+    for ep_name, devices in devices_by_ep.items():
+        matching_devices = []
+        for device in devices:
+            device_type = device.device.type
+            if device_type in hardware_device_types or (
+                str(device_type).rsplit(".", 1)[-1].upper() in device_type_names
+            ):
+                matching_devices.append(device)
+
+        if matching_devices:
+            matching_groups[ep_name] = matching_devices
+
+    return matching_groups
+
+
+def _get_policy_device_type_names(policy) -> tuple[str, ...]:
+    policy_name = getattr(policy, "name", str(policy).rsplit(".", 1)[-1])
+    if policy_name in {
+        "PREFER_NPU",
+        "MAX_EFFICIENCY",
+        "MIN_OVERALL_POWER",
+    }:
+        return ("NPU", "CPU")
+    if policy_name in {"PREFER_GPU", "MAX_PERFORMANCE"}:
+        return ("GPU", "CPU")
+    return ("CPU",)
+
+
+def _compile_model_to_temporary_file(
+    session_options: ort.SessionOptions,
+    model_path: Path,
+    compiled_model_path: Path,
+) -> Path | None:
+    temporary_path = None
+    temporary_directory = None
+
+    try:
+        temporary_directory = Path(tempfile.mkdtemp(
+            prefix=f"{compiled_model_path.stem}.",
+            dir=compiled_model_path.parent,
+        ))
+        temporary_path = temporary_directory / compiled_model_path.name
+
+        model_compiler = ort.ModelCompiler(
+            session_options,
+            model_path,
+            embed_compiled_data_into_model=True,
+            external_initializers_file_path=None,
+        )
+        model_compiler.compile_to_file(str(temporary_path))
+        if not temporary_path.is_file() or temporary_path.stat().st_size == 0:
+            raise RuntimeError("Compilation did not produce a model.")
+
+        generated_paths = list(temporary_directory.iterdir())
+        if generated_paths != [temporary_path]:
+            generated_names = ", ".join(path.name for path in generated_paths)
+            raise RuntimeError(
+                "Compilation produced unexpected external artifacts: "
+                f"{generated_names}"
+            )
+
+        return temporary_path
+    except Exception as error:
+        print(f"Model compilation failed: {error}")
+        print("Using the original model for this run.")
+        if temporary_directory is not None:
+            try:
+                shutil.rmtree(temporary_directory)
+            except OSError as cleanup_error:
+                print(
+                    "Could not remove temporary compilation directory: "
+                    f"{cleanup_error}"
+                )
+        return None
+
+
+def _remove_temporary_model(temporary_path: Path | None) -> None:
+    if temporary_path is not None:
+        temporary_directory = temporary_path.parent
+        try:
+            temporary_path.unlink(missing_ok=True)
+            temporary_directory.rmdir()
+        except OSError as error:
+            print(f"Could not remove temporary compilation output: {error}")
+
 
 def load_and_preprocess_image(image_path: Path) -> np.ndarray:
     img = Image.open(image_path)    
@@ -54,21 +163,176 @@ if __name__ == "__main__":
     print("Setting session options ...")
     session_options = ort.SessionOptions()
     # Change your policy here.
-    session_options.set_provider_selection_policy(ort.OrtExecutionProviderDevicePolicy.PREFER_NPU)
+    ep_policy = ort.OrtExecutionProviderDevicePolicy.PREFER_NPU
+    session_options.set_provider_selection_policy(ep_policy)
 
     print("Compiling model ...")
     model_path = resource_path / "Model" / "SqueezeNet.onnx"
     compiled_model_path = resource_path / "Model" / "SqueezeNet_ctx.onnx"
-    if not compiled_model_path.exists():
-        model_compiler = ort.ModelCompiler(session_options, model_path)
-        model_compiler.compile_to_file(str(compiled_model_path))
-    else:
-        print("Using existing compiled model.")
-    if compiled_model_path.exists():
+
+    relevant_device_groups = {}
+    try:
+        get_ep_devices = _get_ort_compatibility_api("get_ep_devices")
+        get_compatibility_info_from_model = _get_ort_compatibility_api(
+            "get_compatibility_info_from_model"
+        )
+        get_model_compatibility_for_ep_devices = _get_ort_compatibility_api(
+            "get_model_compatibility_for_ep_devices"
+        )
+        compiled_model_compatibility = _get_ort_compatibility_api(
+            "OrtCompiledModelCompatibility"
+        )
+
+        devices_by_ep = {}
+        for device in get_ep_devices():
+            devices_by_ep.setdefault(device.ep_name, []).append(device)
+
+        policy_device_types = _get_policy_device_type_names(ep_policy)
+        relevant_device_groups = _filter_ep_devices_by_types(
+            devices_by_ep, policy_device_types
+        )
+        policy_name = getattr(
+            ep_policy, "name", str(ep_policy).rsplit(".", 1)[-1]
+        )
+        print(
+            f"{policy_name} compatibility check selected "
+            f"{'/'.join(policy_device_types)} candidate EP group(s): "
+            + ", ".join(relevant_device_groups)
+        )
+    except Exception as error:
+        print(f"Could not prepare compiled model compatibility checks: {error}")
+
+    use_compiled_model = False
+    temporary_model_path = None
+    candidate_model_path = (
+        compiled_model_path if compiled_model_path.exists() else None
+    )
+    candidate_is_temporary = False
+
+    if candidate_model_path is None and relevant_device_groups:
+        temporary_model_path = _compile_model_to_temporary_file(
+            session_options, model_path, compiled_model_path
+        )
+        candidate_model_path = temporary_model_path
+        candidate_is_temporary = True
+    elif candidate_model_path is None:
+        print(
+            "Skipping model compilation because compatibility could not be "
+            "evaluated."
+        )
+
+    try:
+        while candidate_model_path is not None:
+            print(f"Checking compiled model compatibility: {candidate_model_path}")
+            candidate_is_optimal = False
+
+            if not relevant_device_groups:
+                print("No relevant execution provider devices were found.")
+            else:
+                matching_metadata_found = False
+                all_matching_groups_optimal = True
+
+                for ep_name, ep_devices in relevant_device_groups.items():
+                    device_descriptions = ", ".join(
+                        f"{ep_device.device.type} "
+                        f"(EP vendor={ep_device.ep_vendor})"
+                        for ep_device in ep_devices
+                    )
+                    print(
+                        f"Probing EP '{ep_name}' with device(s): "
+                        f"{device_descriptions}"
+                    )
+
+                    try:
+                        compatibility_info = get_compatibility_info_from_model(
+                            str(candidate_model_path), ep_name
+                        )
+                        if compatibility_info is None:
+                            print(
+                                "Compiled model has no compatibility metadata for "
+                                f"{ep_name}."
+                            )
+                            continue
+
+                        matching_metadata_found = True
+                        status = get_model_compatibility_for_ep_devices(
+                            ep_devices, compatibility_info
+                        )
+                        status_name = getattr(
+                            status, "name", str(status).rsplit(".", 1)[-1]
+                        )
+                        print(
+                            f"Compiled model compatibility for {ep_name}: "
+                            f"{status_name}"
+                        )
+                        if (
+                            status
+                            != compiled_model_compatibility.EP_SUPPORTED_OPTIMAL
+                        ):
+                            all_matching_groups_optimal = False
+                    except Exception as error:
+                        all_matching_groups_optimal = False
+                        print(
+                            f"Could not check the compiled model for {ep_name}: "
+                            f"{error}"
+                        )
+
+                if not matching_metadata_found:
+                    print(
+                        "Compiled model has no compatibility metadata for any "
+                        "candidate EP group."
+                    )
+
+                candidate_is_optimal = (
+                    matching_metadata_found and all_matching_groups_optimal
+                )
+
+            if candidate_is_optimal:
+                if candidate_is_temporary:
+                    try:
+                        os.replace(candidate_model_path, compiled_model_path)
+                        print(f"Compiled model saved to {compiled_model_path}.")
+                        _remove_temporary_model(candidate_model_path)
+                        temporary_model_path = None
+                    except OSError as error:
+                        print(
+                            f"Could not replace compiled model cache "
+                            f"'{compiled_model_path}' with temporary output "
+                            f"'{candidate_model_path}': {error}"
+                        )
+                        break
+
+                use_compiled_model = True
+                break
+
+            if candidate_is_temporary:
+                print(
+                    "Newly compiled model was not reported as "
+                    "EP_SUPPORTED_OPTIMAL."
+                )
+                break
+
+            if not relevant_device_groups:
+                print(
+                    "Skipping recompilation because compatibility could not be "
+                    "evaluated."
+                )
+                break
+
+            print("Existing compiled model is not optimal; recompiling.")
+            temporary_model_path = _compile_model_to_temporary_file(
+                session_options, model_path, compiled_model_path
+            )
+            candidate_model_path = temporary_model_path
+            candidate_is_temporary = True
+    finally:
+        _remove_temporary_model(temporary_model_path)
+
+    if use_compiled_model:
         print("Using compiled model.")
         model_path_to_use = compiled_model_path
     else:
-        print("No compile output. Using original model.")
+        print("No usable compile output. Using original model.")
         model_path_to_use = model_path
 
     print("Creating session ...")

--- a/Samples/WindowsML/python/SqueezeNetPython/readme.md
+++ b/Samples/WindowsML/python/SqueezeNetPython/readme.md
@@ -24,6 +24,8 @@ extendedZipContent:
 ```PowerShell
 .\Install-Requirements.ps1
 ```
+The pinned Windows ML 2.3 package includes the compiled-model compatibility
+APIs used by this sample.
 ### Install WindowsAppRuntime
 Please install the WindowsAppRuntime that matches the version of the python package `wasdk-Microsoft.Windows.ApplicationModel.DynamicDependency.Bootstrap`
 > For experimental or preview WASDK. The version tags `-xxxN` are changed to `.devN` to fit Python's version requirements.
@@ -31,3 +33,28 @@ Please install the WindowsAppRuntime that matches the version of the python pack
 ```PowerShell
 python main.py
 ```
+
+### Compiled model compatibility
+
+The sample uses the `PREFER_NPU` execution provider device policy and caches the
+compiled model as `Model\SqueezeNet_ctx.onnx`. Before reusing that file, it:
+
+1. Calls `get_ep_devices` and groups the returned devices by execution provider.
+   Devices from different execution providers are never passed together.
+2. For the `PREFER_NPU` policy, checks same-execution-provider groups containing
+   NPU and CPU devices because policy selection can fall back to CPU.
+3. Reads each relevant execution provider's metadata with
+   `get_compatibility_info_from_model` and validates it with
+   `get_model_compatibility_for_ep_devices`.
+4. Requires at least one candidate execution provider group to have matching
+   metadata, and reuses the cached model only when every metadata-bearing group
+   reports `OrtCompiledModelCompatibility.EP_SUPPORTED_OPTIMAL`. A non-optimal
+   result from any applicable group rejects the cache.
+
+If the cached model is missing, has no matching metadata, or is not optimal, the
+sample compiles the original model in a temporary directory with EP context
+embedded in the ONNX file. It verifies that no external sidecars were produced,
+and the temporary model must also report `EP_SUPPORTED_OPTIMAL` before it
+replaces the cache. If compilation or validation fails, temporary outputs are
+removed and inference uses the original `SqueezeNet.onnx`; an existing stale
+compiled model is never used for that run.

--- a/Samples/WindowsML/python/SqueezeNetPython/requirements.txt
+++ b/Samples/WindowsML/python/SqueezeNetPython/requirements.txt
@@ -1,4 +1,4 @@
 pillow
 numpy
-wasdk-Microsoft.Windows.AI.MachineLearning[all]==2.1.3
+wasdk-Microsoft.Windows.AI.MachineLearning[all]==2.3.0
 wasdk-Microsoft.Windows.ApplicationModel.DynamicDependency.Bootstrap==2.1.3

--- a/Samples/nuget.config
+++ b/Samples/nuget.config
@@ -12,5 +12,7 @@
         <!-- Do not add package sources other than WinAppSDK-SampleDeps or localpackages. -->
         <!-- Public Azure Artifacts feed used by both external developers and CI. -->
         <add key="WinAppSDK-SampleDeps" value="https://pkgs.dev.azure.com/shine-oss/WinAppSDK-Samples/_packaging/WinAppSDK-SampleDeps/nuget/v3/index.json" />
+        <!-- Local directory for validating packages before the public feed is hydrated. -->
+        <add key="localpackages" value="localpackages" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md for guidelines on
how to best contribute to the Windows App SDK Samples repository!

-->

## Description

Updates the Windows ML samples to demonstrate how to use ONNX Runtime's compiled-model compatibility APIs before reusing a cached compiled model.

The C++, C#, and Python sample implementations now:

- Extract execution-provider-specific compatibility metadata from cached models.
- Group candidate devices by execution provider and validate each group with `GetModelCompatibilityForEpDevices`.
- Reuse a cached model only when compatibility is reported as `EP_SUPPORTED_OPTIMAL`.
- Reject caches with missing, incompatible, or non-optimal metadata and either recompile when requested or fall back to the original ONNX model.
- Write compiled models to temporary output and replace the cache only after successful compilation.
- Embed execution-provider context in the compiled model so the cache does not depend on sidecar files.

The associated documentation now explains the compatibility statuses, same-EP device-group requirement, cache-reuse policy, and fallback behavior.

## Target Release

2.3

## Checklist

Note that /azp run currently isn't working for this repo.

- [ ] Samples build and run using the Visual Studio versions listed in the [Windows development docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=stable#2-install-visual-studio).
- [ ] Samples build and run on all supported platforms (x64, x86, ARM64) and configurations (Debug, Release).
- [ ] Samples set the minimum supported OS version to Windows 10 version 1809.
- [ ] Samples build clean with no warnings or errors.
- [ ] **[For new samples]**: Samples have completed the [sample guidelines checklist](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#checklist) and follow [standardization/naming guidelines](https://github.com/microsoft/WindowsAppSDK-Samples/blob/main/docs/samples-guidelines.md#standardization-and-naming).
- [ ] Microsoft employees only: you can validate your changes by following the instructions here: https://www.osgwiki.com/wiki/WindowsAppSDK-Samples
